### PR TITLE
🐛Fix component panel auto-scroll back to top.

### DIFF
--- a/src/context-menu/ComponentsPanel.tsx
+++ b/src/context-menu/ComponentsPanel.tsx
@@ -169,7 +169,7 @@ export default function ComponentsPanel(props: ComponentsPanelProps) {
         <Body>
             <Content>
                 <TrayPanel>
-                    <div onBlur={focusInput}>
+                    <div>
                         <p className='title-panel'>Add Component</p>
                         <div className="search-input-panel" >
                             <input id='add-component-input' type="text" name="" value={searchTerm} placeholder="SEARCH" className="search-input__text-input-panel" autoFocus onChange={handleOnChange} />
@@ -195,7 +195,7 @@ export default function ComponentsPanel(props: ComponentsPanelProps) {
                             })
                         }
                     </div>
-                    <Accordion allowZeroExpanded>
+                    <Accordion allowZeroExpanded onBlur={focusInput}>
                         {
                             category.filter((val) => {
                                 if (searchTerm == "") {


### PR DESCRIPTION
# Description

This fix scrolling through component panel and selecting a component but it scroll to top instead of adding the node.

Bug(Gif):
![Animation](https://user-images.githubusercontent.com/84708008/161488863-d2789481-e125-410c-9caf-db72cf04968c.gif)

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Open component panel(Right-click)
2. Open any category
3. Scroll through bottom and choose a component
4. It's expected to add the node instead of scroll back to top(Shown in Gif)

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  