### PR TITLE
🐛Fix path to open components script

### DIFF
--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -179,7 +179,7 @@ export default function Sidebar(props: SidebarProps) {
                 <TrayWidget>
                     <div>
                         <div className="search-input">
-                            <input type="text" name="" value={searchTerm} placeholder="SEARCH" className="search-input__text-input" style={{ width: "80%" }} onChange={handleOnChange} />
+                            <input type="text" name="" value={searchTerm} placeholder="SEARCH" className="search-input__text-input" style={{ width: "75%" }} onChange={handleOnChange} />
                             <a onClick={handleSearchOnClick} className="search-input__button"><i className="fa fa-search "></i></a>
                             <a onClick={handleRefreshOnClick} className="search-input__button"><i className="fa fa-refresh "></i></a>
                         </div>

--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -203,11 +203,6 @@ export default function Sidebar(props: SidebarProps) {
                                                             return componentVal;
                                                         }
                                                     }).map((componentVal, i2) => {
-                                                        let packagePath = componentVal["package_name"];
-                                                        let path = "";
-                                                        if (packagePath != undefined) {
-                                                            path = packagePath.replace(/\./g, "/") + ".py";
-                                                        }
                                                         if (componentVal["category"].toString().toUpperCase() == val["task"].toString()) {
                                                             return (
                                                                 <div key={`index-1-${i2}`}>
@@ -219,7 +214,7 @@ export default function Sidebar(props: SidebarProps) {
                                                                         name={componentVal.task}
                                                                         color={componentVal.color}
                                                                         app={props.lab}
-                                                                        path={componentVal.abs_file_path ?? path} />
+                                                                        path={componentVal.file_path} />
                                                                 </div>
                                                             );
                                                         }
@@ -238,11 +233,6 @@ export default function Sidebar(props: SidebarProps) {
                                     return val
                                 }
                             }).map((val, i) => {
-                                let packagePath = val["package_name"];
-                                let path = "";
-                                if (packagePath != undefined) {
-                                    path = packagePath.replace(/\./g, "/") + ".py";
-                                }
                                 return (
                                     <div key={`index-3-${i}`}>
                                         <TrayItemWidget
@@ -250,7 +240,7 @@ export default function Sidebar(props: SidebarProps) {
                                             name={val.task}
                                             color={val.color}
                                             app={props.lab}
-                                            path={val.abs_file_path ?? path} />
+                                            path={val.file_path} />
                                     </div>
                                 );
                             })

--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -214,7 +214,7 @@ export default function Sidebar(props: SidebarProps) {
                                                                         name={componentVal.task}
                                                                         color={componentVal.color}
                                                                         app={props.lab}
-                                                                        path={componentVal.path} />
+                                                                        path={componentVal.package_name} />
                                                                 </div>
                                                             );
                                                         }
@@ -240,7 +240,7 @@ export default function Sidebar(props: SidebarProps) {
                                             name={val.task}
                                             color={val.color}
                                             app={props.lab}
-                                            path={val.path} />
+                                            path={val.package_name} />
                                     </div>
                                 );
                             })

