### PR TITLE
🐛 Fix Xircuits start in Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+venv*/
 
 # Spyder project settings
 .spyderproject
@@ -132,4 +133,3 @@ dmypy.json
 node_modules/
 *.bundle.*
 labextension/
-

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -7,6 +7,7 @@ import shutil
 import os
 from pathlib import Path
 from sys import platform
+from time import sleep
 
 def start_xircuits():
     print(
@@ -26,28 +27,28 @@ __   __  ___                _ _
     
     if platform == "win32":
         xai_component_path = Path(sys.executable).parents[1] / "Lib" / "site-packages" / "xai_components"
-        config_path = Path(sys.executable).parents[1] / "Lib" / "site-packages" / "xai_components" / ".xircuits"
+        config_path = str(xai_component_path) + "/.xircuits"
     
     else:  
         # the dir path for linux venv looks like : venv/lib/python3.9/site-packages/xircuits
-        venv_python_version = os.listdir("venv/lib")[0]
+        venv_name = sys.executable.split("/")[-3]
+        venv_python_version = os.listdir(venv_name+"/lib")[0]
         xai_component_path = Path(sys.executable).parents[1] / "lib" / venv_python_version / "site-packages" / "xai_components"
-        config_path = Path(sys.executable).parents[1] / "lib" / venv_python_version / "site-packages" / "xai_components" / ".xircuits"
+        config_path = str(xai_component_path) + "/.xircuits"
         
     current_path = Path(os.getcwd()) / "xai_components"
     current_config_path = Path(os.getcwd()) / ".xircuits"
-
 
     if not current_path.exists():
         val = input("Xircuits Component Library is not found. Would you like to load it in the current path (Y/N)? ")
         if val.lower() == ("y" or "yes"):
             shutil.copytree(xai_component_path, current_path, dirs_exist_ok=True)
             if not current_config_path.exists():
-            	shutil.copytree(config_path, current_config_path, dirs_exist_ok=True)
-        
+                shutil.copytree(config_path, current_config_path, dirs_exist_ok=True)
+    
+    sleep(0.1)
     os.system("jupyter lab")
 
 def main(argv=None):
 
-    #argv = argv or sys.argv[1:]
     start_xircuits()


### PR DESCRIPTION
# Description

Previous launch via `xircuits` in linux was hard coded. This PR makes it slightly smarter.

## References
#85 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Test Xircuits Start in Linux**

    1. Create venv in Linux with any name you want
    2. install xircuits
    3. launch xircuits with `xircuits`


## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Add if any.
