### PR TITLE
✨Add context menu option to open node's script

### DIFF
--- a/src/commands/NodeActionCommands.ts
+++ b/src/commands/NodeActionCommands.ts
@@ -31,6 +31,21 @@ export function addNodeActionCommands(
         );
     }
 
+    //Add command to open canvas's node its script
+    commands.addCommand(commandIDs.openScript, {
+        execute:  () =>{
+            const widget = tracker.currentWidget?.content as XPipePanel;
+            const selectedEntities = widget.xircuitsApp.getDiagramEngine().getModel().getSelectedEntities();
+            _.forEach(selectedEntities, (model) => {
+                const filePath = model.extras.path
+                app.commands.execute(commandIDs.openDocManager, {
+                    path: filePath
+                });
+            });
+            widget.xircuitsApp.getDiagramEngine().repaintCanvas();
+        }
+    });
+
     //Add command to undo
     commands.addCommand(commandIDs.undo, {
         execute:  () =>{

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -95,6 +95,7 @@ export const commandIDs = {
 	runXircuit: 'Xircuit-editor:run-node',
 	debugXircuit: 'Xircuit-editor:debug-node',
 	lockXircuit: 'Xircuit-editor:lock-node',
+	openScript: 'Xircuit-editor:open-node-script',
 	undo: 'Xircuit-editor:undo',
 	redo: 'Xircuit-editor:redo',
 	cutNode: 'Xircuit-editor:cut-node',
@@ -1693,7 +1694,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 							if (current_node.header == "GENERAL") {
 								node = GeneralComponentLibrary({ name: data.name, color: current_node["color"], type: data.type });
 							} else if (current_node.header == "ADVANCED") {
-								node = new CustomNodeModel({ name: data.name, color: current_node["color"], extras: { "type": data.type } });
+								node = new CustomNodeModel({ name: data.name, color: data.color, extras: { "type": data.type, "path": data.path } });
 								node.addInPortEnhance('▶', 'in-0');
 								node.addOutPortEnhance('▶', 'out-0');
 

--- a/src/context-menu/NodeActionsPanel.tsx
+++ b/src/context-menu/NodeActionsPanel.tsx
@@ -53,6 +53,12 @@ export class NodeActionsPanel extends React.Component<NodeActionsPanelProps> {
 				</div>
 				<div className="option"
 					onClick={() => {
+						this.props.app.commands.execute(commandIDs.openScript)
+					}}>
+					Open Script
+				</div>
+				<div className="option"
+					onClick={() => {
 						this.props.app.commands.execute(commandIDs.deleteNode)
 					}}>
 					Delete

--- a/src/context-menu/TrayItemPanel.tsx
+++ b/src/context-menu/TrayItemPanel.tsx
@@ -41,7 +41,7 @@ export class TrayItemPanel extends React.Component<TrayItemWidgetProps> {
 			if (current_node.header == "GENERAL") {
 				node = GeneralComponentLibrary({ name: current_node["task"], color: current_node["color"], type: current_node["type"] });
 			} else {
-				node = new CustomNodeModel({ name: current_node["task"], color: current_node["color"], extras: { "type": current_node["type"] } });
+				node = new CustomNodeModel({ name: current_node["task"], color: current_node["color"], extras: { "type": current_node["type"], "path": current_node["file_path"] } });
 				node.addInPortEnhance('▶', 'in-0');
 				node.addOutPortEnhance('▶', 'out-0');
 

--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -218,7 +218,9 @@ export default function Sidebar(props: SidebarProps) {
                                                                     <TrayItemWidget
                                                                         model={{
                                                                             type: componentVal.type,
-                                                                            name: componentVal.task
+                                                                            name: componentVal.task,
+                                                                            color: componentVal.color,
+                                                                            path: componentVal.file_path
                                                                         }}
                                                                         name={componentVal.task}
                                                                         color={componentVal.color}
@@ -245,7 +247,12 @@ export default function Sidebar(props: SidebarProps) {
                                 return (
                                     <div key={`index-3-${i}`}>
                                         <TrayItemWidget
-                                            model={{ type: val.type, name: val.task }}
+                                            model={{ 
+                                                type: val.type, 
+                                                name: val.task,
+                                                color: val.color,
+                                                path: val.file_path
+                                            }}
                                             name={val.task}
                                             color={val.color}
                                             app={props.lab}

--- a/style/NodeActionPanel.css
+++ b/style/NodeActionPanel.css
@@ -8,7 +8,7 @@
   
   .option {
     cursor: pointer;
-    width: 50px;
+    width: 70px;
     height: 13px;
     font-size:small;
     padding: 5px 7px;


### PR DESCRIPTION
# Description

This will enable to open the python script of node in canvas.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Drop any node via sidebar or component panel
2. Open context menu on the node (ctrl+left-click)
3. Select `Open Script`
4. It'll open its script

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

It's only works for any latest dropped node. Any old nodes that's already on canvas will not work as it doesn't have `file_path` data.