### PR TITLE
Don't compile when doing spark submit

### DIFF
--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -854,8 +854,8 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		let pythonCode = getPythonCompiler();
 		let showOutput = false;
 		
-		// Don't compile if 'Run w/o compile' is chosen
-		if(runType != 'run-dont-compile'){
+		// Only compile when 'Run' is chosen
+		if(runType == 'run'){
 			commands.execute(commandIDs.createArbitraryFile, { pythonCode, showOutput });
 			setCompiled(true);
 		}


### PR DESCRIPTION
# Description

This will only allow xircuits to compile when Run option is chosen.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Run xircuits with spark submit and see does it compile/update its python script. It shouldn't update it.
2. Also, run xircuits with the default (Run) option and see does it compile/update its python script. It should still update it.

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  