### PR TITLE
✨ Pull components from repo

### DIFF
--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -95,3 +95,5 @@ webencodings==0.5.1
 websocket-client==1.2.1
 Werkzeug==2.0.2
 zipp==3.4.0
+pygithub
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,3 +72,5 @@ webencodings==0.5.1
 websocket-client==1.2.1
 zipp==3.4.0
 matplotlib
+pygithub
+tqdm

--- a/xircuits/handlers/request_folder.py
+++ b/xircuits/handlers/request_folder.py
@@ -1,0 +1,28 @@
+from tqdm import tqdm
+import os
+from urllib import request
+
+def request_folder(folder, repo_name="XpressAi/Xircuits"):
+    from github import Github
+    print("Downloading " + folder + " from " + repo_name)
+    g = Github()
+    repo = g.get_repo(repo_name)
+    base_url = "https://raw.githubusercontent.com/" + repo_name + "/master/"
+
+    os.mkdir(folder)
+
+    contents = repo.get_contents(folder)
+    total_folders = sum(content.type=='dir' for content in contents)
+    
+    pbar = tqdm(total=total_folders)
+    
+    while len(contents)>0:
+        file_content = contents.pop(0)
+        if file_content.type=='dir':
+            os.mkdir(file_content.path)
+            contents.extend(repo.get_contents(file_content.path))
+            pbar.update(1)
+
+        else:
+            file_url = base_url + "/" + file_content.path
+            request.urlretrieve(file_url, file_content.path)

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -1,13 +1,16 @@
-
 # coding: utf-8
 """A wrapper to start xircuits and offer to start to XAI-components"""
 
-import sys
-import shutil
-import os
 from pathlib import Path
-from sys import platform
-from time import sleep
+from urllib import request
+import os
+from .handlers.request_folder import request_folder
+
+def init_xircuits():
+    url = "https://raw.githubusercontent.com/XpressAI/xircuits/master/.xircuits/config.ini"
+    path = ".xircuits"
+    os.mkdir(path)
+    request.urlretrieve(url, path+"/config.ini")
 
 def start_xircuits():
     print(
@@ -22,33 +25,19 @@ __   __  ___                _ _
 ======================================
 '''
     )
-    
-    # the current handler assumes that the user uses venv to install xircuits
-    
-    if platform == "win32":
-        xai_component_path = Path(sys.executable).parents[1] / "Lib" / "site-packages" / "xai_components"
-        config_path = str(xai_component_path) + "/.xircuits"
-    
-    else:  
-        # the dir path for linux venv looks like : venv/lib/python3.9/site-packages/xircuits
-        venv_name = sys.executable.split("/")[-3]
-        venv_python_version = os.listdir(venv_name+"/lib")[0]
-        xai_component_path = Path(sys.executable).parents[1] / "lib" / venv_python_version / "site-packages" / "xai_components"
-        config_path = str(xai_component_path) + "/.xircuits"
-        
-    current_path = Path(os.getcwd()) / "xai_components"
-    current_config_path = Path(os.getcwd()) / ".xircuits"
 
-    if not current_path.exists():
+    config_path = Path(os.getcwd()) / ".xircuits"
+    component_library_path = Path(os.getcwd()) / "xai_components"
+
+    if not config_path.exists():
+        init_xircuits()
+
+    if not component_library_path.exists():
         val = input("Xircuits Component Library is not found. Would you like to load it in the current path (Y/N)? ")
         if val.lower() == ("y" or "yes"):
-            shutil.copytree(xai_component_path, current_path, dirs_exist_ok=True)
-            if not current_config_path.exists():
-                shutil.copytree(config_path, current_config_path, dirs_exist_ok=True)
+            request_folder("xai_components")
     
-    sleep(0.1)
     os.system("jupyter lab")
 
 def main(argv=None):
-
     start_xircuits()


### PR DESCRIPTION
# Description

This PR improves the xircuits entry point by allowing users to pull `xai_components` from the base github repository. The old method assumed that users would use `venv` to install xircuits, which is fragile and will fail when installing on other venvs like conda. 

I've made it so that request_folder.py util is also very extendable, which can be used to pull other things users may need such as examples and their own component libraries.

## References
 #126

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Verify successful xai_component pull from repo**

  1. Download the wheel from github action
  2. Install it
  3. start xircuits with `xircuits`, accept to download xai_components when prompted
  4. Verify that `.xircuits` and `xai_components` exist
  5. Verify that xircuits works as expected


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

There were multiple ways of copying xai_components to user dir that I've considered. 
1. The old way of copying it from the venv installation - This method is the fastest since the operation is just copying, but as mentioned before it's fragile.
2. Using [git clone sparse checkout](https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/#sparse-checkout-and-partial-clones) - Thought it would be cool for the users to be able to update their xai_component folder by git pulling, but it assumes that the user already has git installed.
3. Getting the zipped repo via [download link](https://github.com/XpressAI/xircuits/archive/refs/heads/master.zip) - wasn't the most elegant solution since it would involve unzipping to a temp folder, moving the folders, then deleting the temp folder and zip.
4. In the end I settled with PyGithub + raw.githubusercontent, inspired by this [repo](https://github.com/download-directory/download-directory.github.io). It has a nice call `repo.get_contents(folder)` and we can recursively get the files we need. The performance isn't as good as 1 since it requests multiple times, but it's more solid in terms of implementation. 