### PR TITLE
✨ Add console command to download examples + datasets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,8 @@ setup_args = dict(
     ],
     entry_points ={
         'console_scripts': [
-            'xircuits = xircuits.start_xircuits:main'
+            'xircuits = xircuits.start_xircuits:main',
+            'xircuits-examples = xircuits.start_xircuits:download_examples'
             ]}
 )
 

--- a/xircuits/handlers/request_folder.py
+++ b/xircuits/handlers/request_folder.py
@@ -15,17 +15,19 @@ def request_folder(folder, repo_name="XpressAi/Xircuits"):
         print(folder + " already exists.")
 
     contents = repo.get_contents(folder)
-    total_folders = sum(content.type=='dir' for content in contents)
-    
-    pbar = tqdm(total=total_folders)
+        
+    urls = {}
     
     while len(contents)>0:
         file_content = contents.pop(0)
         if file_content.type=='dir':
-            os.mkdir(file_content.path)
+            if not os.path.exists(file_content.path):
+                os.mkdir(file_content.path)
             contents.extend(repo.get_contents(file_content.path))
-            pbar.update(1)
 
         else:
             file_url = base_url + "/" + file_content.path
-            request.urlretrieve(file_url, file_content.path)
+            urls.update({file_url: file_content.path})
+
+    for url in tqdm(urls):
+        request.urlretrieve(url, urls[url])

--- a/xircuits/handlers/request_folder.py
+++ b/xircuits/handlers/request_folder.py
@@ -9,7 +9,10 @@ def request_folder(folder, repo_name="XpressAi/Xircuits"):
     repo = g.get_repo(repo_name)
     base_url = "https://raw.githubusercontent.com/" + repo_name + "/master/"
 
-    os.mkdir(folder)
+    if not os.path.exists(folder):
+        os.mkdir(folder)
+    else:
+        print(folder + " already exists.")
 
     contents = repo.get_contents(folder)
     total_folders = sum(content.type=='dir' for content in contents)

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -39,5 +39,9 @@ __   __  ___                _ _
     
     os.system("jupyter lab")
 
+def download_examples(argv=None):
+    request_folder("examples")
+    request_folder("Datasets")
+
 def main(argv=None):
     start_xircuits()


### PR DESCRIPTION
# Description

As we are now able to pull folders directly from the repo, adding a console command entry point for users to download examples is simple. With this PR, users can download the examples and datasets with `xircuits-examples`

## References

#131 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Test Download Examples & Datasets Feature**

1. Download the wheel from github action
2. Install it. You'd probably want to install [full], `pip install xircuits-1.2.0-py3-none-any.whl[full]`
3. Download the examples with command `xircuits-examples`
4. Verify that `examples` and `Datasets` were downloaded
5. Run with `xircuits` and verify that examples works as expected (KerasPredict.xircuits should be the fastest)


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

I've also changed the logic the tqdm progress bar from folders processed -> files downloaded in this PR.
