### PR TITLE
💄Change into labIcon and replace the refresh icon

### DIFF
--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -26,7 +26,7 @@ jobs:
       
     - name: Setup Build Env
       run: |
-        curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | sh 
+        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
         . ~/.nvm/nvm.sh
         nvm install 14.15.3
         nvm use 14.15.3

--- a/src/debugger/SidebarDebugger.ts
+++ b/src/debugger/SidebarDebugger.ts
@@ -6,6 +6,7 @@ import { commandIDs } from '../components/xircuitBodyWidget';
 import { DebuggerWidget } from './DebuggerWidget';
 import { XircuitFactory } from '../xircuitFactory';
 import { Toolbar, CommandToolbarButton } from '@jupyterlab/apputils';
+import { breakpointIcon } from '../ui-components/icons';
 
 export const DebuggerCommandIDs = {
   continue: 'Xircuits-debugger:continue',
@@ -166,7 +167,7 @@ export const DebuggerCommandIDs = {
       // Add command signal to toggle breakpoint
       app.commands.addCommand(commandIDs.breakpointXircuit, {
         caption: trans.__('Toggle Breakpoint'),
-        iconClass: 'jp-BreakpointLogo',
+        icon: breakpointIcon,
         isEnabled: () => {
           return debugMode ?? false;
         },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,7 @@ import { requestAPI } from './server/handler';
 import { OutputPanel } from './kernel/panel';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { DocumentWidget } from '@jupyterlab/docregistry';
+import { xircuitsIcon, debuggerIcon } from './ui-components/icons';
 
 const FACTORY = 'Xircuits editor';
 
@@ -68,7 +69,7 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       name: 'xircuits',
       displayName: 'Xircuits',
       extensions: ['.xircuits'],
-      iconClass: 'jp-XircuitLogo'
+      icon: xircuitsIcon
     });
 
     // Registering the widget factory
@@ -100,6 +101,24 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       name: widget => widget.context.path
     });
     
+    // Find the MainLogo widget in the shell and replace it with the Xircuits Logo
+    const widgets = app.shell.widgets('top');
+    let widget = widgets.next();
+
+    while (widget !== undefined) {
+      if (widget.id === 'jp-MainLogo') {
+        xircuitsIcon.element({
+          container: widget.node,
+          justify: 'center',
+          height: 'auto',
+          width: '25px'
+        });
+        break;
+      }
+
+      widget = widgets.next();
+    }
+
     // Creating the sidebar widget for the xai components
     const sidebarWidget = ReactWidget.create(<Sidebar lab={app}/>);
     sidebarWidget.id = 'xircuits-component-sidebar';
