### PR TITLE
🐛Fix any type input doesn't accept literal

### DIFF
--- a/src/components/CustomPortModel.ts
+++ b/src/components/CustomPortModel.ts
@@ -107,6 +107,10 @@ export  class CustomPortModel extends DefaultPortModel  {
             let result = thisLinkedName.match(regEx);
 
             if(thisNodeModelType != result[1]){
+                // Skip 'any' type check
+                if(result[1] == 'any'){
+                    return;
+                }
 		        port.getNode().getOptions().extras["borderColor"]="red";
 		        port.getNode().getOptions().extras["tip"]="Port linked not correct data type (" + result[1] +")";
                 port.getNode().setSelected(true);


### PR DESCRIPTION
# Description

This will allow literal for `any` type check

## References

If applicable, note issue numbers this pull request addresses. You can also note any other pull requests that address this issue and how this pull request is different.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Change `any` in the python script. For example:
```
@xai_component
class HelloListTupleDict(Component):

    input_list: InArg[any]
```
2. Try connecting any literal to that port. It should be able to link.

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  