### PR TITLE
⚡️Compatibility with python 3.8 and above versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
         <img alt="Documentation" src="https://img.shields.io/website/http/xircuits.io.svg?color=orange">
     </a>
      <a>
-        <img alt="Python" src="https://img.shields.io/badge/python-3.9-blue">
+        <img alt="Python" src="https://img.shields.io/badge/Python-3.8%20%7C%203.9%20%7C%203.10-blue">
     </a>
 </p>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "xircuits",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@emotion/core": "^10.0.35",
@@ -39,7 +39,8 @@
         "react-sanity-pagination": "^2.0.2",
         "react-switch": "^6.0.0",
         "react-textarea-autosize": "^8.3.3",
-        "react-toggle": "^4.1.2"
+        "react-toggle": "^4.1.2",
+        "react-tooltip": "^4.2.21"
       },
       "devDependencies": {
         "@babel/core": "^7.12.10",
@@ -5288,9 +5289,9 @@
       }
     },
     "node_modules/eventsource": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
-      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.1.tgz",
+      "integrity": "sha512-qV5ZC0h7jYIAOhArFJgSfdyz6rALJyb270714o7ZtNnw2WSJ+eexhKtE0O8LYPRsHZHf2osHKZBxGPvm3kPkCA==",
       "dependencies": {
         "original": "^1.0.0"
       },
@@ -9429,6 +9430,30 @@
         "prop-types": ">= 15.3.0 < 18",
         "react": ">= 15.3.0 < 18",
         "react-dom": ">= 15.3.0 < 18"