@@ -112,7 +131,7 @@ const xircuits: JupyterFrontEndPlugin<void> = {
     // Creating the sidebar debugger
     const sidebarDebugger = new XircuitsDebugger.Sidebar({ app, translator, widgetFactory })
     sidebarDebugger.id = 'xircuits-debugger-sidebar';
-    sidebarDebugger.title.iconClass = 'jp-DebuggerLogo';
+    sidebarDebugger.title.icon = debuggerIcon;
     sidebarDebugger.title.caption = "Xircuits Debugger";
     restorer.add(sidebarDebugger, sidebarDebugger.id);
     app.shell.add(sidebarDebugger, 'right', { rank: 1001 });
@@ -129,7 +148,7 @@ const xircuits: JupyterFrontEndPlugin<void> = {
     // Add a command for creating a new xircuits file.
     app.commands.addCommand(commandIDs.createNewXircuit, {
       label: 'Xircuits File',
-      iconClass: 'jp-XircuitLogo',
+      icon: xircuitsIcon,
       caption: 'Create a new xircuits file',
       execute: () => {
         app.commands

--- a/src/kernel/panel.ts
+++ b/src/kernel/panel.ts
@@ -21,6 +21,7 @@ import { Message } from '@lumino/messaging';
 import { StackedPanel } from '@lumino/widgets';
 
 import { Log } from '../log/LogPlugin';
+import { xircuitsIcon } from '../ui-components/icons';
 import { XircuitFactory } from '../xircuitFactory';
 
 /**
@@ -46,7 +47,7 @@ export class OutputPanel extends StackedPanel {
         this.id = 'xircuit-output-panel';
         this.title.label = this._trans.__('Xircuit Output');
         this.title.closable = true;
-        this.title.iconClass = 'jp-XircuitLogo';
+        this.title.icon = xircuitsIcon;
 
         this._sessionContext = new SessionContext({
             sessionManager: manager.sessions,

--- a/src/svg.d.ts
+++ b/src/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+    const value: string;
+    export default value;
+}

--- a/src/ui-components/icons.tsx
+++ b/src/ui-components/icons.tsx
@@ -1,0 +1,10 @@
+import { LabIcon } from '@jupyterlab/ui-components';
+import xircuitsSvg from '../../style/icons/xpress-logo.svg';
+import debuggerSvg from '../../style/icons/debugger.svg';
+import lockSvg from '../../style/icons/lock.svg';
+import breakpointSvg from '../../style/icons/breakpoint.svg';
+
+export const xircuitsIcon = new LabIcon({ name: 'xircuits:xircuits', svgstr: xircuitsSvg });
+export const debuggerIcon = new LabIcon({ name: 'xircuits:debuggerIcon', svgstr: debuggerSvg });
+export const lockIcon = new LabIcon({ name: 'xircuits:lockIcon', svgstr: lockSvg });
+export const breakpointIcon = new LabIcon({ name: 'xircuits:breakpointIcon', svgstr: breakpointSvg });

--- a/src/xircuitFactory.ts
+++ b/src/xircuitFactory.ts
@@ -24,6 +24,7 @@ import { commandIDs } from './components/xircuitBodyWidget';
 import { CommandIDs } from './log/LogPlugin';
 import { ServiceManager } from '@jupyterlab/services';
 import { RunSwitcher } from './components/RunSwitcher';
+import { lockIcon, xircuitsIcon } from './ui-components/icons';
 
 const XPIPE_CLASS = 'xircuits-editor';
 
@@ -107,7 +108,7 @@ export class XircuitFactory extends ABCWidgetFactory<DocumentWidget> {
 
     const widget = new DocumentWidget({ content, context });
     widget.addClass(XPIPE_CLASS);
-    widget.title.iconClass = 'jp-XircuitLogo';
+    widget.title.icon = xircuitsIcon;
 
     /**
      * Create a save button toolbar item.
@@ -190,7 +191,7 @@ export class XircuitFactory extends ABCWidgetFactory<DocumentWidget> {
      * Create a lock button toolbar item.
      */
      let lockButton = new ToolbarButton({
-      iconClass: 'jp-LockLogo',
+      icon: lockIcon,
       tooltip: "Lock all non-general nodes connected from start node",
       onClick: (): void => {
         this.commands.execute(commandIDs.lockXircuit);

--- a/style/base.css
+++ b/style/base.css
@@ -3,13 +3,20 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-#jp-MainLogo {
-    background-image: url(../style/icons/xpress-logo.svg);
-    background-repeat: no-repeat;
+/* Refresh Icon */
+#main-logo{
+  background-image: url(../style/icons/xpress-logo.svg); 
+  background-repeat: no-repeat;
+  display: block;
+  background-size: auto;
+  position: relative;
+  left: 650px;
+  top: 270px;
+  width: 15%;
+  height: 15%; 
 }
-
-#jp-MainLogo > svg {
-    visibility: hidden;
+#main-logo > svg{
+  visibility: hidden;
 }
 
 .jp-DebuggerWidget {

--- a/style/base.css
+++ b/style/base.css
@@ -7,13 +7,12 @@
 #main-logo{
   background-image: url(../style/icons/xpress-logo.svg); 
   background-repeat: no-repeat;
-  display: block;
-  background-size: auto;
-  position: relative;
-  left: 650px;
-  top: 270px;
+  position: fixed;
   width: 15%;
   height: 15%; 
+  top: 50%;
+  left: 55%;
+  transform: translate(-50%, -50%);
 }
 #main-logo > svg{
   visibility: hidden;

--- a/style/base.css
+++ b/style/base.css
@@ -26,21 +26,6 @@
   flex: 0 0 auto;
 }
 
-.jp-XircuitLogo {
-  background-image: url(./icons/xpress-logo.svg);
-  background-repeat: no-repeat;
-}
-
-.jp-DebuggerLogo {
-  background-image: url(./icons/debugger.svg);
-  background-repeat: no-repeat;
-}
-
-.jp-LockLogo {
-  background-image: url(./icons/lock.svg);
-  background-repeat: no-repeat;
-}
-
 .jp-ComponentLibraryLogo {
   background-image: url(./icons/component-library.svg);
   background-repeat: no-repeat;
@@ -51,11 +36,6 @@
   background-image: url(./icons/next.svg);
   background-repeat: no-repeat;
   background-size: 25px 25px;
-}
-
-.jp-BreakpointLogo {
-  background-image: url(./icons/breakpoint.svg);
-  background-repeat: no-repeat;
 }
 
 /* Close button for image viewer*/


### PR DESCRIPTION
# Description

This will change some of the icons to use the [LabIcon](https://github.com/jupyterlab/jupyterlab/tree/3.1.x/packages/ui-components#labicon---set-up-and-render-icons), icon class used by JupyterLab.

The icons changed into `LabIcon` are :

1. xircuits
2. debugger
3. lock
4. breakpoint

This also replace the **refresh** icon to xircuits's icon

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Make sure the changed icons are correct and render properly.
2. Try refreshing the jupyterlab. It should render a xircuits's icon rather than jupyterlab's with the same orbit's icon.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Currently, there some icons still need the css class to be style. Icons can be styled by passing CSS parameters into `.element(...`) as shown [here](https://github.com/jupyterlab/jupyterlab/tree/3.1.x/packages/ui-components#how-to-render-an-icon-into-a-dom-node) if needed to change into `LabIcon`
