### PR TITLE
updated wheel name in github action

### DIFF
--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -45,5 +45,5 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: xircuits-wheel
+        name: xircuits-wheel-${GITHUB_REF#refs/*/}-$(git rev-parse --short "$GITHUB_SHA")
         path: dist

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -27,14 +27,15 @@ jobs:
 
     - name: Get Branch
       id: branch
-      run: echo "git_branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_BRANCH
+      run: echo "git_branch=${GITHUB_REF#refs/heads/}" 
+      
 
     - name: Check Branch
       run: echo "${{ env.branch }}"
 
     - name: Get Hash
       id: hash
-      run: echo "git_hash=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_HASH
+      run: echo "git_hash=$(git rev-parse --short "$GITHUB_SHA")" 
 
     - name: Check Hash
       run: echo "${{ env.hash }}"

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -36,6 +36,10 @@ jobs:
       run: |
         echo "branch_name3=$GITHUB_HEAD_REF" >> $GITHUB_ENV               
 
+    - name: Set Branch Name 4
+      run: |
+        echo "branch_name4=${GITHUB_REF##*/}" >> $GITHUB_ENV               
+
     - name: Get Hash
       id: hash
       run: echo "git_hash=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
@@ -64,5 +68,5 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: xircuits-wheel-${{ env.branch_name2 }}-${{ env.git_hash }}
+        name: xircuits-wheel-${{ env.branch_name4 }}-${{ env.git_hash }}
         path: dist

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Set Branch Name 4
       run: |
-        echo "branch_name4=${GITHUB_REF##*/}" >> $GITHUB_ENV               
+        echo "branch_name4=${GITHUB_HEAD_REF##*/}" >> $GITHUB_ENV               
 
     - name: Get Hash
       id: hash

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -61,5 +61,5 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: xircuits-wheel-"${{ env.branch }}"-"${{ env.hash }}"
+        name: xircuits-wheel-${GITHUB_REF#refs/heads/}-$(git rev-parse --short "$GITHUB_SHA")
         path: dist

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -29,11 +28,11 @@ jobs:
       run: |
         echo "branch_name=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
-     - name: Set Branch Name 2
+    - name: Set Branch Name 2
       run: |
         echo "branch_name2=$GITHUB_REF" >> $GITHUB_ENV
 
-     - name: Set Branch Name 3
+    - name: Set Branch Name 3
       run: |
         echo "branch_name3=$GITHUB_HEAD_REF" >> $GITHUB_ENV               
 

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -23,6 +23,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
+
+    - name: Check Branch and Commit Hash
+      run: |
+        echo "Branch: ${{ steps.vars.outputs.branch }}"
+        echo "Sha: ${{ steps.vars.outputs.sha_short }}"
       
     - name: Setup Build Env
       run: |
@@ -45,5 +51,5 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: xircuits-wheel-${GITHUB_REF#refs/*/}-$(git rev-parse --short "$GITHUB_SHA")
+        name: xircuits-wheel-${GITHUB_REF#refs/*/}-${GITHUB_SHA}
         path: dist

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -60,5 +60,5 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: "xircuits-wheel-"${{ env.branch }}"-"${{ env.hash }}"
+        name: xircuits-wheel-"${{ env.branch }}"-"${{ env.hash }}"
         path: dist

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -46,7 +46,11 @@ jobs:
     - name: Check Hash2
       env:
         hash-short: $(git rev-parse --short "$GITHUB_SHA")" 
-      run: echo "hash-short"
+      run: echo "$hash-short"
+
+    - name: Get branch name
+      if: ${{ contains(github.ref, 'refs/tags/') }}
+      run: echo "::set-env name=BRANCH_NAME::${GITHUB_REF##*/}"
       
     - name: Setup Build Env
       run: |
@@ -69,5 +73,5 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: xircuits-wheel-${GITHUB_REF_NAME}
+        name: ${{ env.BRANCH_NAME }}-xircuits-artifact
         path: dist

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -25,31 +25,18 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
 
-    - name: Get Branch
-      id: branch
-      run: echo "git_branch=${GITHUB_REF#refs/heads/}" 
-      
-
-    - name: Check Branch
-      run: echo "$GITHUB_REF_NAME"
-
-    - name: Check Branch 2
-      run: echo $GITHUB_REF_NAME
+    - name: Set Branch Name
+      run: |
+        echo "branch_name=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
     - name: Get Hash
       id: hash
-      run: echo "git_hash=$(git rev-parse --short "$GITHUB_SHA")" 
+      run: echo "git_hash=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
 
     - name: Check Hash
       run: echo "${{ env.hash }}"
 
-    - name: Check Hash2
-      env:
-        hash-short: $(git rev-parse --short "$GITHUB_SHA")" 
-      run: echo "$hash-short"
-
     - name: Get branch name
-      if: ${{ contains(github.ref, 'refs/tags/') }}
       run: echo "::set-env name=BRANCH_NAME::${GITHUB_REF##*/}"
       
     - name: Setup Build Env

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -31,7 +31,10 @@ jobs:
       
 
     - name: Check Branch
-      run: echo "${{ env.branch }}"
+      run: echo "$GITHUB_REF_NAME"
+
+    - name: Check Branch 2
+      run: echo $GITHUB_REF_NAME
 
     - name: Get Hash
       id: hash
@@ -39,6 +42,11 @@ jobs:
 
     - name: Check Hash
       run: echo "${{ env.hash }}"
+
+    - name: Check Hash2
+      env:
+        hash-short: $(git rev-parse --short "$GITHUB_SHA")" 
+      run: echo "hash-short"
       
     - name: Setup Build Env
       run: |
@@ -61,5 +69,5 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: xircuits-wheel-${GITHUB_REF#refs/heads/}-$(git rev-parse --short "$GITHUB_SHA")
+        name: xircuits-wheel-${GITHUB_REF_NAME}
         path: dist

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -34,11 +34,8 @@ jobs:
       run: echo "git_hash=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
 
     - name: Check Hash
-      run: echo "${{ env.hash }}"
+      run: echo "$env.git_hash"
 
-    - name: Get branch name
-      run: echo "::set-env name=BRANCH_NAME::${GITHUB_REF##*/}"
-      
     - name: Setup Build Env
       run: |
         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
@@ -60,5 +57,5 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ env.BRANCH_NAME }}-xircuits-artifact
+        name: ${{ env.branch_name }}-xircuits-artifact
         path: dist

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -51,5 +51,5 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: xircuits-wheel-${GITHUB_REF#refs/*/}-${GITHUB_SHA}
+        name: "xircuits-wheel-${GITHUB_REF#refs/*/}-${GITHUB_SHA}"
         path: dist

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -25,10 +25,19 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
 
-    - name: Check Branch and Commit Hash
-      run: |
-        echo "Branch: ${{ steps.vars.outputs.branch }}"
-        echo "Sha: ${{ steps.vars.outputs.sha_short }}"
+    - name: Get Branch
+      id: branch
+      run: echo "git_branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_BRANCH
+
+    - name: Check Branch
+      run: echo "${{ env.branch }}"
+
+    - name: Get Hash
+      id: hash
+      run: echo "git_hash=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_HASH
+
+    - name: Check Hash
+      run: echo "${{ env.hash }}"
       
     - name: Setup Build Env
       run: |
@@ -51,5 +60,5 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: "xircuits-wheel-${GITHUB_REF#refs/*/}-${GITHUB_SHA}"
+        name: "xircuits-wheel-"${{ env.branch }}"-"${{ env.hash }}"
         path: dist

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -29,6 +29,14 @@ jobs:
       run: |
         echo "branch_name=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
+     - name: Set Branch Name 2
+      run: |
+        echo "branch_name2=$GITHUB_REF" >> $GITHUB_ENV
+
+     - name: Set Branch Name 3
+      run: |
+        echo "branch_name3=$GITHUB_HEAD_REF" >> $GITHUB_ENV               
+
     - name: Get Hash
       id: hash
       run: echo "git_hash=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
@@ -57,5 +65,5 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ env.branch_name }}-xircuits-artifact
+        name: xircuits-wheel-${{ env.branch_name2 }}-${{ env.git_hash }}
         path: dist

--- a/.github/workflows/build-python-wheel.yml
+++ b/.github/workflows/build-python-wheel.yml
@@ -23,22 +23,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-
     - name: Set Branch Name
       run: |
-        echo "branch_name=$GITHUB_REF_NAME" >> $GITHUB_ENV
+        echo "branch_name=${GITHUB_HEAD_REF##*/}" >> $GITHUB_ENV               
 
-    - name: Set Branch Name 2
-      run: |
-        echo "branch_name2=$GITHUB_REF" >> $GITHUB_ENV
-
-    - name: Set Branch Name 3
-      run: |
-        echo "branch_name3=$GITHUB_HEAD_REF" >> $GITHUB_ENV               
-
-    - name: Set Branch Name 4
-      run: |
-        echo "branch_name4=${GITHUB_HEAD_REF##*/}" >> $GITHUB_ENV               
+    - name: Check Branch
+      run: echo "$env.branch_name"
 
     - name: Get Hash
       id: hash
@@ -68,5 +58,5 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: xircuits-wheel-${{ env.branch_name4 }}-${{ env.git_hash }}
+        name: xircuits-wheel-${{ env.branch_name }}-${{ env.git_hash }}
         path: dist


### PR DESCRIPTION
# Description

When downloading the github action artifacts, every file is named `xircuits-wheel`. For the sake of distinguishing which is which, I've added the branch name and the commit hash.


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Documentation
- [x] Others (Please Specify): Github Action

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Check the artifact in this pull request. It should have the branch name and hash.

## Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [x] Others: Github  

