### PR TITLE
🐛Fix same type port cannot linked

### DIFF
--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -73,7 +73,9 @@ export  class CustomPortModel extends DefaultPortModel  {
         let thisNode = this.getNode();
         let thisNodeModelType = thisNode.getOptions()["extras"]["type"];
         let thisName = port.getName();
+        let sourcePortName = thisPort.getName();
         let thisPortType = thisName.split('-')[1];
+        let sourcePortType = sourcePortName.split('-')[2];
 
         if (this.isParameterNode(thisNodeModelType) == true){
             // if the port you are trying to link ready has other links
@@ -127,8 +129,8 @@ export  class CustomPortModel extends DefaultPortModel  {
 
         }else{
             if (thisName.startsWith("parameter")){
-                // Skip 'any' type check
-                if(thisName.includes('any')){
+                // Skip 'any' or same type check
+                if(thisPortType == 'any' || thisPortType == sourcePortType){
                     return
                 }
 		        port.getNode().getOptions().extras["borderColor"]="red";


### PR DESCRIPTION
# Description

This will allow link ports of same type.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Try connecting `outPort` of `string` type to `inPort` of `string` type

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  