### PR TITLE
✨Enable open/close sidebar debugger

### DIFF
--- a/xpipe/src/components/xpipeBodyWidget.tsx
+++ b/xpipe/src/components/xpipeBodyWidget.tsx
@@ -99,7 +99,8 @@ export const commandIDs = {
 	runXpipe: 'Xpipe-editor:run-node',
 	debugXpipe: 'Xpipe-editor:debug-node',
 	createArbitraryFile: 'Xpipe-editor:create-arbitrary-file',
-	openXpipeDebugger: 'Xpipe-debugger:open',
+	openAnalysisViewer: 'Xpipe-analysis-viewer:open',
+	openCloseDebugger: 'Xpipe-debugger:open/close',
 	breakpointXpipe: 'Xpipe-editor:breakpoint-node',
 	nextNode: 'Xpipe-editor:next-node',
 	testXpipe: 'Xpipe-editor:test-node'
@@ -504,7 +505,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		}
 
 		alert("Run.")
-		commands.execute(commandIDs.openXpipeDebugger);
+		commands.execute(commandIDs.openAnalysisViewer);
 		let nodesCount = diagramEngine.getModel().getNodes().length;
 
 		console.log(diagramEngine.getModel().getNodes());
@@ -574,7 +575,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			return;
 		}
 
-		alert("Debug xpipe")
+		commands.execute(commandIDs.openCloseDebugger);
 
         if(compiled && saved){
 		    onClick('displayDebug');

--- a/xpipe/src/index.tsx
+++ b/xpipe/src/index.tsx
@@ -130,11 +130,22 @@ const extension: JupyterFrontEndPlugin<void> = {
     app.shell.add(sidebarWidget, "left");
 
     // Creating the sidebar debugger
-    const sidebarXpipe = new XpipeDebugger.Sidebar({ app, translator, widgetFactory})
-    sidebarXpipe.id = 'xpipe-debugger-sidebar';
-    sidebarXpipe.title.iconClass = 'jp-XpipeLogo';
-    restorer.add(sidebarXpipe, sidebarXpipe.id);
-    app.shell.add(sidebarXpipe, 'right');
+    const sidebarDebugger = new XpipeDebugger.Sidebar({ app, translator, widgetFactory})
+    sidebarDebugger.id = 'xpipe-debugger-sidebar';
+    sidebarDebugger.title.iconClass = 'jp-XpipeLogo';
+    restorer.add(sidebarDebugger, sidebarDebugger.id);
+    app.shell.add(sidebarDebugger, 'right', { rank: 1001 });
+    
+    // Add a command to open/close xpipe sidebar debugger
+    app.commands.addCommand(commandIDs.openCloseDebugger, {
+      execute: () => {
+        if (sidebarDebugger.isHidden) {
+          app.shell.activateById(sidebarDebugger.id);
+        }else{
+          app.commands.execute('application:toggle-right-area');
+        }
+      },
+    });
 
     // Add command signal to save xpipe
     app.commands.addCommand(commandIDs.saveXpipe, {
@@ -248,7 +259,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     });
 
     // Add a command for opening the xpipe analysis viewer when run button clicked.
-    app.commands.addCommand(commandIDs.openXpipeDebugger, {
+    app.commands.addCommand(commandIDs.openAnalysisViewer, {
       execute: (options: IXpipeAnalysisViewerOptions) => {
         return createXpipeAnalysisViewer(app, options);
       }

--- a/xpipe/src/xpipeFactory.ts
+++ b/xpipe/src/xpipeFactory.ts
@@ -141,7 +141,7 @@ export class XpipeFactory extends ABCWidgetFactory<XPipeWidget, XPipeDocModel> {
      */
      let debugButton = new ToolbarButton({
       icon:bugIcon,
-      tooltip: 'Open Xpipe Debugger',
+      tooltip: 'Open/Close Xpipe Debugger',
       onClick: (): void => {
         this.commands.execute(commandIDs.debugXpipe);
       }


### PR DESCRIPTION
**Feature added**
Enabling to open and close the sidebar debugger

**Test**
1. Clicking the debug toolbar button will open the debugger
2. Clicking it again will close the debugger