### PR TITLE
⚡️Link obvious port

### DIFF
--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -338,14 +338,13 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 
 		const outPorts = sourceNode['portsOut'];
 		const inPorts = targetNode['portsIn'];
-		const newLink = new DefaultLinkModel();
 
 		for (let outPortIndex in outPorts) {
 			const outPort = outPorts[outPortIndex];
 			const outPortName = outPort.getOptions()['name'];
 			const outPortLabel = outPort.getOptions()['label'];
 			const outPortType = outPort.getOptions()['type'];
-			const outPortLabelArray: string[] = outPortLabel.split('_')
+			const outPortLabelArray: string[] = outPortLabel.split('_');
 			if (outPort.getOptions()['label'] == '▶') {
 				// Skip ▶ outPort
 				continue
@@ -360,15 +359,18 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 				const intersection = outPortLabelArray.filter(element => inPortLabelArray.includes(element));
 
 				if (outPortLabel == inPortLabel && outPortType == inPortType || intersection.length >= 1) {
+					// Create new link
+					const newLink = new DefaultLinkModel();
 					// Set sourcePort
-					let sourcePort = sourceNode.getPorts()[outPortName];
+					const sourcePort = sourceNode.getPorts()[outPortName];
 					newLink.setSourcePort(sourcePort);
 					// Set targetPort
-					let targetPort = targetNode.getPorts()[inPortName];
+					const targetPort = targetNode.getPorts()[inPortName];
 					newLink.setTargetPort(targetPort);
-					continue
+
+					xircuitsApp.getDiagramEngine().getModel().addLink(newLink);
+					break;
 				}
-				xircuitsApp.getDiagramEngine().getModel().addLink(newLink);
 			}
 		}
 	}

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -324,59 +324,6 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		return null;
 	}
 
-	const linkObviousPort = (link: DefaultLinkModel) => {
-		const sourcePort = link.getSourcePort();
-		const targetPort = link.getTargetPort();
-		const sourceNode = sourcePort.getNode();
-		const targetNode = targetPort.getNode();
-		if (sourcePort.getOptions()['label'] != '▶' && targetPort.getOptions()['label'] != '▶') {
-			// When it's not ▶ being linked, just return
-			return;
-		}
-		if (sourceNode['portsOut'].length <= 1) {
-			// When node got no outputPort, just return
-			return;
-		}
-
-		const outPorts = sourceNode['portsOut'];
-		const inPorts = targetNode['portsIn'];
-
-		for (let outPortIndex in outPorts) {
-			const outPort = outPorts[outPortIndex];
-			const outPortName = outPort.getOptions()['name'];
-			const outPortLabel = outPort.getOptions()['label'];
-			const outPortType = outPort.getOptions()['type'];
-			const outPortLabelArray: string[] = outPortLabel.split('_');
-			if (outPort.getOptions()['label'] == '▶') {
-				// Skip ▶ outPort
-				continue
-			}
-
-			for (let inPortIndex in inPorts) {
-				const inPort = inPorts[inPortIndex];
-				const inPortName = inPort.getOptions()['name'];
-				const inPortLabel = inPort.getOptions()['label'];
-				const inPortType = inPort.getOptions()['type'];
-				const inPortLabelArray: string[] = inPortLabel.split('_');
-				const intersection = outPortLabelArray.filter(element => inPortLabelArray.includes(element));
-
-				if (outPortLabel == inPortLabel && outPortType == inPortType || intersection.length >= 1) {
-					// Create new link
-					const newLink = new DefaultLinkModel();
-					// Set sourcePort
-					const sourcePort = sourceNode.getPorts()[outPortName];
-					newLink.setSourcePort(sourcePort);
-					// Set targetPort
-					const targetPort = targetNode.getPorts()[inPortName];
-					newLink.setTargetPort(targetPort);
-
-					xircuitsApp.getDiagramEngine().getModel().addLink(newLink);
-					break;
-				}
-			}
-		}
-	}
-
 	const getAllNodesFromStartToFinish = (): NodeModel[] | null => {
 		let model = xircuitsApp.getDiagramEngine().getModel();
 		let nodeModels = model.getNodes();

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState, useCallback, useEffect, useRef } from 'react';
 import { CanvasWidget } from '@projectstorm/react-canvas-core';
 import { DemoCanvasWidget } from '../helpers/DemoCanvasWidget';
-import { LinkModel, DiagramModel, DiagramEngine, DefaultLinkModel } from '@projectstorm/react-diagrams';
+import { DefaultLinkModel, LinkModel } from '@projectstorm/react-diagrams';
 import { NodeModel } from "@projectstorm/react-diagrams-core/src/entities/node/NodeModel";
 import { Dialog, showDialog, showErrorMessage } from '@jupyterlab/apputils';
 import { ILabShell, JupyterFrontEnd } from '@jupyterlab/application';
@@ -10,11 +10,9 @@ import {
 	DocumentRegistry
 } from '@jupyterlab/docregistry';
 import styled from '@emotion/styled';
-import { CustomNodeModel } from "./CustomNodeModel";
 import { XPipePanel } from '../xircuitWidget';
 import { Log } from '../log/LogPlugin';
 import { ServiceManager } from '@jupyterlab/services';
-import ComponentList from '../tray_library/Component';
 import { formDialogWidget } from '../dialog/formDialogwidget';
 import { showFormDialog } from '../dialog/FormDialog';
 import { RunDialog } from '../dialog/RunDialog';

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -105,6 +105,7 @@ export const commandIDs = {
 	deleteNode: 'Xircuit-editor:delete-node',
 	addNodeGivenPosition: 'Xircuit-editor:add-node', 
 	connectNodeByLink: 'Xircuit-editor:connect-node',
+	connectLinkToObviousPorts: 'Xircuit-editor:connect-obvious-link',
 	addCommentNode: 'Xircuit-editor:add-comment-node',
 	createArbitraryFile: 'Xircuit-editor:create-arbitrary-file',
 	openDebugger: 'Xircuit-debugger:open',
@@ -232,7 +233,8 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 								 * Detect changes when link is connected
 								 */
 								targetPortChanged: e => {
-									linkObviousPort(e.entity as DefaultLinkModel);
+									const sourceLink = e.entity as any;
+									app.commands.execute(commandIDs.connectLinkToObviousPorts, { sourceLink });
 									onChange();
 								},
 								/**


### PR DESCRIPTION
# Description

This will enable automatic link of `outPorts` when ▶ linked. If there exist any `outPort`, it'll automatically link that port into next node's `inPort` with similar name.
![Link Obvious Ports](https://user-images.githubusercontent.com/84708008/165257379-77776d0e-8b20-4ef9-820b-40b9e80697e4.gif)

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Easiest example is SparkSQLPlotBar.xircuits
   1. Try linking ▶ to ▶ from e2e.
   2. It's expected other `outPorts` will automatically link to `inPorts` with same name.

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes
**Disclaimer**
This just a simple 'finding a similar name' kind of thing. It doesn't knows where it should connect. It'll not cover all use case.