### PR TITLE
🐛Fix adding node via link

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -301,7 +301,7 @@ export function addNodeActionCommands(
             let targetPort;
 
             // Get source link node port
-            const linkPort = sourceLink.getSourcePort();
+            const linkPort = sourceLink.sourcePort;
 
             // When '▶' of sourcePort from inPort, connect to '▶' outPort of target node
             if (linkPort.getOptions()['name'] == "in-0") {
@@ -317,7 +317,7 @@ export function addNodeActionCommands(
                 // '▶' of sourcePort to '▶' of targetPort
                 sourcePort = linkPort;
                 targetPort = targetNode.getPorts()["in-0"];
-                app.commands.execute(commandIDs.connectLinkToObviousPorts, { sourceLink, targetNode });
+                app.commands.execute(commandIDs.connectLinkToObviousPorts, { droppedSourceLink:sourceLink, targetNode });
             }
             newLink.setSourcePort(sourcePort);
             newLink.setTargetPort(targetPort);
@@ -329,10 +329,12 @@ export function addNodeActionCommands(
     //Add command to connect link to obvious port given link and target node
     commands.addCommand(commandIDs.connectLinkToObviousPorts, {
         execute: (args) => {
-            const sourceLink = args['sourceLink'] as unknown as DefaultLinkModel;
             const widget = tracker.currentWidget?.content as XPipePanel;
-            const sourcePort = sourceLink.getSourcePort();
-            const targetPort = sourceLink.getTargetPort();
+            const draggedLink = args['draggedLink'] as any;
+            const droppedSourceLink = args['droppedSourceLink'] as any;
+            // Check whether link is dropped or dragged
+            const sourcePort = droppedSourceLink == undefined ? draggedLink.getSourcePort() : droppedSourceLink.sourcePort;
+            const targetPort = droppedSourceLink == undefined ? draggedLink.getTargetPort() : droppedSourceLink.link.getTargetPort();
             const sourceNode = sourcePort.getNode();
             const targetNode = args['targetNode'] as any ?? targetPort.getNode();
             const outPorts = sourceNode['portsOut'];

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -278,7 +278,10 @@ export function addNodeActionCommands(
             const nodePosition = args['nodePosition'] as any;
 
             const widget = tracker.currentWidget?.content as XPipePanel;
-            node.setPosition(nodePosition);
+
+            const canvasNodePosition = widget.xircuitsApp.getDiagramEngine().getRelativeMousePoint(nodePosition)
+            node.setPosition(canvasNodePosition);
+
             widget.xircuitsApp.getDiagramEngine().getModel().addNode(node);
         },
         label: trans.__('Add node')

--- a/src/components/DragNewLinkState.ts
+++ b/src/components/DragNewLinkState.ts
@@ -80,7 +80,9 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 
 					if (!this.config.allowLooseLinks) {
 						const linkEvent = event.event;
-						this.fireEvent(linkEvent);
+						// Weird behaviour where sourcePort's data is missing
+						// For now just pass the port's data itself
+						this.fireEvent(linkEvent, this.port);
 						this.link.remove();
 						this.engine.repaintCanvas();
 					}
@@ -89,9 +91,9 @@ export class DragNewLinkState extends AbstractDisplacementState<DiagramEngine> {
 		);
 	}
 
-	fireEvent = (linkEvent) => {
+	fireEvent = (linkEvent, sourcePort) => {
 		//@ts-ignore
-		this.engine.fireEvent({ link: this.link, linkEvent }, 'droppedLink');
+		this.engine.fireEvent({ link: this.link, linkEvent, sourcePort }, 'droppedLink');
 	};
 
 	/**

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -234,7 +234,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 								 */
 								targetPortChanged: e => {
 									const sourceLink = e.entity as any;
-									app.commands.execute(commandIDs.connectLinkToObviousPorts, { sourceLink });
+									app.commands.execute(commandIDs.connectLinkToObviousPorts, { draggedLink: sourceLink });
 									onChange();
 								},
 								/**
@@ -1554,8 +1554,8 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 	const [isPanelAtLeft, setIsPanelAtLeft] = useState<boolean>(true);
 	const [componentPanelPosition, setComponentPanelPosition] = useState({ x: 0, y: 0 });
 	const [actionPanelPosition, setActionPanelPosition] = useState({ x: 0, y: 0 });
-	const [nodePosition, setNodePosition] = useState({ x: 0, y: 0 });
-	const [looseLinkData, setLooseLinkData] = useState<any>();
+	const [nodePosition, setNodePosition] = useState<any>();
+	const [looseLinkData, setLooseLinkData] = useState<any>({});
 	const [isParameterLink, setIsParameterLink] = useState<boolean>(false);
 
 	// Component & Action panel position
@@ -1623,13 +1623,8 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			}
 		}
 
-		const newNodePosition = {
-			x: event.link.points[1].position.x,
-			y: event.link.points[1].position.y,
-		};
-
-		setLooseLinkData(event.link);
-		setNodePosition(newNodePosition);
+		setLooseLinkData({link: event.link, sourcePort: event.sourcePort});
+		setNodePosition(event.linkEvent);
 		panelPosition(event.linkEvent);
 		setIsComponentPanelShown(true);
 	};

--- a/src/context-menu/TrayItemPanel.tsx
+++ b/src/context-menu/TrayItemPanel.tsx
@@ -14,7 +14,7 @@ export interface TrayItemWidgetProps {
 	app: JupyterFrontEnd;
 	eng: DiagramEngine;
 	nodePosition?: {x: number, y: number};
-	linkData?: DefaultLinkModel;
+	linkData?: any;
 	isParameter?: boolean;
 }
 


### PR DESCRIPTION
# Description

This will fix adding node via component panel or dropped link. Previously, when updating the package-lock file, this feature cannot be use. It's due to incorrect node position and somehow the `sourcePort`'s data is missing(Not sure why).

## References

#121 

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. With latest update of package-lock.json
   1. Git clone new repo
   2. Delete package-lock.son and tsconfig.tsbuildinfo
   3. Install development as usual
   4. Create xircuits file
   5. Add node via component panel or dropped link
2. Try also from the wheel

Note: Haven't tested both but I assumed it'll work.

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Currently, the comment component is broken. It doesn't show the comment's textarea. Haven't figured out what causing this.
Also, the context menu's position is kinda wrong. 