+      }
+    },
+    "node_modules/react-tooltip": {
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.21.tgz",
+      "integrity": "sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==",
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "uuid": "^7.0.3"
+      },
+      "engines": {
+        "npm": ">=6.13"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/react-tooltip/node_modules/uuid": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/react-transition-group": {
@@ -16142,9 +16167,9 @@
       "dev": true
     },
     "eventsource": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
-      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.1.tgz",
+      "integrity": "sha512-qV5ZC0h7jYIAOhArFJgSfdyz6rALJyb270714o7ZtNnw2WSJ+eexhKtE0O8LYPRsHZHf2osHKZBxGPvm3kPkCA==",
       "requires": {
         "original": "^1.0.0"
       }
@@ -19254,6 +19279,22 @@
       "integrity": "sha512-4Ohw31TuYQdhWfA6qlKafeXx3IOH7t4ZHhmRdwsm1fQREwOBGxJT+I22sgHqR/w8JRdk+AeMCJXPImEFSrNXow==",
       "requires": {
         "classnames": "^2.2.5"
+      }
+    },
+    "react-tooltip": {
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.21.tgz",
+      "integrity": "sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==",
+      "requires": {
+        "prop-types": "^15.7.2",
+        "uuid": "^7.0.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
       }
     },
     "react-transition-group": {

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -278,7 +278,10 @@ export function addNodeActionCommands(
             const nodePosition = args['nodePosition'] as any;
 
             const widget = tracker.currentWidget?.content as XPipePanel;
-            node.setPosition(nodePosition);
+
+            const canvasNodePosition = widget.xircuitsApp.getDiagramEngine().getRelativeMousePoint(nodePosition)
+            node.setPosition(canvasNodePosition);
+
             widget.xircuitsApp.getDiagramEngine().getModel().addNode(node);
         },
         label: trans.__('Add node')
@@ -298,7 +301,7 @@ export function addNodeActionCommands(
             let targetPort;
 
             // Get source link node port
-            const linkPort = sourceLink.getSourcePort();
+            const linkPort = sourceLink.sourcePort;
 
             // When '▶' of sourcePort from inPort, connect to '▶' outPort of target node
             if (linkPort.getOptions()['name'] == "in-0") {
@@ -314,7 +317,7 @@ export function addNodeActionCommands(
                 // '▶' of sourcePort to '▶' of targetPort
                 sourcePort = linkPort;
                 targetPort = targetNode.getPorts()["in-0"];
-                app.commands.execute(commandIDs.connectLinkToObviousPorts, { sourceLink, targetNode });
+                app.commands.execute(commandIDs.connectLinkToObviousPorts, { droppedSourceLink:sourceLink, targetNode });
             }
             newLink.setSourcePort(sourcePort);
             newLink.setTargetPort(targetPort);
@@ -326,10 +329,12 @@ export function addNodeActionCommands(
     //Add command to connect link to obvious port given link and target node
     commands.addCommand(commandIDs.connectLinkToObviousPorts, {
         execute: (args) => {
-            const sourceLink = args['sourceLink'] as unknown as DefaultLinkModel;
             const widget = tracker.currentWidget?.content as XPipePanel;
-            const sourcePort = sourceLink.getSourcePort();
-            const targetPort = sourceLink.getTargetPort();
+            const draggedLink = args['draggedLink'] as any;
+            const droppedSourceLink = args['droppedSourceLink'] as any;
+            // Check whether link is dropped or dragged
+            const sourcePort = droppedSourceLink == undefined ? draggedLink.getSourcePort() : droppedSourceLink.sourcePort;
+            const targetPort = droppedSourceLink == undefined ? draggedLink.getTargetPort() : droppedSourceLink.link.getTargetPort();
             const sourceNode = sourcePort.getNode();
             const targetNode = args['targetNode'] as any ?? targetPort.getNode();
             const outPorts = sourceNode['portsOut'];

--- a/src/components/DragNewLinkState.ts
+++ b/src/components/DragNewLinkState.ts
@@ -80,7 +80,9 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 
 					if (!this.config.allowLooseLinks) {
 						const linkEvent = event.event;
-						this.fireEvent(linkEvent);
+						// Weird behaviour where sourcePort's data is missing
+						// For now just pass the port's data itself
+						this.fireEvent(linkEvent, this.port);
 						this.link.remove();
 						this.engine.repaintCanvas();
 					}
@@ -89,9 +91,9 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 		);
 	}
 
-	fireEvent = (linkEvent) => {
+	fireEvent = (linkEvent, sourcePort) => {
 		//@ts-ignore
-		this.engine.fireEvent({ link: this.link, linkEvent }, 'droppedLink');
+		this.engine.fireEvent({ link: this.link, linkEvent, sourcePort }, 'droppedLink');
 	};
 
 	/**

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -234,7 +234,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 								 */
 								targetPortChanged: e => {
 									const sourceLink = e.entity as any;
-									app.commands.execute(commandIDs.connectLinkToObviousPorts, { sourceLink });
+									app.commands.execute(commandIDs.connectLinkToObviousPorts, { draggedLink: sourceLink });
 									onChange();
 								},
 								/**
@@ -1554,8 +1554,8 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 	const [isPanelAtLeft, setIsPanelAtLeft] = useState<boolean>(true);
 	const [componentPanelPosition, setComponentPanelPosition] = useState({ x: 0, y: 0 });
 	const [actionPanelPosition, setActionPanelPosition] = useState({ x: 0, y: 0 });
-	const [nodePosition, setNodePosition] = useState({ x: 0, y: 0 });
-	const [looseLinkData, setLooseLinkData] = useState<any>();
+	const [nodePosition, setNodePosition] = useState<any>();
+	const [looseLinkData, setLooseLinkData] = useState<any>({});
 	const [isParameterLink, setIsParameterLink] = useState<boolean>(false);
 
 	// Component & Action panel position
@@ -1623,13 +1623,8 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			}
 		}
 
-		const newNodePosition = {
-			x: event.link.points[1].position.x,
-			y: event.link.points[1].position.y,
-		};
-
-		setLooseLinkData(event.link);
-		setNodePosition(newNodePosition);
+		setLooseLinkData({link: event.link, sourcePort: event.sourcePort});
+		setNodePosition(event.linkEvent);
 		panelPosition(event.linkEvent);
 		setIsComponentPanelShown(true);
 	};

--- a/src/context-menu/TrayItemPanel.tsx
+++ b/src/context-menu/TrayItemPanel.tsx
@@ -14,7 +14,7 @@ export interface TrayItemWidgetProps {
 	app: JupyterFrontEnd;
 	eng: DiagramEngine;
 	nodePosition?: {x: number, y: number};
-	linkData?: DefaultLinkModel;
+	linkData?: any;
 	isParameter?: boolean;
 }
 

--- a/xircuits/handlers/components.py
+++ b/xircuits/handlers/components.py
@@ -74,7 +74,6 @@ def remove_prefix(input_str, prefix):
         return input_str
 
 def read_orig_code(node: ast.AST, lines):
-    print(ast.dump(node))
     line_from = node.lineno - 1
     col_from = node.col_offset
 


### PR DESCRIPTION
# Description
We have identified that those two methods (str.removeprefix and ast.unparse) stop us from supporting python versions < 3.9. the current changes add support for python versions > 3.8. 

AST parsing differences between different Python versions:
- [Python 3.7](https://gist.github.com/mansouralawi/6dc729ec0e4ee946237eaa3019c7ad5c)
- [Python 3.8](https://gist.github.com/mansouralawi/e6e1a90e9e048f5beee7d3540df5c357)
- [Python 3.9](https://gist.github.com/mansouralawi/64250ae9c4dcfaef753adcfe4646c6b2)

*What is preventing Xircuits from running on Python 3.7 is the missing of `end_lineno` and `end_col_offset` from the AST parse.*

## References

this PR is based on an older PR https://github.com/XpressAI/xircuits/pull/87 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] Refactoring
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

- Manual test for same Xircuits behaviour and features as before:

    1. Clone Xircuits
    2. Build Xircuits with python 3.8
    3. Run `Xircuits`
    4. Check if the components library (side bar) exist, 
    5. Run a workflow
    6. Repeat with python versions  3.9 , 3.10 & 3.11


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Add if any.
