### PR TITLE
🎨Create custom and triangle link animation

### DIFF
--- a/src/components/link/CustomLinkFactory.tsx
+++ b/src/components/link/CustomLinkFactory.tsx
@@ -1,0 +1,70 @@
+import { DefaultLinkFactory } from '@projectstorm/react-diagrams';
+import * as React from 'react';
+import { CustomLinkModel, TriangleLinkModel } from './CustomLinkModel';
+import styled from '@emotion/styled';
+import { css, keyframes } from '@emotion/react';
+
+namespace S {
+	export const Keyframes = keyframes`
+		from {
+			stroke-dashoffset: 24;
+		}
+		to {
+			stroke-dashoffset: 0;
+		}
+	`;
+
+	const selected = css`
+		stroke-dasharray: 10, 2;
+		animation: ${Keyframes} 1s linear infinite;
+	`;
+
+	export const Path = styled.path<{ selected: boolean }>`
+		${(p) => p.selected && selected};
+		fill: none;
+		pointer-events: auto;
+	`;
+}
+
+export class CustomLinkFactory extends DefaultLinkFactory {
+	constructor() {
+		super('custom');
+	}
+
+	generateModel(): CustomLinkModel {
+		return new CustomLinkModel();
+	}
+
+	generateLinkSegment(model: CustomLinkModel, selected: boolean, path: string) {
+		return (
+			<S.Path
+				selected={selected}
+				stroke={selected ? 'yellow' : model.getOptions().color}
+				strokeWidth={model.getOptions().width}
+				d={path}
+			/>
+		);
+	}
+}
+
+export class TriangleLinkFactory extends DefaultLinkFactory {
+	constructor() {
+		super('triangle');
+	}
+
+	generateModel(): TriangleLinkModel {
+		return new TriangleLinkModel();
+	}
+
+	generateLinkSegment(model: TriangleLinkModel, selected: boolean, path: string) {
+		return (
+			<S.Path
+				selected={!selected}
+				stroke={!selected ? model.getOptions().selectedColor : 'yellow'}
+				strokeWidth={model.getOptions().width}
+				d={path}
+			/>
+		);
+	}
+}
+

--- a/src/components/link/CustomLinkModel.ts
+++ b/src/components/link/CustomLinkModel.ts
@@ -1,0 +1,35 @@
+import { DefaultLinkModel } from '@projectstorm/react-diagrams';
+import { CustomPortModel } from '../CustomPortModel';
+
+// Custom link
+export class CustomLinkModel extends DefaultLinkModel {
+	constructor() {
+		super({
+			type: 'custom',
+			width: 3
+		});
+	}
+}
+
+export class CustomLinkPortModel extends CustomPortModel {
+	createLinkModel(): CustomLinkModel | null {
+		return new CustomLinkModel();
+	}
+}
+
+// Triangle link
+export class TriangleLinkModel extends DefaultLinkModel {
+	constructor() {
+		super({
+			type: 'triangle',
+			width: 3
+		});
+	}
+}
+
+export class TrianglePortModel extends CustomPortModel {
+	createLinkModel(): TriangleLinkModel | null {
+		return new TriangleLinkModel();
+	}
+}
+


### PR DESCRIPTION
# Description

This will create custom links animation for triangle and non-triangle(custom) ports. 

Custom link

1. Unselected : Gray line
2. Selected : Yellow `stroke-dashoffset`

Triangle link

1. Unselected : Blue `stroke-dashoffset`
2. Selected : Yellow line

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Try the 4 line conditions mentioned above.
2. Connect the links as usual and run xircuits.

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  