### PR TITLE
Added literal list and literal tuple component support

### DIFF
--- a/xpipe/src/components/CustomPortModel.ts
+++ b/xpipe/src/components/CustomPortModel.ts
@@ -142,7 +142,9 @@ export  class CustomPortModel extends DefaultPortModel  {
             nodeModelType === 'boolean' ||
             nodeModelType === 'int' ||
             nodeModelType === 'float' ||
-            nodeModelType === 'string'
+            nodeModelType === 'string' ||
+            nodeModelType === 'list' ||
+            nodeModelType === 'tuple'
         );
     }
 
@@ -206,10 +208,12 @@ export  class CustomPortModel extends DefaultPortModel  {
 
         while ((sourceNode != null) &&
                 nodeType != 'Start' &&
-				nodeType != 'boolean' &&
-				nodeType != 'int' &&
-				nodeType != 'float' &&
-				nodeType != 'string'){
+                nodeType != 'boolean' &&
+                nodeType != 'int' &&
+                nodeType != 'float' &&
+                nodeType != 'string' &&
+                nodeType != 'list' &&
+                nodeType != 'tuple'){
             //console.log("Curent sourceNode:", sourceNode.getOptions()["name"]);
             let inPorts = sourceNode.getInPorts();
             

--- a/xpipe/src/components/xpipeBodyWidget.tsx
+++ b/xpipe/src/components/xpipeBodyWidget.tsx
@@ -351,7 +351,17 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 
 											if (sourceNodeType == 'string'){
 												pythonCode += '    ' + bindingName + '.' + label + '.value = ' + "'" + sourcePortLabel + "'\n";
-											}else {
+											}
+											
+											else if (sourceNodeType == 'list'){
+												pythonCode += '    ' + bindingName + '.' + label + '.value = ' + "[" + sourcePortLabel + "]" +"\n";
+											}
+											
+											else if (sourceNodeType == 'tuple'){
+												pythonCode += '    ' + bindingName + '.' + label + '.value = ' + "(" + sourcePortLabel + ")" + "\n";
+											}
+
+											else {
 												pythonCode += '    ' + bindingName + '.' + label + '.value = ' + sourcePortLabel + "\n";
 											}
 
@@ -1103,6 +1113,37 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 
 									}
 
+								} else if (data.type === 'tuple') {
+
+									if ((data.name).startsWith("Literal")) {
+
+										let theResponse = window.prompt('Enter Tuple Values (Without () Brackets):');
+										node = new CustomNodeModel({ name: data.name, color: current_node["color"], extras: { "type": data.type } });
+										node.addOutPortEnhance(theResponse, 'out-0');
+
+									} else {
+
+										let theResponse = window.prompt('notice', 'Enter Tuple Name (Without Quotes):');
+										node = new CustomNodeModel({ name: "Hyperparameter (Tuple): " + theResponse, color: current_node["color"], extras: { "type": data.type } });
+										node.addOutPortEnhance('▶', 'parameter-out-0');
+									}
+
+								} else if (data.type === 'list') {
+
+									if ((data.name).startsWith("Literal")) {
+
+										let theResponse = window.prompt('Enter List Values (Without [] Brackets):');
+										node = new CustomNodeModel({ name: data.name, color: current_node["color"], extras: { "type": data.type } });
+										node.addOutPortEnhance(theResponse, 'out-0');
+
+									} else {
+
+										let theResponse = window.prompt('notice', 'Enter List Name (Without Quotes):');
+										node = new CustomNodeModel({ name: "Hyperparameter (List): " + theResponse, color: current_node["color"], extras: { "type": data.type } });
+										node.addOutPortEnhance('▶', 'parameter-out-0');
+
+									}
+
 								} else if (data.type === 'debug') {
 									node = new CustomNodeModel({ name: data.name, color: current_node["color"], extras: { "type": data.type } });
 									node.addInPortEnhance('▶', 'in-0');
@@ -1148,6 +1189,12 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 												} else if (current_node["variable"].split(" - ")[node_index].split(" , ")[variable_index].trim().includes("InArg[float]")) {
 													in_str = "parameter-float-in-" + in_count;
 													in_count += 1;
+												} else if (current_node["variable"].split(" - ")[node_index].split(" , ")[variable_index].trim().includes("InArg[list]")) {
+													in_str = "parameter-list-in-" + in_count;
+													in_count += 1;
+												} else if (current_node["variable"].split(" - ")[node_index].split(" , ")[variable_index].trim().includes("InArg[tuple]")) {
+													in_str = "parameter-tuple-in-" + in_count;
+													in_count += 1;
 												} else {
 													in_str = "in-" + in_count;
 													in_count += 1;
@@ -1171,6 +1218,12 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 											} else if (current_node["variable"].split(" , ")[variable_index].trim().includes("InArg[float]")) {
 												in_str = "parameter-float-in-" + in_count;
 												in_count += 1;
+											} else if (current_node["variable"].split(" , ")[variable_index].trim().includes("InArg[list]")) {
+												in_str = "parameter-list-in-" + in_count;
+												in_count += 1;
+											} else if (current_node["variable"].split(" , ")[variable_index].trim().includes("InArg[tuple]")) {
+												in_str = "parameter-tuple-in-" + in_count;
+												in_count += 1;											
 											} else {
 												in_str = "in-" + in_count;
 												in_count += 1;

--- a/xpipe/src/components_xpipe/Component.ts
+++ b/xpipe/src/components_xpipe/Component.ts
@@ -227,7 +227,11 @@ function getVariableType(input: string) {
         return 'boolean'
     } else if (input.includes("string")) {
         return 'string'
-    }
+    } else if (input.includes("list")) {
+    return 'list'
+    } else if (input.includes("tuple")) {
+    return 'tuple'
+    }   
 }
 
 function getComponentType(input: string, header: string) {
@@ -331,6 +335,8 @@ async function get_all_components_method(serviceManager: ServiceManager, basePat
         { task: "Literal Float", id: 11 },
         { task: "Literal True", id: 12 },
         { task: "Literal False", id: 13 },
+        { task: "Literal List", id: 14 },
+        { task: "Literal Tuple", id: 15 },
     ];
 
     const colorList_adv = [

--- a/xpipe/xai_learning/component_test.py
+++ b/xpipe/xai_learning/component_test.py
@@ -9,3 +9,22 @@ class HelloHyperparameter(Component):
     def execute(self) -> None:
         input_str = self.input_str.value
         print("Hello " + input_str)
+        
+class HelloTupleOrList(Component):
+    input_list: InArg[list]
+    input_tuple: InArg[tuple]
+
+    def __init__(self):
+        
+        self.input_tuple = InArg.empty()
+        self.input_list = InArg.empty()
+
+    def execute(self) -> None:
+        
+        input_list = self.input_list.value if self.input_list.value else ""
+        input_tuple = self.input_tuple.value if self.input_tuple.value else ""
+        
+        print( "\nDisplaying List: ")
+        print(input_list) 
+        print("\nDisplaying Tuple: ")
+        print(input_tuple)


### PR DESCRIPTION
This pull request adds support for literal list and literal tuple default components. It is especially useful for future xai-components that requires a variable function option input, such as:

`df = spark.read.format("libsvm").option(*options).load(filepath)`

Where *options is a literal tuple provided by the user.

## Tests:
I have added a HelloTupleOrList component in  \xpipe\xai_learning\component_test.py.

1. Try creating a literal list and tuple from the XAI Traywidget General tab. You do not have to supply () or [].
2. Connect the literal list and tuple to the HelloTupleOrList. If you connect the incorrect datatype (eg string), the error tooltip will display.
3. Try saving and codegen-ing it. You should see the correct datatype format generated.

```
c_1.input_list.value = [1,2,3,4]
c_1.input_tuple.value = ("11", "ccc", 1)
```
4. Try running the codegen-ed script. It should display the literal list and/or tuple you've supplied. 