### PR TITLE
✨Add context menu

### DIFF
--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -26,7 +26,7 @@ jobs:
       
     - name: Setup Build Env
       run: |
-        curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | sh 
+        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
         . ~/.nvm/nvm.sh
         nvm install 14.15.3
         nvm use 14.15.3

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "style/index.js"
+    "style/index.js",
+    "schema/**/*.json"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -115,7 +116,8 @@
       }
     },
     "extension": true,
-    "outputDir": "xircuits/labextension"
+    "outputDir": "xircuits/labextension",
+    "schemaDir": "schema"
   },
   "styleModule": "style/index.js"
 }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,0 +1,50 @@
+{
+    "title": "Xircuits Context Menu",
+    "description": "Xircuits Context Menu settings.",
+    "jupyter.lab.menus": {
+        "context": [
+            {
+                "command": "Xircuit-editor:edit-node",
+                "selector": ".xircuits-editor",
+                "rank": 0
+            },
+            {
+                "command": "Xircuit-editor:delete-node",
+                "selector": ".xircuits-editor",
+                "rank": 1
+            },
+            {
+                "type": "separator",
+                "selector": ".xircuits-editor",
+                "rank": 11
+            },
+            {
+                "command": "Xircuit-editor:save-node",
+                "selector": ".xircuits-editor",
+                "rank": 12
+            },
+            {
+                "command": "Xircuit-editor:run-node",
+                "selector": ".xircuits-editor",
+                "rank": 13
+            },
+            {
+                "type": "separator",
+                "selector": ".xircuits-editor",
+                "rank": 21
+            },
+            {
+                "command": "Xircuit-editor:create-new",
+                "selector": ".xircuits-editor",
+                "rank": 22
+            },
+            {
+                "command": "Xircuit-log:open",
+                "selector": ".xircuits-editor",
+                "rank": 23
+            }
+        ]
+    },
+    "additionalProperties": false,
+    "type": "object"
+}

