### PR TITLE
✨Add component that enable to add import

### DIFF
--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -401,6 +401,17 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			let current_node: any;
 			let package_name: string = "components";
 
+			const addImportNode = getNodeModelByName(nodeModels, 'AddImport');
+			if (componentName == 'AddImport') {
+				const importPortName = addImportNode['portsIn'][1].getOptions()['name']
+				const getImportPortLinks = addImportNode.getPorts()[importPortName].getLinks();
+				for (let portLink in getImportPortLinks) {
+					// Add value of import_str port for importing
+					const importLabel = getImportPortLinks[portLink].getSourcePort().getOptions()["label"];
+					pythonCode += importLabel + "\n";
+				}
+			}
+
 			if (component_exist != -1) {
 				current_node = componentList[component_exist];
 				package_name = current_node["package_name"];

--- a/xai_components/xai_template/example_components.py
+++ b/xai_components/xai_template/example_components.py
@@ -104,3 +104,15 @@ class HelloContext(Component):
         print(f"After Adding Context:\n{ctx}")
 
         self.done = True
+        
+@xai_component(color="red")
+class AddImport(Component):
+    import_str: InArg[str]
+
+    def __init__(self):
+
+        self.done = False
+
+    def execute(self, ctx) -> None:
+
+        self.done = True

--- a/xai_components/xai_template/example_components.py
+++ b/xai_components/xai_template/example_components.py
@@ -110,7 +110,7 @@ class AddImport(Component):
     import_str: InArg[str]
 
     def __init__(self):
-
+        self.import_str = InArg.empty()
         self.done = False
 
     def execute(self, ctx) -> None:


### PR DESCRIPTION
# Description

This add new component called `AddImport` that manually added a `string` import to the code generator script.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [x] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. In template category, use the `AddImport` component.
2. Link a literal string to `import_str` port.
3. Compile.
4. Check the script and see does it add the `import_str`'s value to the import.

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Only allow one `string` import per component.