### PR TITLE
🐛Dispose output panel when no kernel selected

### DIFF
--- a/src/kernel/panel.ts
+++ b/src/kernel/panel.ts
@@ -61,6 +61,10 @@ export class OutputPanel extends StackedPanel {
             .then(async (value) => {
                 if (value) {
                     await sessionContextDialogs.selectKernel(this._sessionContext);
+                    // Dispose panel when no kernel selected
+                    if (this._sessionContext.hasNoKernel) {
+                        super.dispose();
+                    }
                 }
             })
             .catch((reason) => {


### PR DESCRIPTION
# Description

This will fix the output panel broken when no kernel selected.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. When running any xircuits, don't pick any kernel. 
   1. Click Run again.
   2. It should prompt to select a kernel. 
   3. Select a kernel.
   4. Xircuits should be able to run as usual.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  