### PR TITLE
ENG09 Optimized JSON rending logic

### DIFF
--- a/xpipe/src/training-diagram/Application.ts
+++ b/xpipe/src/training-diagram/Application.ts
@@ -10,49 +10,13 @@ export class Application {
 	protected activeModel: SRD.DiagramModel;
 
 	protected diagramEngine: SRD.DiagramEngine;
-	protected projectData: string;
 
-	constructor(projectData:string) {
+	constructor() {
 
-		
 		this.diagramEngine = SRD.default();
 		this.activeModel = new SRD.DiagramModel();
 		this.diagramEngine.getNodeFactories().registerFactory(new CustomNodeFactory());
-		
-		this.projectData;
-
-		//if the .xipe file has correct format, generate the nodes
-		try {
-
-			let links = projectData["layers"][0]["models"];
-			let nodes = projectData["layers"][1]["models"];
-
-			for (let nodeID in nodes){
-				
-				let node =  nodes[nodeID];
-				let newNode = new CustomNodeModel({ name:node["name"], color:node["color"], extras: node["extras"] });
-				newNode.setPosition(node["x"], node["y"]);
-				
-				for (let portID in node.ports){
-					
-					let port = node.ports[portID];
-					if (port.alignment == "right") newNode.addOutPortEnhance(port.label, port.name);
-					if (port.alignment == "left") newNode.addInPortEnhance(port.label, port.name);
-					
-				} 
-
-				this.activeModel.addAll(newNode);
-				this.diagramEngine.setModel(this.activeModel);
-			}
-		}
-
-		//if incorrect, generate the default nodes.
-		catch(error){
-			console.log(error.message);
-			console.log("Generating New Diagram");
-
-			//initialize default start and finish node
-			let startNode = new CustomNodeModel({ name:'Start', color:'rgb(255,102,102)', extras:{ "type":"Start" } });
+		let startNode = new CustomNodeModel({ name:'Start', color:'rgb(255,102,102)', extras:{ "type":"Start" } });
 			startNode.addOutPortEnhance('▶', 'out-0');
 			startNode.addOutPortEnhance('  ', 'parameter-out-1');
 			startNode.setPosition(100, 100);
@@ -64,7 +28,9 @@ export class Application {
 
 			this.activeModel.addAll(startNode, finishedNode);
 			this.diagramEngine.setModel(this.activeModel);
-		}
+
+		this.diagramEngine.setModel(this.activeModel);
+		
 	}
 
 	public getActiveDiagram(): SRD.DiagramModel {
@@ -73,5 +39,22 @@ export class Application {
 
 	public getDiagramEngine(): SRD.DiagramEngine {
 		return this.diagramEngine;
+	}
+
+	public loadDiagramEngine(projectData): SRD.DiagramEngine {
+		console.log("load diagram engine! ");
+		//if a xpipe has ID 
+		if (projectData["id"]) {
+			console.log("Loading diagram! ");
+			this.activeModel.deserializeModel(projectData, this.diagramEngine);
+			this.diagramEngine.setModel(this.activeModel);
+			return this.diagramEngine;
+		}
+		
+		else {
+			//initialize default start and finish node
+			console.log("incorrect format.");
+			return this.diagramEngine;
+		}
 	}
 }

--- a/xpipe/src/training-diagram/components/BodyWidget.tsx
+++ b/xpipe/src/training-diagram/components/BodyWidget.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useCallback } from 'react';
+import React, { FC, useState, useCallback, useEffect } from 'react';
 import * as NumericInput from "react-numeric-input";
 import { Application } from '../Application';
 import { CanvasWidget } from '@projectstorm/react-canvas-core';
@@ -75,6 +75,11 @@ export const BodyWidget: FC<BodyWidgetProps> = ({ app, projectData }) => {
 	const [intNodesValue, setIntNodesValue] = useState<number[]>([0]);
 	const [floatNodesValue, setFloatNodesValue] = useState<number[]>([0.00]);
 	const [boolNodesValue, setBoolNodesValue] = useState<boolean[]>([false]);
+
+	const [engineLoad, setEngineLoad] = useState(app.getDiagramEngine());
+	useEffect (() => { setEngineLoad(app.loadDiagramEngine(projectData)); }, [] );
+	useEffect (() => { app.getDiagramEngine(); } )
+
 
 	const getTargetNodeModelId = (linkModels: LinkModel[], sourceId: string): string | null => {
 
@@ -694,7 +699,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({ app, projectData }) => {
 						forceUpdate();
 					}}>
 					<DemoCanvasWidget>
-						<CanvasWidget engine={app.getDiagramEngine()} />
+						<CanvasWidget engine={engineLoad} />
 					</DemoCanvasWidget>
 				</Layer>
 			</Content>

--- a/xpipe/src/training-diagram/index.tsx
+++ b/xpipe/src/training-diagram/index.tsx
@@ -4,6 +4,6 @@ import { BodyWidget } from './components/BodyWidget';
 import { Application } from './Application';
 
 export function CreateTrainingDiagramComponent(projectData: string) {
-	var app = new Application(projectData);
+	var app = new Application();
 	return <BodyWidget app={app} projectData={projectData} />;
 }


### PR DESCRIPTION
I finally finally got the load JSON working. So this morning when I said it was working, I applied this logic:

`useEffect (() =>  { app.loadDiagramEngine(projectData) } );`

It load perfectly, but after testing I realized that it kept re-rending for every event! So I put

`useEffect (() =>  { app.loadDiagramEngine(projectData) }, [] );`

to make it run once like didComponentMount . But that didn't work because the rendering of the app.loadDiagramEngine(projectData) does not connect with the react canvas, it runs the load diagram but goes nowhere. So then I tried using reactHooks as flags. Something along the lines of

```
const [diagramLoad, setDiagramLoad] = useState(false);
useEffect (() =>  { app.loadDiagramEngine(projectData); setDiagramLoad(true) }, [diagramLoad] );
```

Still no good, same reasons. The app doesn't connect with the canvas. Several hours of self-hate later and a hint from Mr Eduardo, I found the key which was in
```
<DemoCanvasWidget>
    <CanvasWidget engine={app.getDiagramEngine()} />
</DemoCanvasWidget>

```

Instead of calling the app.getDiagramEngine() from the canvas widget, I made it into a state.

```
<DemoCanvasWidget>
    <CanvasWidget engine={engineLoad} />
 </DemoCanvasWidget>
```

the final solution is like:

```
const [engineLoad, setEngineLoad] = useState(app.getDiagramEngine());
    useEffect (() => {  app.getDiagramEngine();})
    useEffect (() =>  { setEngineLoad(app.loadDiagramEngine([projectData]); }, [] );
```