### PR TITLE
🐛Fix kernel not dispose when closed

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -99,7 +99,7 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       }),
       name: widget => widget.context.path
     });
-    
+
     // Creating the sidebar widget for the xai components
     const sidebarWidget = ReactWidget.create(<Sidebar lab={app}/>);
     sidebarWidget.id = 'xircuits-component-sidebar';
@@ -247,9 +247,6 @@ const xircuits: JupyterFrontEndPlugin<void> = {
 
         // Create the panel if it does not exist
         if (!outputPanel || outputPanel.isDisposed) {
-          await createPanel();
-        } else {
-          outputPanel.dispose();
           await createPanel();
         }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -212,6 +212,11 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       return outputPanel;
     }
 
+    // Dispose the output panel when closing browser or tab
+    window.addEventListener('beforeunload', function (e) {
+      outputPanel.dispose();
+    });
+
     async function requestToSparkSubmit(path: string, addArgs: string) {
       const dataToSend = { "currentPath": path, "addArgs": addArgs };
 

--- a/src/kernel/panel.ts
+++ b/src/kernel/panel.ts
@@ -3,23 +3,16 @@ import {
     SessionContext,
     sessionContextDialogs,
 } from '@jupyterlab/apputils';
-
 import { OutputAreaModel, SimplifiedOutputArea } from '@jupyterlab/outputarea';
-
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-
 import { KernelMessage, ServiceManager } from '@jupyterlab/services';
-
 import {
     ITranslator,
     nullTranslator,
     TranslationBundle,
 } from '@jupyterlab/translation';
-
 import { Message } from '@lumino/messaging';
-
 import { StackedPanel } from '@lumino/widgets';
-
 import { Log } from '../log/LogPlugin';
 import { XircuitFactory } from '../xircuitFactory';
 


### PR DESCRIPTION
# Description

This will fix the 'zombie' kernel still exist when closing/refreshing tab.

Also, as discussed before, remove the need to create a kernel every time run button clicked. Currently, it'll use the same kernel as long as the output panel still exist.

## References

#55 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Try running xircuits multiple times without closing the output panel. 
   1. The xircuits shouldn't prompt user to select a kernel after the first run.
   2. It'll only use the kernel created when the first run was clicked.
2. Try running xircuits and then remove the output panel.
   1. Try run it again and it should prompt user to select a kernel.
3. While the output panel exist, close/reload the tab.
   1. The xircuits's kernel shouldn't exist in the 'Running Kernels' panel.


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

**Don't manual close the xircuits's kernel in the 'Running Kernels' panel. It'll break the xircuits kernel and refresh is needed to fix it.**