### PR TITLE
✨Remember last input of added arguments for spark submit

### DIFF
--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -168,6 +168,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 	const [inDebugMode, setInDebugMode] = useState<boolean>(false);
 	const [currentIndex, setCurrentIndex] = useState<number>(-1);
 	const [runType, setRunType] = useState<string>("run");
+	const [addedArgSparkSubmit, setAddedArgSparkSubmit] = useState<string>("");
 	const xircuitLogger = new Log(app);
 	const contextRef = useRef(context);
 	const notInitialRender = useRef(false);
@@ -1395,6 +1396,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			title,
 			body: formDialogWidget(
 				<RunDialog
+					lastAddedArgsSparkSubmit={addedArgSparkSubmit}
 					childSparkSubmitNodes={sparkSubmitNodes}
 					childStringNodes={stringNodes}
 					childBoolNodes={boolNodes}
@@ -1416,6 +1418,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		let commandStr = ' ';
 		// Added arguments for spark submit
 		let addArgs = dialogResult["value"][sparkSubmitNodes] ?? "";
+		setAddedArgSparkSubmit(addArgs);
 
 		stringNodes.forEach((param) => {
 			if (param == 'experiment name') {

--- a/src/dialog/RunDialog.tsx
+++ b/src/dialog/RunDialog.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import Switch from "react-switch";
 
 export const RunDialog = ({
+	lastAddedArgsSparkSubmit,
 	childSparkSubmitNodes,
 	childStringNodes,
 	childBoolNodes,
@@ -28,6 +29,7 @@ export const RunDialog = ({
 					<><div><h4 style={{ marginTop: 2, marginBottom: 0 }}>Spark Submit</h4></div><div>{childSparkSubmitNodes}
 						<div>
 							<TextareaAutosize
+								defaultValue={lastAddedArgsSparkSubmit}
 								minRows={3}
 								maxRows={8}
 								name={childSparkSubmitNodes}


### PR DESCRIPTION
# Description

This will make the added arguments for spark submit use the previous input as default value.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Run xircuits using spark submit with added argument
2. Run again with spark submit and see if the previous input of added args is still there

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  