### PR TITLE
⚡️Open node's script at specific line 

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -14,7 +14,6 @@ import { formDialogWidget } from '../dialog/formDialogwidget';
 import { CommentDialog } from '../dialog/CommentDialog';
 import React from 'react';
 import { showFormDialog } from '../dialog/FormDialog';
-import { IDocumentManager } from '@jupyterlab/docmanager';
 
 /**
  * Add the commands for node actions.
@@ -22,7 +21,6 @@ import { IDocumentManager } from '@jupyterlab/docmanager';
 export function addNodeActionCommands(
     app: JupyterFrontEnd,
     tracker: IXircuitsDocTracker,
-    docmanager: IDocumentManager,
     translator: ITranslator
 ): void {
     const trans = translator.load('jupyterlab');
@@ -62,9 +60,6 @@ export function addNodeActionCommands(
                 return;
             }
             
-            // Need to delete opened file first
-            docmanager.closeFile(nodePath);
-
             // Open node's file name
             const newWidget = await app.commands.execute(
                 commandIDs.openDocManager,

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -68,9 +68,13 @@ export function addNodeActionCommands(
                 }
             );
             newWidget.context.ready.then(() => {
-                // Go to node's line
+                // Go to end of node's line first before go to its class
                 app.commands.execute('codemirror:go-to-line', {
-                    line: nodeLineNo
+                    line: nodeLineNo[0].end_lineno
+                }).then(() => {
+                    app.commands.execute('codemirror:go-to-line', {
+                        line: nodeLineNo[0].lineno
+                    })
                 })
             });
         }

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -48,10 +48,10 @@ export function addNodeActionCommands(
 
     //Add command to open node's script at specific line
     commands.addCommand(commandIDs.openScript, {
-        execute: async () => {
+        execute: async (args) => {
             const node = selectedNode();
-            const nodePath = node.extras.path;
-            const className: string = 'class ' + node.name;
+            const nodePath = args['nodePath'] as string ?? node.extras.path;
+            const className: string = 'class ' + args['nodeName'] as string ?? node.name;
 
             // Need to delete opened file first
             docmanager.closeFile(nodePath);

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -51,8 +51,17 @@ export function addNodeActionCommands(
         execute: async (args) => {
             const node = selectedNode();
             const nodePath = args['nodePath'] as string ?? node.extras.path;
-            const className: string = 'class ' + args['nodeName'] as string ?? node.name;
+            const nodeName = args['nodeName'] as string ?? node.name;
+            const className: string = 'class ' + nodeName;
 
+            if (node.name.startsWith('Literal') || node.name.startsWith('Hyperparameter')) {
+                showDialog({
+                    title: `${node.name} don't have its own script`,
+                    buttons: [Dialog.warnButton({ label: 'OK' })]
+                })
+                return;
+            }
+            
             // Need to delete opened file first
             docmanager.closeFile(nodePath);
 

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -52,14 +52,14 @@ export function addNodeActionCommands(
             const nodeName = args['nodeName'] as string ?? node.name;
             const nodeLineNo = args['nodeLineNo'] as number ?? node.extras.lineNo;
 
-            if (node.name.startsWith('Literal') || node.name.startsWith('Hyperparameter')) {
+            if (nodeName.startsWith('Literal') || nodeName.startsWith('Hyperparameter')) {
                 showDialog({
                     title: `${node.name} don't have its own script`,
                     buttons: [Dialog.warnButton({ label: 'OK' })]
                 })
                 return;
             }
-            
+
             // Open node's file name
             const newWidget = await app.commands.execute(
                 commandIDs.openDocManager,
@@ -68,24 +68,10 @@ export function addNodeActionCommands(
                 }
             );
             newWidget.context.ready.then(() => {
-                // Wait for search widget render
-                setTimeout(() => {
-                    // Search class name
-                    app.commands.execute('documentsearch:start', {
-                        searchText: className
-                    }).then(() => {
-                        // Force pressed 'Enter' key
-                        let inputField = document.getElementsByClassName('jp-DocumentSearch-input');
-                        const keyboardEvent = new KeyboardEvent('keydown', {
-                            code: 'Enter',
-                            key: 'Enter',
-                            keyCode: 13,
-                            view: window,
-                            bubbles: true
-                        });
-                        inputField[inputField.length - 1].dispatchEvent(keyboardEvent);
-                    })
-                }, 5)
+                // Go to node's line
+                app.commands.execute('codemirror:go-to-line', {
+                    line: nodeLineNo
+                })
             });
         }
     });

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -50,7 +50,7 @@ export function addNodeActionCommands(
             const node = selectedNode();
             const nodePath = args['nodePath'] as string ?? node.extras.path;
             const nodeName = args['nodeName'] as string ?? node.name;
-            const className: string = 'class ' + nodeName;
+            const nodeLineNo = args['nodeLineNo'] as number ?? node.extras.lineNo;
 
             if (node.name.startsWith('Literal') || node.name.startsWith('Hyperparameter')) {
                 showDialog({

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -14,6 +14,7 @@ import { formDialogWidget } from '../dialog/formDialogwidget';
 import { CommentDialog } from '../dialog/CommentDialog';
 import React from 'react';
 import { showFormDialog } from '../dialog/FormDialog';
+import { IDocumentManager } from '@jupyterlab/docmanager';
 
 /**
  * Add the commands for node actions.
@@ -21,6 +22,7 @@ import { showFormDialog } from '../dialog/FormDialog';
 export function addNodeActionCommands(
     app: JupyterFrontEnd,
     tracker: IXircuitsDocTracker,
+    docmanager: IDocumentManager,
     translator: ITranslator
 ): void {
     const trans = translator.load('jupyterlab');

--- a/src/context-menu/TrayItemPanel.tsx
+++ b/src/context-menu/TrayItemPanel.tsx
@@ -75,8 +75,10 @@ export class TrayItemPanel extends React.Component<TrayItemWidgetProps> {
 				onClick={(event) => {
 					if (event.ctrlKey || event.metaKey) {
 						const { commands } = this.props.app;
-						commands.execute('docmanager:open', {
-							path: this.props.currentNode["file_path"]
+						commands.execute(commandIDs.openScript, {
+							nodePath: this.props.currentNode["file_path"],
+							nodeName: this.props.currentNode["class"],
+							nodeLineNo: this.props.currentNode["lineno"]
 						});
 						return;
 					}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -157,7 +157,7 @@ const xircuits: JupyterFrontEndPlugin<void> = {
     app.shell.add(sidebarDebugger, 'right', { rank: 1001 });
 
     // Additional commands for node action
-    addNodeActionCommands(app, tracker, docmanager, translator);
+    addNodeActionCommands(app, tracker, translator);
 
     // Add a command to open xircuits sidebar debugger
     app.commands.addCommand(commandIDs.openDebugger, {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -157,7 +157,7 @@ const xircuits: JupyterFrontEndPlugin<void> = {
     app.shell.add(sidebarDebugger, 'right', { rank: 1001 });
 
     // Additional commands for node action
-    addNodeActionCommands(app, tracker, translator);
+    addNodeActionCommands(app, tracker, docmanager, translator);
 
     // Add a command to open xircuits sidebar debugger
     app.commands.addCommand(commandIDs.openDebugger, {

--- a/src/tray_library/AdvanceComponentLib.tsx
+++ b/src/tray_library/AdvanceComponentLib.tsx
@@ -31,7 +31,8 @@ export function AdvancedComponentLibrary(props: AdvancedComponentLibraryProps) {
         extras: {
             "type": nodeData.type,
             "path": nodeData.file_path,
-            "description": nodeData.docstring
+            "description": nodeData.docstring,
+            "lineNo": nodeData.lineno
         }
     });
     node.addInPortEnhance('▶', 'in-0');

--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -221,12 +221,14 @@ export default function Sidebar(props: SidebarProps) {
                                                                             name: componentVal.task,
                                                                             color: componentVal.color,
                                                                             path: componentVal.file_path,
-                                                                            docstring: componentVal.docstring
+                                                                            docstring: componentVal.docstring,
+                                                                            lineNo: componentVal.lineno
                                                                         }}
                                                                         name={componentVal.task}
                                                                         color={componentVal.color}
                                                                         app={props.lab}
-                                                                        path={componentVal.file_path} />
+                                                                        path={componentVal.file_path}
+                                                                        lineNo= {componentVal.lineno}/>
                                                                 </div>
                                                             );
                                                         }
@@ -253,12 +255,14 @@ export default function Sidebar(props: SidebarProps) {
                                                 name: val.task,
                                                 color: val.color,
                                                 path: val.file_path,
-                                                docstring: val.docstring
+                                                docstring: val.docstring,
+                                                lineNo: val.lineno
                                             }}
                                             name={val.task}
                                             color={val.color}
                                             app={props.lab}
-                                            path={val.file_path} />
+                                            path={val.file_path}
+                                            lineNo= {val.lineno} />
                                     </div>
                                 );
                             })

--- a/src/tray_library/TrayItemWidget.tsx
+++ b/src/tray_library/TrayItemWidget.tsx
@@ -11,6 +11,7 @@ export interface TrayItemWidgetProps {
 	name: string;
 	path: string;
 	app: JupyterFrontEnd;
+	lineNo: number;
 }
 
 interface TrayStyledProps {
@@ -44,8 +45,10 @@ export class TrayItemWidget extends React.Component<TrayItemWidgetProps> {
 						const { commands } = this.props.app;
 						commands.execute(commandIDs.openScript, {
 							nodePath: this.props.path,
-							nodeName: this.props.name
+							nodeName: this.props.name,
+							nodeLineNo: this.props.lineNo
 						});
+						
 					}
 					this.forceUpdate();
 				}}
@@ -54,7 +57,8 @@ export class TrayItemWidget extends React.Component<TrayItemWidgetProps> {
 						const { commands } = this.props.app;
 						commands.execute(commandIDs.openScript, {
 							nodePath: this.props.path,
-							nodeName: this.props.name
+							nodeName: this.props.name,
+							nodeLineNo: this.props.lineNo
 						});
 					}
 					this.forceUpdate();

--- a/src/tray_library/TrayItemWidget.tsx
+++ b/src/tray_library/TrayItemWidget.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
+import { commandIDs } from '../components/xircuitBodyWidget';
 
 export interface TrayItemWidgetProps {
 	model: any;
@@ -41,17 +42,19 @@ export class TrayItemWidget extends React.Component<TrayItemWidgetProps> {
 				onClick={(event) => {
 					if (event.ctrlKey || event.metaKey) {
 						const { commands } = this.props.app;
-						commands.execute('docmanager:open', {
-							path: this.props.path
+						commands.execute(commandIDs.openScript, {
+							nodePath: this.props.path,
+							nodeName: this.props.name
 						});
 					}
 					this.forceUpdate();
 				}}
-				onDoubleClick={(event) => {
+				onDoubleClick={() => {
 					if (this.props.path != "") {
 						const { commands } = this.props.app;
-						commands.execute('docmanager:open', {
-							path: this.props.path
+						commands.execute(commandIDs.openScript, {
+							nodePath: this.props.path,
+							nodeName: this.props.name
 						});
 					}
 					this.forceUpdate();

--- a/xircuits/handlers/components.py
+++ b/xircuits/handlers/components.py
@@ -158,6 +158,7 @@ class ComponentsRouteHandler(APIHandler):
         ]
 
         docstring = ast.get_docstring(node)
+        lineno = node.lineno
 
         output = {
             "class": name,
@@ -170,7 +171,8 @@ class ComponentsRouteHandler(APIHandler):
             "category": category,
             "type": "debug",
             "variables": variables,
-            "docstring": docstring
+            "docstring": docstring,
+            "lineno" : lineno
         }
         output.update(keywords)
 

--- a/xircuits/handlers/components.py
+++ b/xircuits/handlers/components.py
@@ -158,7 +158,12 @@ class ComponentsRouteHandler(APIHandler):
         ]
 
         docstring = ast.get_docstring(node)
-        lineno = node.lineno
+        lineno = [
+            {
+                "lineno": node.lineno,
+                "end_lineno": node.end_lineno
+            }
+        ]
 
         output = {
             "class": name,


### PR DESCRIPTION
# Description

This PR will enable to open node's script and go to its specific line.

Ways to open script are via context menu and component library.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Drag a node to canvas.
   1. Open context menu
   2. Choose `Open Script`
   3. It'll go to that node name 
2. (Additional) `Ctrl+click` or `double-click` any node on component library(sidebar).
   1. It'll open its script and go to that node name 

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes
Need to update JupyterLab to at least **3.4.0v**.
Notice a few bugs with this latest JupyterLab update. Probably need to check on that or fix the version.