### PR TITLE
🐛Fix context menu and components panel spawn coordinates

### DIFF
--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -1596,9 +1596,9 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			x: canvas.innerWidth / 2,
 			y: canvas.innerHeight / 2,
 		}
-		const menuDimension = {
+		const menuOffset = {
 			x: 95,
-			y: 267
+			y: 250
 		}
 		const fileBrowserWidth = document.getElementsByClassName("jp-FileBrowser")['filebrowser'].clientWidth;
 		const tabWidth = document.getElementsByClassName("lm-TabBar")[0].clientWidth;
@@ -1607,7 +1607,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			setIsPanelAtTop(false);
 			setIsPanelAtLeft(false);
 			newPanelPosition.x = canvas.innerWidth - newPanelPosition.x - tabWidth;
-			newPanelPosition.y = canvas.innerHeight - newPanelPosition.y - menuDimension.y;
+			newPanelPosition.y = canvas.innerHeight - newPanelPosition.y - menuOffset.y;
 		} else if (newPanelPosition.x > newCenterPosition.x && newPanelPosition.y < newCenterPosition.y) {
 			// Top right
 			setIsPanelAtTop(true);
@@ -1619,7 +1619,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			setIsPanelAtTop(false);
 			setIsPanelAtLeft(true);
 			newPanelPosition.x = newPanelPosition.x - fileBrowserWidth - tabWidth;
-			newPanelPosition.y = canvas.innerHeight - newPanelPosition.y - menuDimension.y;
+			newPanelPosition.y = canvas.innerHeight - newPanelPosition.y - menuOffset.y;
 		} else {
 			// Top left
 			setIsPanelAtTop(true);

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -1577,7 +1577,6 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 	const [isComponentPanelShown, setIsComponentPanelShown] = useState(false);
 	const [actionPanelShown, setActionPanelShown] = useState(false);
 	const [dontHidePanel, setDontHidePanel] = useState(false);
-	const [isPanelAtTop, setIsPanelAtTop] = useState<boolean>(true);
 	const [isPanelAtLeft, setIsPanelAtLeft] = useState<boolean>(true);
 	const [componentPanelPosition, setComponentPanelPosition] = useState({ x: 0, y: 0 });
 	const [actionPanelPosition, setActionPanelPosition] = useState({ x: 0, y: 0 });
@@ -1604,25 +1603,21 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		const tabWidth = document.getElementsByClassName("lm-TabBar")[0].clientWidth;
 		if (newPanelPosition.x > newCenterPosition.x && newPanelPosition.y > newCenterPosition.y) {
 			// Bottom right
-			setIsPanelAtTop(false);
 			setIsPanelAtLeft(false);
 			newPanelPosition.x = canvas.innerWidth - newPanelPosition.x - tabWidth;
 			newPanelPosition.y = canvas.innerHeight - newPanelPosition.y - menuOffset.y;
 		} else if (newPanelPosition.x > newCenterPosition.x && newPanelPosition.y < newCenterPosition.y) {
 			// Top right
-			setIsPanelAtTop(true);
 			setIsPanelAtLeft(false);
 			newPanelPosition.x = canvas.innerWidth - newPanelPosition.x - tabWidth;
 			newPanelPosition.y = newPanelPosition.y - 84;
 		} else if (newPanelPosition.x < newCenterPosition.x && newPanelPosition.y > newCenterPosition.y) {
 			// Bottom left
-			setIsPanelAtTop(false);
 			setIsPanelAtLeft(true);
 			newPanelPosition.x = newPanelPosition.x - fileBrowserWidth - tabWidth;
 			newPanelPosition.y = canvas.innerHeight - newPanelPosition.y - menuOffset.y;
 		} else {
 			// Top left
-			setIsPanelAtTop(true);
 			setIsPanelAtLeft(true);
 			newPanelPosition.x = newPanelPosition.x - fileBrowserWidth - tabWidth;
 			newPanelPosition.y = newPanelPosition.y - 84;
@@ -1787,8 +1782,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 								onMouseLeave={()=>setDontHidePanel(false)}
 								id='component-panel'
 								style={{
-									top: isPanelAtTop ? componentPanelPosition.y : null,
-									bottom: !isPanelAtTop ? componentPanelPosition.y : null,
+									top: componentPanelPosition.y,
 									right: !isPanelAtLeft ? componentPanelPosition.x : null,
 									left: isPanelAtLeft ? componentPanelPosition.x : null
 								}}
@@ -1808,8 +1802,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 							<div
 								id='context-menu'
 								style={{
-									top: isPanelAtTop ? actionPanelPosition.y : null,
-									bottom: !isPanelAtTop ? actionPanelPosition.y : null,
+									top: actionPanelPosition.y,
 									right: !isPanelAtLeft ? actionPanelPosition.x : null,
 									left: isPanelAtLeft ? actionPanelPosition.x : null
 								}}

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -1595,9 +1595,9 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			x: canvas.innerWidth / 2,
 			y: canvas.innerHeight / 2,
 		}
-		const menuOffset = {
+		const menuDimension = {
 			x: 95,
-			y: 250
+			y: 290
 		}
 		const fileBrowserWidth = document.getElementsByClassName("jp-FileBrowser")['filebrowser'].clientWidth;
 		const tabWidth = document.getElementsByClassName("lm-TabBar")[0].clientWidth;
@@ -1605,7 +1605,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			// Bottom right
 			setIsPanelAtLeft(false);
 			newPanelPosition.x = canvas.innerWidth - newPanelPosition.x - tabWidth;
-			newPanelPosition.y = canvas.innerHeight - newPanelPosition.y - menuOffset.y;
+			newPanelPosition.y = newPanelPosition.y - menuDimension.y - 84;
 		} else if (newPanelPosition.x > newCenterPosition.x && newPanelPosition.y < newCenterPosition.y) {
 			// Top right
 			setIsPanelAtLeft(false);
@@ -1615,7 +1615,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			// Bottom left
 			setIsPanelAtLeft(true);
 			newPanelPosition.x = newPanelPosition.x - fileBrowserWidth - tabWidth;
-			newPanelPosition.y = canvas.innerHeight - newPanelPosition.y - menuOffset.y;
+			newPanelPosition.y = newPanelPosition.y - menuDimension.y - 84;
 		} else {
 			// Top left
 			setIsPanelAtLeft(true);

--- a/src/context-menu/ComponentsPanel.tsx
+++ b/src/context-menu/ComponentsPanel.tsx
@@ -19,12 +19,12 @@ import { TrayPanel } from './TrayPanel';
 import { TrayItemPanel } from './TrayItemPanel';
 
 export const Body = styled.div`
-  flex-grow: 1;
   display: flex;
   flex-wrap: wrap;
-  min-height: 100%;
   background-color: black;
-  height: 100%;
+  height: 270px;
+  border-top: 10px;
+  border-radius: 12px;
   overflow-y: auto;
 `;
 
@@ -167,7 +167,7 @@ export default function ComponentsPanel(props: ComponentsPanelProps) {
 
     return (
         <Body>
-            <Content>
+            <Content onBlur={focusInput}>
                 <TrayPanel>
                     <div>
                         <p className='title-panel'>Add Component</p>
@@ -195,7 +195,7 @@ export default function ComponentsPanel(props: ComponentsPanelProps) {
                             })
                         }
                     </div>
-                    <Accordion allowZeroExpanded onBlur={focusInput}>
+                    <Accordion allowZeroExpanded>
                         {
                             category.filter((val) => {
                                 if (searchTerm == "") {

--- a/style/ComponentsPanel.css
+++ b/style/ComponentsPanel.css
@@ -11,15 +11,13 @@
   }
 
   .add-component-panel {
-    width: 250px;
-    height: 270px;
-    position: fixed;
-    z-index: 10;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    max-width: 250px;
+    max-height: 270px;
+    position: absolute;
+    z-index: 1000;
     border-top: 10px;
     border-color: #000;
     border-radius: 12px;
-    overflow-y: auto;
   }
   
   .accordion__item_panel {

--- a/style/NodeActionPanel.css
+++ b/style/NodeActionPanel.css
@@ -1,6 +1,7 @@
     .node-action-context-menu {
-    position: fixed;
-    z-index: 10;
+    position: absolute;
+    z-index: 1000;
+    max-width: 95px;
     border-top: 10px;
     border-color: #000;
     border-radius: 12px;

--- a/style/NodeActionPanel.css
+++ b/style/NodeActionPanel.css
@@ -11,7 +11,7 @@
     cursor: pointer;
     flex-grow: 1;
     width: 90%;
-    height: 15%;
+    height: 19px;
     font-size:small;
     padding: 5px 7px;
     color: #fff;


### PR DESCRIPTION
# Description

This will fix context menu and component panel from rendering at the wrong position.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Open context menu and component panel
   1. Create `.xircuits` file
   2. Right-click to open context menu anywhere on canvas
   3. Drop a link onto canvas to open components panel
   4. Make sure both panel was opened inside canvas 
   5. Also, make sure it's spawn at the correct position where the mouse was clicked or link dropped

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  