### PR TITLE
🎨Update toolbar button and switch context menu shortcut key

### DIFF
--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -1600,9 +1600,6 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 
 	// Show the component panel context menu
 	const showComponentPanel = (event: React.MouseEvent<HTMLDivElement>) => {
-		// Disable the default context menu
-		event.preventDefault();
-
 		setActionPanelShown(false);
 		setIsComponentPanelShown(false);
 
@@ -1647,6 +1644,9 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 
 	// Show the nodeActionPanel context menu
 	const showNodeActionPanel = (event: React.MouseEvent<HTMLDivElement>) => {
+		// Disable the default context menu
+		event.preventDefault();
+
 		setActionPanelShown(false);
 		setIsComponentPanelShown(false);
 
@@ -1739,11 +1739,11 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 					onMouseDown={(event) => {
 						event.preventDefault();
 					}}
-					onContextMenu={showComponentPanel}
+					onContextMenu={showNodeActionPanel}
 					onClick={(event) => {
 						hidePanel();
 						if (event.ctrlKey || event.metaKey) {
-							showNodeActionPanel(event);
+							showComponentPanel(event);
 						}
 					}}>
 					<DemoCanvasWidget>

--- a/src/xircuitFactory.ts
+++ b/src/xircuitFactory.ts
@@ -232,7 +232,7 @@ export class XircuitFactory extends ABCWidgetFactory<DocumentWidget> {
      */
     let testButton = new ToolbarButton({
       icon: editIcon,
-      tooltip: 'For testing purpose',
+      tooltip: 'For testing purposes',
       onClick: (): void => {
         this.commands.execute(commandIDs.testXircuit)
       }
@@ -243,7 +243,7 @@ export class XircuitFactory extends ABCWidgetFactory<DocumentWidget> {
      */
     let compileButton = new ToolbarButton({
       icon: checkIcon,
-      tooltip: 'Compile',
+      tooltip: 'Compile Xircuits',
       onClick: (): void => {
         this.commands.execute(commandIDs.compileXircuit);
       }
@@ -254,7 +254,7 @@ export class XircuitFactory extends ABCWidgetFactory<DocumentWidget> {
      */
     let compileAndRunButton = new ToolbarButton({
       icon: runIcon,
-      tooltip: 'Compile and Run',
+      tooltip: 'Compile and Run Xircuits',
       onClick: (): void => {
         this.commands.execute(commandIDs.runXircuit);
       }

--- a/src/xircuitFactory.ts
+++ b/src/xircuitFactory.ts
@@ -1,29 +1,34 @@
-import { 
-  ABCWidgetFactory, 
-  DocumentRegistry, 
-  DocumentWidget 
+import {
+  ABCWidgetFactory,
+  DocumentRegistry,
+  DocumentWidget
 } from '@jupyterlab/docregistry';
-import { 
-  ILabShell, 
-  JupyterFrontEnd 
+import {
+  ILabShell,
+  JupyterFrontEnd
 } from '@jupyterlab/application';
 import { Signal } from '@lumino/signaling';
 import { XPipePanel } from './xircuitWidget';
-import { 
-  bugIcon, 
-  checkIcon, 
-  editIcon, 
-  listIcon, 
-  refreshIcon, 
-  runIcon, 
-  saveIcon
+import {
+  bugIcon,
+  checkIcon,
+  copyIcon,
+  cutIcon,
+  editIcon,
+  listIcon,
+  pasteIcon,
+  redoIcon,
+  refreshIcon,
+  runIcon,
+  saveIcon,
+  undoIcon
 } from '@jupyterlab/ui-components';
 import { ToolbarButton } from '@jupyterlab/apputils';
 import { commandIDs } from './components/xircuitBodyWidget';
 import { CommandIDs } from './log/LogPlugin';
 import { ServiceManager } from '@jupyterlab/services';
 import { RunSwitcher } from './components/RunSwitcher';
-import { lockIcon, revertIcon, xircuitsIcon } from './ui-components/icons';
+import { lockIcon, xircuitsIcon } from './ui-components/icons';
 
 const XPIPE_CLASS = 'xircuits-editor';
 
@@ -117,9 +122,31 @@ export class XircuitFactory extends ABCWidgetFactory<DocumentWidget> {
      */
     let saveButton = new ToolbarButton({
       icon: saveIcon,
-      tooltip: 'Save Xircuits',
+      tooltip: 'Save (Ctrl+S)',
       onClick: (): void => {
         this.commands.execute(commandIDs.saveXircuit);
+      }
+    });
+
+    /**
+     * Create a undo button toolbar item.
+     */
+    let undoButton = new ToolbarButton({
+      icon: undoIcon,
+      tooltip: 'Undo (Ctrl+Z)',
+      onClick: (): void => {
+        this.commands.execute(commandIDs.undo);
+      }
+    });
+
+    /**
+     * Create a redo button toolbar item.
+     */
+    let redoButton = new ToolbarButton({
+      icon: redoIcon,
+      tooltip: 'Redo (Ctrl+Y)',
+      onClick: (): void => {
+        this.commands.execute(commandIDs.redo);
       }
     });
 
@@ -135,68 +162,68 @@ export class XircuitFactory extends ABCWidgetFactory<DocumentWidget> {
     });
 
     /**
-     * Create a revert button toolbar item.
+     * Create a cut button toolbar item.
      */
-    let revertButton = new ToolbarButton({
-      icon: revertIcon,
-      tooltip: 'Revert Xircuits to Checkpoint',
+    let cutButton = new ToolbarButton({
+      icon: cutIcon,
+      tooltip: 'Cut selected nodes',
       onClick: (): void => {
-        this.commands.execute(commandIDs.revertDocManager);
+        this.commands.execute(commandIDs.cutNode);
       }
     });
 
     /**
-     * Create a compile button toolbar item.
+     * Create a copy button toolbar item.
      */
-    let compileButton = new ToolbarButton({
-      icon: checkIcon,
-      tooltip: 'Compile Xircuits',
+    let copyButton = new ToolbarButton({
+      icon: copyIcon,
+      tooltip: 'Copy selected nodes',
       onClick: (): void => {
-        this.commands.execute(commandIDs.compileXircuit);
+        this.commands.execute(commandIDs.copyNode);
       }
     });
 
     /**
-     * Create a run button toolbar item.
+     * Create a paste button toolbar item.
      */
-    let runButton = new ToolbarButton({
-      icon: runIcon,
-      tooltip: 'Run Xircuits',
+    let pasteButton = new ToolbarButton({
+      icon: pasteIcon,
+      tooltip: 'Paste nodes from the clipboard',
       onClick: (): void => {
-        this.commands.execute(commandIDs.runXircuit);
+        this.commands.execute(commandIDs.pasteNode);
       }
     });
 
     /**
      * Create a debug button toolbar item.
      */
-    let debugButton = new ToolbarButton({
-      icon:bugIcon,
-      tooltip: 'Open Xircuits Debugger and enable Image Viewer',
+    // let debugButton = new ToolbarButton({
+    //   icon:bugIcon,
+    //   tooltip: 'Open Xircuits Debugger and enable Image Viewer',
+    //   onClick: (): void => {
+    //     this.commands.execute(commandIDs.debugXircuit);
+    //   }
+    // });
+
+    /**
+     * Create a lock button toolbar item.
+     */
+    let lockButton = new ToolbarButton({
+      icon: lockIcon,
+      tooltip: "Lock all non-general nodes connected from start node",
       onClick: (): void => {
-        this.commands.execute(commandIDs.debugXircuit);
+        this.commands.execute(commandIDs.lockXircuit);
       }
     });
 
     /**
      * Create a log button toolbar item.
      */
-     let logButton = new ToolbarButton({
+    let logButton = new ToolbarButton({
       icon: listIcon,
       tooltip: 'Open log',
       onClick: (): void => {
         this.commands.execute(CommandIDs.openLog);
-      }
-    });
-
-    /**
-     * Create a lock button toolbar item.
-     */
-     let lockButton = new ToolbarButton({
-      icon: lockIcon,
-      tooltip: "Lock all non-general nodes connected from start node",
-      onClick: (): void => {
-        this.commands.execute(commandIDs.lockXircuit);
       }
     });
 
@@ -210,21 +237,44 @@ export class XircuitFactory extends ABCWidgetFactory<DocumentWidget> {
         this.commands.execute(commandIDs.testXircuit)
       }
     });
-  
-    widget.toolbar.insertItem(0,'xircuits-add-save', saveButton);
-    widget.toolbar.insertItem(1,'xircuits-add-reload', reloadButton);
-    widget.toolbar.insertItem(2,'xircuits-add-revert', revertButton);
-    widget.toolbar.insertItem(3,'xircuits-add-compile', compileButton);
-    widget.toolbar.insertItem(4,'xircuits-add-run', runButton);
+
+    /**
+     * Create a compile button toolbar item.
+     */
+    let compileButton = new ToolbarButton({
+      icon: checkIcon,
+      tooltip: 'Compile',
+      onClick: (): void => {
+        this.commands.execute(commandIDs.compileXircuit);
+      }
+    });
+
+    /**
+     * Create a compile and run button toolbar item.
+     */
+    let compileAndRunButton = new ToolbarButton({
+      icon: runIcon,
+      tooltip: 'Compile and Run',
+      onClick: (): void => {
+        this.commands.execute(commandIDs.runXircuit);
+      }
+    });
+
+    widget.toolbar.insertItem(0, 'xircuits-add-save', saveButton);
+    widget.toolbar.insertItem(1, 'xircuits-add-undo', undoButton);
+    widget.toolbar.insertItem(2, 'xircuits-add-redo', redoButton);
+    widget.toolbar.insertItem(3, 'xircuits-add-reload', reloadButton);
+    widget.toolbar.insertItem(4, 'xircuits-add-cut', cutButton);
+    widget.toolbar.insertItem(5, 'xircuits-add-copy', copyButton);
+    widget.toolbar.insertItem(6, 'xircuits-add-paste', pasteButton);
+    widget.toolbar.insertItem(7, 'xircuits-add-lock', lockButton);
+    widget.toolbar.insertItem(8, 'xircuits-add-log', logButton);
+    widget.toolbar.insertItem(9, 'xircuits-add-test', testButton);
+    widget.toolbar.insertItem(10, 'xircuits-add-compile', compileButton);
+    widget.toolbar.insertItem(11, 'xircuits-add-run', compileAndRunButton);
+    widget.toolbar.insertItem(12, 'xircuits-run-type', new RunSwitcher(this));
     // TODO: Fix debugger
     // widget.toolbar.insertItem(5,'xircuits-add-debug', debugButton);
-    widget.toolbar.insertItem(6,'xircuits-add-lock', lockButton);
-    widget.toolbar.insertItem(7,'xircuits-add-log', logButton);
-    widget.toolbar.insertItem(8,'xircuits-add-test', testButton);
-    widget.toolbar.insertItem(9,
-      'xircuits-run-type',
-      new RunSwitcher(this)
-    );
 
     return widget;
   }

--- a/ui-tests/tests/E2E.spec.ts
+++ b/ui-tests/tests/E2E.spec.ts
@@ -25,9 +25,9 @@ test('Should complete E2E test', async ({
     dialog.dismiss().catch(() => {});
   });
 
-  await page.locator("xpath=//*[contains(@title, 'Save Xircuits')]").first().click();
+  await page.locator("xpath=//*[contains(@title, 'Save (Ctrl+S)')]").first().click();
   await page.locator("xpath=//*[contains(@title, 'Compile Xircuits')]").first().click();
-  await page.locator("xpath=//*[contains(@title, 'Run Xircuits')]").first().click();
+  await page.locator("xpath=//*[contains(@title, 'Compile and Run Xircuits')]").first().click();
 
   // Start Xircuits
   await page.locator('button:has-text("Start")').click();


### PR DESCRIPTION
# Description

This update and rearrange the toolbar button. Also, switch the shortcut keys between context menu and component panel.

![Updated Toolbar](https://user-images.githubusercontent.com/84708008/165665497-c21aef6f-f4a7-4920-921a-d5ebc1c75e82.PNG)

Removed:

1. Revert

Added:

1. Undo
2. Redo
3. Cut
4. Copy
5. Paste

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Tests

1. Test each toolbar button 
2. Right-clicking canvas to open context menu
3. Ctrl+left-click to open component panel

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  