### PR TITLE
added Literal Dict support

### DIFF
--- a/xpipe/src/components/CustomPortModel.ts
+++ b/xpipe/src/components/CustomPortModel.ts
@@ -144,7 +144,8 @@ export  class CustomPortModel extends DefaultPortModel  {
             nodeModelType === 'float' ||
             nodeModelType === 'string' ||
             nodeModelType === 'list' ||
-            nodeModelType === 'tuple'
+            nodeModelType === 'tuple' ||
+            nodeModelType === 'dict'
         );
     }
 
@@ -213,7 +214,8 @@ export  class CustomPortModel extends DefaultPortModel  {
                 nodeType != 'float' &&
                 nodeType != 'string' &&
                 nodeType != 'list' &&
-                nodeType != 'tuple'){
+                nodeType != 'tuple' &&
+                nodeType != 'dict'){
             //console.log("Curent sourceNode:", sourceNode.getOptions()["name"]);
             let inPorts = sourceNode.getInPorts();
             

--- a/xpipe/src/components/xpipeBodyWidget.tsx
+++ b/xpipe/src/components/xpipeBodyWidget.tsx
@@ -361,6 +361,10 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 												pythonCode += '    ' + bindingName + '.' + label + '.value = ' + "(" + sourcePortLabel + ")" + "\n";
 											}
 
+											else if (sourceNodeType == 'dict'){
+												pythonCode += '    ' + bindingName + '.' + label + '.value = ' + "{" + sourcePortLabel + "}" + "\n";
+											}
+
 											else {
 												pythonCode += '    ' + bindingName + '.' + label + '.value = ' + sourcePortLabel + "\n";
 											}
@@ -1112,6 +1116,22 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 										node.addOutPortEnhance('▶', 'parameter-out-0');
 
 									}
+									
+								} else if (data.type === 'list') {
+
+									if ((data.name).startsWith("Literal")) {
+
+										let theResponse = window.prompt('Enter List Values (Without [] Brackets):');
+										node = new CustomNodeModel({ name: data.name, color: current_node["color"], extras: { "type": data.type } });
+										node.addOutPortEnhance(theResponse, 'out-0');
+
+									} else {
+
+										let theResponse = window.prompt('notice', 'Enter List Name (Without Quotes):');
+										node = new CustomNodeModel({ name: "Hyperparameter (List): " + theResponse, color: current_node["color"], extras: { "type": data.type } });
+										node.addOutPortEnhance('▶', 'parameter-out-0');
+
+									}
 
 								} else if (data.type === 'tuple') {
 
@@ -1128,18 +1148,18 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 										node.addOutPortEnhance('▶', 'parameter-out-0');
 									}
 
-								} else if (data.type === 'list') {
+								} else if (data.type === 'dict') {
 
 									if ((data.name).startsWith("Literal")) {
 
-										let theResponse = window.prompt('Enter List Values (Without [] Brackets):');
+										let theResponse = window.prompt('Enter Dict Values (Without {} Brackets):');
 										node = new CustomNodeModel({ name: data.name, color: current_node["color"], extras: { "type": data.type } });
 										node.addOutPortEnhance(theResponse, 'out-0');
 
 									} else {
 
-										let theResponse = window.prompt('notice', 'Enter List Name (Without Quotes):');
-										node = new CustomNodeModel({ name: "Hyperparameter (List): " + theResponse, color: current_node["color"], extras: { "type": data.type } });
+										let theResponse = window.prompt('notice', 'Enter Dict Name (Without Quotes):');
+										node = new CustomNodeModel({ name: "Hyperparameter (Dict): " + theResponse, color: current_node["color"], extras: { "type": data.type } });
 										node.addOutPortEnhance('▶', 'parameter-out-0');
 
 									}
@@ -1195,6 +1215,9 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 												} else if (current_node["variable"].split(" - ")[node_index].split(" , ")[variable_index].trim().includes("InArg[tuple]")) {
 													in_str = "parameter-tuple-in-" + in_count;
 													in_count += 1;
+												} else if (current_node["variable"].split(" - ")[node_index].split(" , ")[variable_index].trim().includes("InArg[dict]")) {
+													in_str = "parameter-dict-in-" + in_count;
+													in_count += 1;
 												} else {
 													in_str = "in-" + in_count;
 													in_count += 1;
@@ -1223,6 +1246,9 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 												in_count += 1;
 											} else if (current_node["variable"].split(" , ")[variable_index].trim().includes("InArg[tuple]")) {
 												in_str = "parameter-tuple-in-" + in_count;
+												in_count += 1;
+											} else if (current_node["variable"].split(" , ")[variable_index].trim().includes("InArg[dict]")) {
+												in_str = "parameter-dict-in-" + in_count;
 												in_count += 1;											
 											} else {
 												in_str = "in-" + in_count;

--- a/xpipe/src/components_xpipe/Component.ts
+++ b/xpipe/src/components_xpipe/Component.ts
@@ -231,7 +231,9 @@ function getVariableType(input: string) {
     return 'list'
     } else if (input.includes("tuple")) {
     return 'tuple'
-    }   
+    } else if (input.includes("dict")) {
+    return 'dict'
+    }
 }
 
 function getComponentType(input: string, header: string) {
@@ -337,6 +339,7 @@ async function get_all_components_method(serviceManager: ServiceManager, basePat
         { task: "Literal False", id: 13 },
         { task: "Literal List", id: 14 },
         { task: "Literal Tuple", id: 15 },
+        { task: "Literal Dict", id: 16 },
     ];
 
     const colorList_adv = [

--- a/xpipe/xai_learning/component_test.py
+++ b/xpipe/xai_learning/component_test.py
@@ -10,21 +10,28 @@ class HelloHyperparameter(Component):
         input_str = self.input_str.value
         print("Hello " + input_str)
         
-class HelloTupleOrList(Component):
+class HelloListTupleDict(Component):
     input_list: InArg[list]
     input_tuple: InArg[tuple]
+    input_dict: InArg[dict]
+
 
     def __init__(self):
         
         self.input_tuple = InArg.empty()
         self.input_list = InArg.empty()
+        self.input_dict = InArg.empty()
 
     def execute(self) -> None:
         
         input_list = self.input_list.value if self.input_list.value else ""
         input_tuple = self.input_tuple.value if self.input_tuple.value else ""
+        input_dict = self.input_dict.value if self.input_dict.value else ""
+
         
         print( "\nDisplaying List: ")
         print(input_list) 
         print("\nDisplaying Tuple: ")
         print(input_tuple)
+        print("\nDisplaying Dict: ")
+        print(input_dict)


### PR DESCRIPTION
Adding literal dict support. Useful for **kwargs in functions.

## Tests:

I modified HelloTupleOrList to HelloListTupleDict in \xpipe\xai_learning\component_test.py.

1. Try creating a literal dict from the XAI Traywidget General tab. 
2. Connect the literal list and tuple to the HelloListTupleDict . If you connect the incorrect datatype (eg string), the error tooltip will display.
3. Try saving and codegen-ing it. You should see the correct datatype format generated, ie `c_1.input_dict.value = {"test":123}
`
4. Try running the codegen-ed script. It should display the literal dict you've supplied.