--- a/src/commands/ContextMenu.ts
+++ b/src/commands/ContextMenu.ts
@@ -69,10 +69,11 @@ export function addContextMenuCommands(
             _.forEach(selectedEntities, (model) => {
 
                 let node = null;
-                let links = widget.xircuitsApp.getDiagramEngine().getModel()["layers"][0]["models"]
+                let links = widget.xircuitsApp.getDiagramEngine().getModel()["layers"][0]["models"];
+                let oldValue = model.getPorts()["out-0"].getOptions()["label"]
 
                 // Prompt the user to enter new value
-                let theResponse = window.prompt('Enter New Value (Without Quotes):', "");
+                let theResponse = window.prompt('Enter New Value (Without Quotes):', oldValue);
                 if(theResponse == null || theResponse == ""){
                     // When Cancel is clicked or no input provided, just return
                     return

--- a/src/commands/ContextMenu.ts
+++ b/src/commands/ContextMenu.ts
@@ -1,0 +1,31 @@
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { commandIDs } from '../components/xircuitBodyWidget';
+import { ITranslator } from '@jupyterlab/translation';
+import { IXircuitsDocTracker } from '../index';
+import * as _ from 'lodash';
+import { CustomNodeModel } from '../components/CustomNodeModel';
+import { XPipePanel } from '../xircuitWidget';
+import { Dialog, showDialog } from '@jupyterlab/apputils';
+
+/**
+ * Add the commands for the xircuits's context menu.
+ */
+export function addContextMenuCommands(
+    app: JupyterFrontEnd,
+    tracker: IXircuitsDocTracker,
+    translator: ITranslator
+): void {
+    const trans = translator.load('jupyterlab');
+    const { commands, shell } = app;
+
+    /**
+     * Whether there is an active xircuits.
+     */
+    function isEnabled(): boolean {
+        return (
+            tracker.currentWidget !== null &&
+            tracker.currentWidget === shell.currentWidget
+        );
+    }
+
+}

--- a/src/commands/ContextMenu.ts
+++ b/src/commands/ContextMenu.ts
@@ -74,7 +74,7 @@ export function addContextMenuCommands(
 
                 // Prompt the user to enter new value
                 let theResponse = window.prompt('Enter New Value (Without Quotes):', oldValue);
-                if(theResponse == null || theResponse == ""){
+                if(theResponse == null || theResponse == "" || theResponse == oldValue){
                     // When Cancel is clicked or no input provided, just return
                     return
                 }

--- a/src/commands/ContextMenu.ts
+++ b/src/commands/ContextMenu.ts
@@ -6,6 +6,7 @@ import * as _ from 'lodash';
 import { CustomNodeModel } from '../components/CustomNodeModel';
 import { XPipePanel } from '../xircuitWidget';
 import { Dialog, showDialog } from '@jupyterlab/apputils';
+import { DefaultLinkModel } from '@projectstorm/react-diagrams';
 
 /**
  * Add the commands for the xircuits's context menu.
@@ -68,6 +69,7 @@ export function addContextMenuCommands(
             _.forEach(selectedEntities, (model) => {
 
                 let node = null;
+                let links = widget.xircuitsApp.getDiagramEngine().getModel()["layers"][0]["models"]
 
                 // Prompt the user to enter new value
                 let theResponse = window.prompt('Enter New Value (Without Quotes):');
@@ -78,6 +80,29 @@ export function addContextMenuCommands(
                 let position = model.getPosition();
                 node.setPosition(position);
                 widget.xircuitsApp.getDiagramEngine().getModel().addNode(node);
+
+                // Update the links
+                for (let linkID in links) {
+
+                    let link = links[linkID];
+
+                    if (link["sourcePort"] && link["targetPort"]) {
+
+                        let newLink = new DefaultLinkModel();
+
+                        let sourcePort = node.getPorts()["out-0"];
+                        newLink.setSourcePort(sourcePort);
+
+                        // This to make sure the new link came from the same literal node as previous link
+                        let sourceLinkNodeId = link["sourcePort"].getParent().getID()
+                        let sourceNodeId = model.getOptions()["id"]
+                        if (sourceLinkNodeId == sourceNodeId) {
+                            newLink.setTargetPort(link["targetPort"]);
+                        }
+
+                        widget.xircuitsApp.getDiagramEngine().getModel().addLink(newLink)
+                    }
+                }
 
                 // Remove old node
                 model.remove();

--- a/src/commands/ContextMenu.ts
+++ b/src/commands/ContextMenu.ts
@@ -72,7 +72,11 @@ export function addContextMenuCommands(
                 let links = widget.xircuitsApp.getDiagramEngine().getModel()["layers"][0]["models"]
 
                 // Prompt the user to enter new value
-                let theResponse = window.prompt('Enter New Value (Without Quotes):');
+                let theResponse = window.prompt('Enter New Value (Without Quotes):', "");
+                if(theResponse == null || theResponse == ""){
+                    // When Cancel is clicked or no input provided, just return
+                    return
+                }
                 node = new CustomNodeModel({ name: model["name"], color: model["color"], extras: { "type": model["extras"]["type"] } });
                 node.addOutPortEnhance(theResponse, 'out-0');
 

--- a/src/components/CustomNodeFactory.tsx
+++ b/src/components/CustomNodeFactory.tsx
@@ -4,10 +4,13 @@ import { CustomNodeModel } from './CustomNodeModel';
 import {AbstractReactFactory, GenerateModelEvent, GenerateWidgetEvent} from '@projectstorm/react-canvas-core';
 import { DiagramEngine } from '@projectstorm/react-diagrams-core';
 import {CustomNodeWidget} from "./CustomNodeWidget";
+import { JupyterFrontEnd } from '@jupyterlab/application';
 
 export class CustomNodeFactory extends AbstractReactFactory<CustomNodeModel, DiagramEngine> {
-	constructor() {
+	app : JupyterFrontEnd
+	constructor(app) {
 		super('custom-node');
+		this.app = app;
 	}
 
 	generateModel(initialConfig: GenerateModelEvent) {
@@ -15,6 +18,6 @@ export class CustomNodeFactory extends AbstractReactFactory<CustomNodeModel, Dia
 	}
 
 	generateReactWidget(event: GenerateWidgetEvent<any>): JSX.Element {
-		return <CustomNodeWidget engine={this.engine as DiagramEngine} node={event.model} />;
+		return <CustomNodeWidget engine={this.engine as DiagramEngine} node={event.model} app={this.app}/>;
 	}
 }

--- a/src/components/CustomNodeWidget.tsx
+++ b/src/components/CustomNodeWidget.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { DiagramEngine } from '@projectstorm/react-diagrams-core';
-
-import { DefaultLinkModel, DefaultNodeModel ,DefaultPortLabel} from '@projectstorm/react-diagrams';
+import { DefaultNodeModel ,DefaultPortLabel} from '@projectstorm/react-diagrams';
 import styled from '@emotion/styled';
 import "react-image-gallery/styles/css/image-gallery.css";
 import ImageGallery from 'react-image-gallery';
@@ -11,7 +10,6 @@ import { Pagination } from "krc-pagination";
 import 'krc-pagination/styles.css';
 import { Action, ActionEvent, InputType } from '@projectstorm/react-canvas-core';
 import Toggle from 'react-toggle'
-import { CustomNodeModel } from './CustomNodeModel';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { commandIDs } from './xircuitBodyWidget';
 

--- a/src/components/CustomNodeWidget.tsx
+++ b/src/components/CustomNodeWidget.tsx
@@ -12,6 +12,7 @@ import 'krc-pagination/styles.css';
 import { Action, ActionEvent, InputType } from '@projectstorm/react-canvas-core';
 import Toggle from 'react-toggle'
 import { CustomNodeModel } from './CustomNodeModel';
+import { JupyterFrontEnd } from '@jupyterlab/application';
 
 
 var S;
@@ -66,15 +67,17 @@ var S;
 export interface DefaultNodeProps {
     node: DefaultNodeModel;
     engine: DiagramEngine;
+    app: JupyterFrontEnd;
 }
 
 interface CustomDeleteItemsActionOptions {
 	keyCodes?: number[];
     customDelete?: CustomNodeWidget;
+    app: JupyterFrontEnd;
 }
 
 export class CustomDeleteItemsAction extends Action {
-    constructor(options: CustomDeleteItemsActionOptions = {}) {
+    constructor(options: CustomDeleteItemsActionOptions) {
         options = {
             keyCodes: [46, 8],
             ...options

--- a/src/components/XircuitsApp.ts
+++ b/src/components/XircuitsApp.ts
@@ -1,42 +1,43 @@
 import * as SRD from '@projectstorm/react-diagrams';
-import {CustomNodeFactory} from "./CustomNodeFactory";
+import { CustomNodeFactory } from "./CustomNodeFactory";
 import { CustomNodeModel } from './CustomNodeModel';
 import { ZoomCanvasAction } from '@projectstorm/react-canvas-core';
 import { CustomDeleteItemsAction } from './CustomNodeWidget';
+import { JupyterFrontEnd } from '@jupyterlab/application';
 
 export class XircuitsApplication {
 
-	protected activeModel: SRD.DiagramModel;
+        protected activeModel: SRD.DiagramModel;
 
-	protected diagramEngine: SRD.DiagramEngine;
+        protected diagramEngine: SRD.DiagramEngine;
 
-	constructor() {
+        constructor(app: JupyterFrontEnd) {
 
-        this.diagramEngine = SRD.default({ registerDefaultZoomCanvasAction: false, registerDefaultDeleteItemsAction: false });
-        this.activeModel = new SRD.DiagramModel();
-        this.diagramEngine.getNodeFactories().registerFactory(new CustomNodeFactory());
-        this.diagramEngine.getActionEventBus().registerAction(new ZoomCanvasAction({ inverseZoom: true }))
-        this.diagramEngine.getActionEventBus().registerAction(new CustomDeleteItemsAction());
+                this.diagramEngine = SRD.default({ registerDefaultZoomCanvasAction: false, registerDefaultDeleteItemsAction: false });
+                this.activeModel = new SRD.DiagramModel();
+                this.diagramEngine.getNodeFactories().registerFactory(new CustomNodeFactory(app));
+                this.diagramEngine.getActionEventBus().registerAction(new ZoomCanvasAction({ inverseZoom: true }))
+                this.diagramEngine.getActionEventBus().registerAction(new CustomDeleteItemsAction({ app }));
 
-        let startNode = new CustomNodeModel({ name: 'Start', color: 'rgb(255,102,102)', extras: { "type": "Start" } });
-        startNode.addOutPortEnhance('▶', 'out-0');
-        startNode.addOutPortEnhance('  ', 'parameter-out-1');
-        startNode.setPosition(100, 100);
+                let startNode = new CustomNodeModel({ name: 'Start', color: 'rgb(255,102,102)', extras: { "type": "Start" } });
+                startNode.addOutPortEnhance('▶', 'out-0');
+                startNode.addOutPortEnhance('  ', 'parameter-out-1');
+                startNode.setPosition(100, 100);
 
-        let finishedNode = new CustomNodeModel({ name: 'Finish', color: 'rgb(255,102,102)', extras: { "type": "Finish" } });
-        finishedNode.addInPortEnhance('▶', 'in-0');
-        finishedNode.addInPortEnhance('  ', 'parameter-in-1');
-        finishedNode.setPosition(700, 100);
+                let finishedNode = new CustomNodeModel({ name: 'Finish', color: 'rgb(255,102,102)', extras: { "type": "Finish" } });
+                finishedNode.addInPortEnhance('▶', 'in-0');
+                finishedNode.addInPortEnhance('  ', 'parameter-in-1');
+                finishedNode.setPosition(700, 100);
 
-        this.activeModel.addAll(startNode, finishedNode);
-        this.diagramEngine.setModel(this.activeModel);
-	}
+                this.activeModel.addAll(startNode, finishedNode);
+                this.diagramEngine.setModel(this.activeModel);
+        }
 
-	public getActiveDiagram(): SRD.DiagramModel {
-		return this.activeModel;
-	}
+        public getActiveDiagram(): SRD.DiagramModel {
+                return this.activeModel;
+        }
 
-	public getDiagramEngine(): SRD.DiagramEngine {
-		return this.diagramEngine;
-	}
+        public getDiagramEngine(): SRD.DiagramEngine {
+                return this.diagramEngine;
+        }
 }

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -91,6 +91,8 @@ export const commandIDs = {
 	runXircuit: 'Xircuit-editor:run-node',
 	debugXircuit: 'Xircuit-editor:debug-node',
 	lockXircuit: 'Xircuit-editor:lock-node',
+	editNode: 'Xircuit-editor:edit-node',
+	deleteNode: 'Xircuit-editor:delete-node',
 	createArbitraryFile: 'Xircuit-editor:create-arbitrary-file',
 	openDebugger: 'Xircuit-debugger:open',
 	breakpointXircuit: 'Xircuit-editor:breakpoint-node',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -132,6 +132,9 @@ const xircuits: JupyterFrontEndPlugin<void> = {
     restorer.add(sidebarDebugger, sidebarDebugger.id);
     app.shell.add(sidebarDebugger, 'right', { rank: 1001 });
 
+    // Additional commands for context menu
+    addContextMenuCommands(app, tracker, translator);
+
     // Add a command to open xircuits sidebar debugger
     app.commands.addCommand(commandIDs.openDebugger, {
       execute: () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,8 @@ import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { commandIDs } from './components/xircuitBodyWidget';
 import {
   WidgetTracker,
-  ReactWidget
+  ReactWidget,
+  IWidgetTracker
 } from '@jupyterlab/apputils';
 import { ILauncher } from '@jupyterlab/launcher';
 import { XircuitFactory } from './xircuitFactory';
@@ -22,8 +23,21 @@ import { OutputPanel } from './kernel/panel';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { DocumentWidget } from '@jupyterlab/docregistry';
 import { runIcon, saveIcon } from '@jupyterlab/ui-components';
+import { addContextMenuCommands } from './commands/ContextMenu';
+import { Token } from '@lumino/coreutils';
 
 const FACTORY = 'Xircuits editor';
+
+// Export a token so other extensions can require it
+export const IXircuitsDocTracker = new Token<IWidgetTracker<DocumentWidget>>(
+  'xircuitsDocTracker'
+);
+
+/**
+ * A class that tracks xircuits widgets.
+ */
+ export interface IXircuitsDocTracker
+ extends IWidgetTracker<DocumentWidget> {}
 
 /**
  * Initialization data for the documents extension.
@@ -39,7 +53,7 @@ const xircuits: JupyterFrontEndPlugin<void> = {
     IDocumentManager,
     ITranslator
   ],
-
+  provides: IXircuitsDocTracker,
   activate: async (
     app: JupyterFrontEnd,
     launcher: ILauncher,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,7 @@ import { requestAPI } from './server/handler';
 import { OutputPanel } from './kernel/panel';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { DocumentWidget } from '@jupyterlab/docregistry';
+import { runIcon, saveIcon } from '@jupyterlab/ui-components';
 
 const FACTORY = 'Xircuits editor';
 
@@ -128,7 +129,7 @@ const xircuits: JupyterFrontEndPlugin<void> = {
 
     // Add a command for creating a new xircuits file.
     app.commands.addCommand(commandIDs.createNewXircuit, {
-      label: 'Xircuits File',
+      label: 'Create New Xircuits',
       iconClass: 'jp-XircuitLogo',
       caption: 'Create a new xircuits file',
       execute: () => {
@@ -277,6 +278,8 @@ const xircuits: JupyterFrontEndPlugin<void> = {
 
     // Add command signal to save xircuits
     app.commands.addCommand(commandIDs.saveXircuit, {
+      label: "Save",
+      icon: saveIcon,
       execute: args => {
         widgetFactory.saveXircuitSignal.emit(args);
       }
@@ -291,6 +294,8 @@ const xircuits: JupyterFrontEndPlugin<void> = {
 
     // Add command signal to run xircuits
     app.commands.addCommand(commandIDs.runXircuit, {
+      label: "Run Xircuits",
+      icon: runIcon,
       execute: args => {
         widgetFactory.runXircuitSignal.emit(args);
       }

--- a/src/log/LogPlugin.ts
+++ b/src/log/LogPlugin.ts
@@ -104,7 +104,7 @@ export const logPlugin: JupyterFrontEndPlugin<void> = {
       });
       
       logConsoleWidget.addClass('jp-LogConsole');
-      logConsoleWidget.title.label = 'Xircuit Log console';
+      logConsoleWidget.title.label = 'xircuits Log console';
       logConsoleWidget.title.icon = listIcon;
 
       logConsoleWidget.toolbar.addItem(
@@ -140,8 +140,9 @@ export const logPlugin: JupyterFrontEndPlugin<void> = {
     };
 
     app.commands.addCommand(CommandIDs.openLog, {
-      label: 'Xircuit Log Console',
-      caption: 'Xircuit log console',
+      label: 'Open Xircuits Log Console',
+      caption: 'Xircuits log console',
+      icon: listIcon,
       isToggled: () => logConsoleWidget !== null,
       execute: () => {
         if (logConsoleWidget) {
@@ -187,7 +188,7 @@ export const logPlugin: JupyterFrontEndPlugin<void> = {
 
     app.commands.addCommand(commandIDs.outputMsg, {
       label: 'Output log message',
-      caption: 'Output xircuit log message.',
+      caption: 'Output xircuits log message.',
       execute: args => {
         const outputMsg = typeof args['outputMsg'] === 'undefined' ? '' : (args['outputMsg'] as string);
         const setLevel = args['level'] as any;

--- a/src/xircuitWidget.tsx
+++ b/src/xircuitWidget.tsx
@@ -60,7 +60,7 @@ export class XPipePanel extends ReactWidget {
     this.stepOutDebugSignal = options.stepOutDebugSignal;
     this.evaluateDebugSignal = options.evaluateDebugSignal;
     this.debugModeSignal = options.debugModeSignal;
-    this.xircuitsApp = new XircuitsApplication();
+    this.xircuitsApp = new XircuitsApplication(this.app);
   }
 
   handleEvent(event: Event): void {

--- a/src/xircuitWidget.tsx
+++ b/src/xircuitWidget.tsx
@@ -68,23 +68,30 @@ export class XPipePanel extends ReactWidget {
       // force focus on the editor in order stop key event propagation (e.g. "Delete" key) into unintended
       // parts of jupyter lab.
       this.node.focus();
+      // Just to enable back the loses focus event
+      this.node.addEventListener('blur', this, true);
     }else if(event.type === 'blur'){
       // Unselect any selected nodes when the editor loses focus
       const deactivate = x => x.setSelected(false);
       const model = this.xircuitsApp.getDiagramEngine().getModel();
       model.getNodes().forEach(deactivate);
       model.getLinks().forEach(deactivate);
+    }else if(event.type === 'contextmenu'){
+      // Disable loses focus event when opening context menu
+      this.node.removeEventListener('blur', this, true);
     }
   }
 
   protected onAfterAttach(msg) {
     this.node.addEventListener('mouseup', this, true);
     this.node.addEventListener('blur', this, true);
+    this.node.addEventListener('contextmenu', this, true);
   }
 
   protected onBeforeDetach() {
     this.node.removeEventListener('mouseup', this, true);
     this.node.removeEventListener('blur', this, true);
+    this.node.removeEventListener('contextmenu', this, true);
   }
 
   render(): any {

--- a/src/xircuitWidget.tsx
+++ b/src/xircuitWidget.tsx
@@ -1,14 +1,12 @@
 import { ReactWidget } from '@jupyterlab/apputils';
 import { ILabShell, JupyterFrontEnd } from '@jupyterlab/application';
 import { Signal } from '@lumino/signaling';
-import {
-  Context
-} from '@jupyterlab/docregistry';
+import { Context } from '@jupyterlab/docregistry';
 import { BodyWidget } from './components/xircuitBodyWidget';
 import React, {  } from 'react';
 import * as _ from 'lodash';
 import { ServiceManager } from '@jupyterlab/services';
-import { XircuitsApplication } from './components/XircuitsApp'
+import { XircuitsApplication } from './components/XircuitsApp';
 
 /**
  * DocumentWidget: widget that represents the view or editor for a file type.


### PR DESCRIPTION
# Description

This added a context menu for xircuits by right-clicking it. 

Currently, the context menu have 6 options which are:

1. Edit
2. Delete
3. Save
4. Run Xircuits
5. Create New Xircuits
6. Open Xircuits Log Console

For `Edit` & `Delete`, it's only enable when right-clicking a node. However, `Edit` only works for **Literal Node**.

Also, fix literal node editing when cancel is pressed or no input provided.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Tests

1. Do test the 6 options in the context menu. All of these options are explanatory by their given name except for 1) & 2)
   1. Edit: Enable to edit Literal Value
   2. Delete: Enable to delete any node
2. Do check the previous function for edit and delete still works
   1. Edit: Double clicking Literal Node
   2. Delete: Press 'Delete' or 'backspace' keys on any node
3. While editing, either provide an empty `string`, press cancel or ok
   1. It shouldn't do anything. 


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

The `Shift+Right Click for Browser Menu` can't be removed as it's [hardcoded](https://github.com/jupyterlab/jupyterlab/blob/7f87d89dc88ad86e84fb2245c873139ce60dec3c/packages/application-extension/src/index.tsx#L124-L129) in JupyterLab itself.
