### PR TITLE
🐛Skip any type check of outport

### DIFF
--- a/src/components/port/CustomPortLabel.tsx
+++ b/src/components/port/CustomPortLabel.tsx
@@ -21,22 +21,22 @@ namespace S {
 		flex-grow: 1;
 	`;
 
-	export const SymbolContainer = styled.div<{ symbolType: string; selected: boolean; }>`
+	export const SymbolContainer = styled.div<{ symbolType: string; selected: boolean; isOutPort: boolean }>`
         width: 17px;
 		height: 15px;
 		border: 5px hidden;
 		background: ${(p) => (p.selected ? 'white' : 'rgba(0, 0, 0, 0.2)')};
-		border-radius: 0px 20px 20px 0px;
+		border-radius: ${(p) => (p.isOutPort ? '20px 0px 0px 20px' : '0px 20px 20px 0px')} ;
 		display: ${(p) => p.symbolType == null ? 'none' : 'visible'};
 		text-align: center;
 	`;
 
-	export const Symbol = styled.div`
+	export const Symbol = styled.div<{ isOutPort: boolean }>`
 		color: black;
 		font-weight: bold;
 		font-size: 9px;
 		font-family: Helvetica, Arial, sans-serif;
-		padding-top: 3px;
+		padding:${(p) => (p.isOutPort ? '3px 0px 0px 2px' : '3px 2px 0px 0px')};
 	`;
 
 	export const Port = styled.div`
@@ -51,8 +51,16 @@ namespace S {
 
 export class CustomPortLabel extends React.Component<CustomPortLabelProps> {
 	render() {
-		let portType = this.props.port.getOptions().name.split("-")[1];
+		let portName = this.props.port.getOptions().name;
+		let portType;
 		let symbolLabel;
+		let isOutPort;
+		if(portName.includes('parameter-out')){
+			portType = portName.split("-")[2];
+			isOutPort = true;
+		} else {
+			portType = portName.split("-")[1];
+		}
 
 		switch (portType) {
 			case "string":
@@ -97,8 +105,8 @@ export class CustomPortLabel extends React.Component<CustomPortLabelProps> {
 		}
 
 		const symbol = (
-			<S.SymbolContainer symbolType={symbolLabel} selected={portHasLink}>
-				<S.Symbol>
+			<S.SymbolContainer symbolType={symbolLabel} selected={portHasLink} isOutPort={isOutPort}>
+				<S.Symbol isOutPort={isOutPort}>
 					{symbolLabel}
 				</S.Symbol>
 			</S.SymbolContainer>);

--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -73,7 +73,9 @@ export  class CustomPortModel extends DefaultPortModel  {
         let thisNode = this.getNode();
         let thisNodeModelType = thisNode.getOptions()["extras"]["type"];
         let thisName = port.getName();
+        let sourcePortName = thisPort.getName();
         let thisPortType = thisName.split('-')[1];
+        let sourcePortType = sourcePortName.split('-')[2];
 
         if (this.isParameterNode(thisNodeModelType) == true){
             // if the port you are trying to link ready has other links
@@ -127,9 +129,9 @@ export  class CustomPortModel extends DefaultPortModel  {
 
         }else{
             if (thisName.startsWith("parameter")){
-                // Skip 'any' type check
-                if(thisName.includes('any')){
-                    return
+                // Skip 'any' type check for both in and out ports
+                if (thisPortType || sourcePortType == 'any') {
+                    return;
                 }
 		        port.getNode().getOptions().extras["borderColor"]="red";
 		        port.getNode().getOptions().extras["tip"]= "Node link to this port must be a hyperparameter/literal";

--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -130,7 +130,7 @@ export  class CustomPortModel extends DefaultPortModel  {
         }else{
             if (thisName.startsWith("parameter")){
                 // Skip 'any' type check for both in and out ports or same type check
-                if(thisPortType || sourcePortType == 'any' || thisPortType == sourcePortType){
+                if(thisPortType == 'any' || sourcePortType == 'any' || thisPortType == sourcePortType){
                     return
                 }
 		        port.getNode().getOptions().extras["borderColor"]="red";


### PR DESCRIPTION
# Description

This will allow `outPort` of `any` type to link to any `inPorts` regardless of the `type`.

## References

#111 

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Open KerasModelPredict.xircuits.
2. Try to link ResNet50's `model` outPort to any port(except ▶) of KerasPredict.
3. It's expected to linked together.

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  