--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -203,6 +203,11 @@ export default function Sidebar(props: SidebarProps) {
                                                             return componentVal;
                                                         }
                                                     }).map((componentVal, i2) => {
+                                                        let packagePath = componentVal["package_name"];
+                                                        let path = "";
+                                                        if (packagePath != undefined) {
+                                                            path = packagePath.replace(/\./g, "/") + ".py";
+                                                        }
                                                         if (componentVal["category"].toString().toUpperCase() == val["task"].toString()) {
                                                             return (
                                                                 <div key={`index-1-${i2}`}>
@@ -214,7 +219,7 @@ export default function Sidebar(props: SidebarProps) {
                                                                         name={componentVal.task}
                                                                         color={componentVal.color}
                                                                         app={props.lab}
-                                                                        path={componentVal.package_name} />
+                                                                        path={componentVal.abs_file_path ?? path} />
                                                                 </div>
                                                             );
                                                         }
@@ -233,6 +238,11 @@ export default function Sidebar(props: SidebarProps) {
                                     return val
                                 }
                             }).map((val, i) => {
+                                let packagePath = val["package_name"];
+                                let path = "";
+                                if (packagePath != undefined) {
+                                    path = packagePath.replace(/\./g, "/") + ".py";
+                                }
                                 return (
                                     <div key={`index-3-${i}`}>
                                         <TrayItemWidget
@@ -240,7 +250,7 @@ export default function Sidebar(props: SidebarProps) {
                                             name={val.task}
                                             color={val.color}
                                             app={props.lab}
-                                            path={val.package_name} />
+                                            path={val.abs_file_path ?? path} />
                                     </div>
                                 );
                             })

--- a/src/tray_library/TrayItemWidget.tsx
+++ b/src/tray_library/TrayItemWidget.tsx
@@ -40,19 +40,21 @@ export class TrayItemWidget extends React.Component<TrayItemWidgetProps> {
 				}}
 				onClick={(event) => {
 					if (event.ctrlKey || event.metaKey) {
+						let path = this.props.path.replace(/\./g,"/") + ".py";
 						const { commands } = this.props.app;
 						commands.execute('docmanager:open', {
-							path: this.props.path,
+							path: path,
 							factory: 'Editor',
 						});
 					}
 					this.forceUpdate();
 				}}
 				onDoubleClick={(event) => {
-					if (this.props.path != "") {
+					let path = this.props.path.replace(/\./g,"/") + ".py";
+					if (path != "") {
 						const { commands } = this.props.app;
 						commands.execute('docmanager:open', {
-							path: this.props.path,
+							path: path,
 							factory: 'Editor',
 						});
 					}

--- a/src/tray_library/TrayItemWidget.tsx
+++ b/src/tray_library/TrayItemWidget.tsx
@@ -42,8 +42,7 @@ export class TrayItemWidget extends React.Component<TrayItemWidgetProps> {
 					if (event.ctrlKey || event.metaKey) {
 						const { commands } = this.props.app;
 						commands.execute('docmanager:open', {
-							path: this.props.path,
-							factory: 'Editor',
+							path: this.props.path
 						});
 					}
 					this.forceUpdate();
@@ -52,8 +51,7 @@ export class TrayItemWidget extends React.Component<TrayItemWidgetProps> {
 					if (this.props.path != "") {
 						const { commands } = this.props.app;
 						commands.execute('docmanager:open', {
-							path: this.props.path,
-							factory: 'Editor',
+							path: this.props.path
 						});
 					}
 					this.forceUpdate();

--- a/src/tray_library/TrayItemWidget.tsx
+++ b/src/tray_library/TrayItemWidget.tsx
@@ -40,21 +40,19 @@ export class TrayItemWidget extends React.Component<TrayItemWidgetProps> {
 				}}
 				onClick={(event) => {
 					if (event.ctrlKey || event.metaKey) {
-						let path = this.props.path.replace(/\./g,"/") + ".py";
 						const { commands } = this.props.app;
 						commands.execute('docmanager:open', {
-							path: path,
+							path: this.props.path,
 							factory: 'Editor',
 						});
 					}
 					this.forceUpdate();
 				}}
 				onDoubleClick={(event) => {
-					let path = this.props.path.replace(/\./g,"/") + ".py";
-					if (path != "") {
+					if (this.props.path != "") {
 						const { commands } = this.props.app;
 						commands.execute('docmanager:open', {
-							path: path,
+							path: this.props.path,
 							factory: 'Editor',
 						});
 					}

--- a/xircuits/handlers/components.py
+++ b/xircuits/handlers/components.py
@@ -148,6 +148,7 @@ class ComponentsRouteHandler(APIHandler):
             "class": name,
             "package_name": ("xai_components." if python_path is None else "") + file_path.as_posix().replace("/", ".")[:-3],
             "python_path": str(python_path) if python_path is not None else None,
+            "abs_file_path": os.path.join(str(python_path), str(file_path)) if python_path is not None else None,
             "task": name,
             "header": GROUP_ADVANCED,
             "category": category,

--- a/xircuits/handlers/components.py
+++ b/xircuits/handlers/components.py
@@ -7,6 +7,7 @@ from itertools import chain
 
 import tornado
 from jupyter_server.base.handlers import APIHandler
+import platform
 
 from .config import get_config
 
@@ -149,6 +150,7 @@ class ComponentsRouteHandler(APIHandler):
             "package_name": ("xai_components." if python_path is None else "") + file_path.as_posix().replace("/", ".")[:-3],
             "python_path": str(python_path) if python_path is not None else None,
             "abs_file_path": os.path.join(str(python_path), str(file_path)) if python_path is not None else None,
+            "file_path": "xai_components/" + (file_path.as_posix()[:-3] + ".py" if platform.system() == "Windows" else str(file_path)),
             "task": name,
             "header": GROUP_ADVANCED,
             "category": category,


### PR DESCRIPTION
# Description
This fix **double clicking** and **ctrl-click** a component library to open its python script.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [x] Xircuits Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. **Ctrl+click** any component in component_library to open its script.
2. Also, try **double clicking**.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
