### PR TITLE
🐛Fix type check 'any'

### DIFF
--- a/src/components/CustomPortModel.ts
+++ b/src/components/CustomPortModel.ts
@@ -116,6 +116,10 @@ export  class CustomPortModel extends DefaultPortModel  {
 
         }else{
             if (thisName.startsWith("parameter")){
+                // Skip 'any' type check
+                if(thisName.includes('any')){
+                    return
+                }
 		        port.getNode().getOptions().extras["borderColor"]="red";
 		        port.getNode().getOptions().extras["tip"]= "Node link to this port must be a hyperparameter/literal";
                 port.getNode().setSelected(true);


### PR DESCRIPTION
# Description

This will skip `any` type check.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Open examples/KerasModelPredict.xircuits
2. Delete and Add new `KerasPredict` node
3. Connect  **`model`** from `ResNet50` into **`model`** in `KerasPredict`
4. You should be able to connect the link when doing the above.
5. Run the xircuits.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
