### PR TITLE
🎨Update port error tooltip to display expected type. Add timer and default port type symbols.

### DIFF
--- a/src/components/CustomNodeWidget.tsx
+++ b/src/components/CustomNodeWidget.tsx
@@ -377,7 +377,7 @@ export class CustomNodeWidget extends React.Component<DefaultNodeProps> {
                             delayUpdate={50}
                             getContent={() =>
                                 <div data-no-drag className='error-container'>
-                                    <p className='error-text'>{this.props.node.getOptions().extras["tip"]}</p>
+                                    <div className='markdown-body' dangerouslySetInnerHTML={this.renderText(this.props.node.getOptions().extras["tip"])} />
                                     <button
                                         type="button"
                                         className="close"

--- a/src/components/CustomNodeWidget.tsx
+++ b/src/components/CustomNodeWidget.tsx
@@ -402,7 +402,7 @@ export class CustomNodeWidget extends React.Component<DefaultNodeProps> {
                                     offset = leftSidebar.clientWidth + 2;
                                 }
 
-                                newPositionX = newPositionX - 110 + offset + (nodeDimension.x / 2);
+                                newPositionX = newPositionX - 184 + offset + (nodeDimension.x / 2);
                                 newPositionY = newPositionY + 90 + nodeDimension.y;
 
                                 const tooltipPosition = this.props.engine.getRelativePoint(newPositionX, newPositionY);

--- a/src/components/port/CustomPortLabel.tsx
+++ b/src/components/port/CustomPortLabel.tsx
@@ -75,6 +75,9 @@ export class CustomPortLabel extends React.Component<CustomPortLabelProps> {
 			case "boolean":
 				symbolLabel = '⊤⊥';
 				break;
+			case "time.time":
+				symbolLabel = '𝘵';
+				break;
 			case "list":
 				symbolLabel = '[ ]';
 				break;
@@ -87,8 +90,11 @@ export class CustomPortLabel extends React.Component<CustomPortLabelProps> {
 			case "any":
 				symbolLabel = '[_]';
 				break;
-			default:
+			case "0":
 				symbolLabel = null;
+				break;
+			default:
+				symbolLabel = '◎';
 				break;
 		}
 

--- a/src/components/port/CustomPortLabel.tsx
+++ b/src/components/port/CustomPortLabel.tsx
@@ -36,7 +36,7 @@ namespace S {
 		font-weight: bold;
 		font-size: 9px;
 		font-family: Helvetica, Arial, sans-serif;
-		padding:${(p) => (p.isOutPort ? '3px 0px 0px 2px' : '3px 2px 0px 0px')};
+		padding:${(p) => (p.isOutPort ? '2px 0px 0px 2px' : '2px 2px 0px 0px')};
 	`;
 
 	export const Port = styled.div`

--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -73,9 +73,10 @@ export  class CustomPortModel extends DefaultPortModel  {
         const thisNode = this.getNode();
         const thisNodeModelType = thisNode.getOptions()["extras"]["type"];
         const thisName: string = port.getName();
-        const thisLabel: string = port.getOptions()["label"];
+        const thisLabel: string = "**" + port.getOptions()["label"] + "**";
         const sourcePortName: string = thisPort.getName();
         const thisPortType: string = thisName.split('-')[1];
+        const thisPortTypeText: string = "*`" + thisPortType + "`*";
         const sourcePortType: string = sourcePortName.split('-')[2];
 
         if (this.isParameterNode(thisNodeModelType) == true){
@@ -91,7 +92,7 @@ export  class CustomPortModel extends DefaultPortModel  {
                         return;
                 }
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]=`Port ${thisLabel} doesn't allow multi-link of (${thisPortType}) type`;
+		        port.getNode().getOptions().extras["tip"]=`Port ${thisLabel} doesn't allow multi-link of ${thisPortTypeText} type`;
                 port.getNode().setSelected(true);
                 return false;
             }
@@ -99,7 +100,7 @@ export  class CustomPortModel extends DefaultPortModel  {
 
             if (!thisName.startsWith("parameter")){
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} linked is not parameter, please link a non parameter node to it`;
+		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} linked is not a parameter, please link a non parameter node to it`;
                 port.getNode().setSelected(true);
                 return false;
             }
@@ -122,7 +123,7 @@ export  class CustomPortModel extends DefaultPortModel  {
                     return;
                 }
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} linked not correct data type (${result[1]})`;
+		        port.getNode().getOptions().extras["tip"]= `Incorrect data type. Port ${thisLabel} is a type ` + "*`" + result[1] + "`*";
                 port.getNode().setSelected(true);
                 //tested - add stuff
                 return false;
@@ -135,7 +136,7 @@ export  class CustomPortModel extends DefaultPortModel  {
                     return
                 }
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} is a (${thisPortType}) type, please connect port from (${thisPortType}) type`;
+		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} is a ${thisPortTypeText} type, please connect port from ${thisPortTypeText} type`;
                 port.getNode().setSelected(true);
                 return false;
             }else if(Object.keys(port.getLinks()).length > 0){

--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -32,7 +32,7 @@ export  class CustomPortModel extends DefaultPortModel  {
 
         if (canTriangleLinkToTriangle == false){
             port.getNode().getOptions().extras["borderColor"]="red";
-            port.getNode().getOptions().extras["tip"]="Triangle must be linked to triangle";
+            port.getNode().getOptions().extras["tip"]="Triangle must be linked to triangle.";
             port.getNode().setSelected(true);
             console.log("triangle to triangle failed.");
             //tested
@@ -43,7 +43,7 @@ export  class CustomPortModel extends DefaultPortModel  {
 
         if (checkLinkDirection == false){
             port.getNode().getOptions().extras["borderColor"]="red";
-            port.getNode().getOptions().extras["tip"]="Port should be created from outPort [right] to inPort [left]";
+            port.getNode().getOptions().extras["tip"]="Port should be created from outPort [right] to inPort [left].";
             port.getNode().setSelected(true);
             console.log("Port should be created from outPort [right] to inPort [left]");
             return false;
@@ -92,7 +92,7 @@ export  class CustomPortModel extends DefaultPortModel  {
                         return;
                 }
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]=`Port ${thisLabel} doesn't allow multi-link of ${thisPortTypeText} type`;
+		        port.getNode().getOptions().extras["tip"]=`Port ${thisLabel} doesn't allow multi-links of ${thisPortTypeText} type.`;
                 port.getNode().setSelected(true);
                 return false;
             }
@@ -100,7 +100,7 @@ export  class CustomPortModel extends DefaultPortModel  {
 
             if (!thisName.startsWith("parameter")){
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} linked is not a parameter, please link a non parameter node to it`;
+		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} linked is not a parameter, please link a non parameter node to it.`;
                 port.getNode().setSelected(true);
                 return false;
             }
@@ -123,7 +123,7 @@ export  class CustomPortModel extends DefaultPortModel  {
                     return;
                 }
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]= `Incorrect data type. Port ${thisLabel} is a type ` + "*`" + result[1] + "`*";
+		        port.getNode().getOptions().extras["tip"]= `Incorrect data type. Port ${thisLabel} is a type ` + "*`" + result[1] + "`*.";
                 port.getNode().setSelected(true);
                 //tested - add stuff
                 return false;
@@ -136,12 +136,12 @@ export  class CustomPortModel extends DefaultPortModel  {
                     return
                 }
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} is a ${thisPortTypeText} type, please connect port from ${thisPortTypeText} type`;
+		        port.getNode().getOptions().extras["tip"]= `Inncorrect input for port ${thisLabel}, please connect port from a ${thisPortTypeText} type.`;
                 port.getNode().setSelected(true);
                 return false;
             }else if(Object.keys(port.getLinks()).length > 0){
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} has link, please delete the current link to proceed`;
+		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} only allows 1 link per port! Please delete the current link to proceed.`;
                 port.getNode().setSelected(true);
                 return false;
             }

--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -70,12 +70,13 @@ export  class CustomPortModel extends DefaultPortModel  {
      */
     canParameterLinkToPort = (thisPort, port) => {
 
-        let thisNode = this.getNode();
-        let thisNodeModelType = thisNode.getOptions()["extras"]["type"];
-        let thisName = port.getName();
-        let sourcePortName = thisPort.getName();
-        let thisPortType = thisName.split('-')[1];
-        let sourcePortType = sourcePortName.split('-')[2];
+        const thisNode = this.getNode();
+        const thisNodeModelType = thisNode.getOptions()["extras"]["type"];
+        const thisName: string = port.getName();
+        const thisLabel: string = port.getOptions()["label"];
+        const sourcePortName: string = thisPort.getName();
+        const thisPortType: string = thisName.split('-')[1];
+        const sourcePortType: string = sourcePortName.split('-')[2];
 
         if (this.isParameterNode(thisNodeModelType) == true){
             // if the port you are trying to link ready has other links
@@ -90,7 +91,7 @@ export  class CustomPortModel extends DefaultPortModel  {
                         return;
                 }
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]=`Port doesn't allow multi-link of ${thisPortType} type`;
+		        port.getNode().getOptions().extras["tip"]=`Port ${thisLabel} doesn't allow multi-link of (${thisPortType}) type`;
                 port.getNode().setSelected(true);
                 return false;
             }
@@ -98,7 +99,7 @@ export  class CustomPortModel extends DefaultPortModel  {
 
             if (!thisName.startsWith("parameter")){
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]="Port linked is not parameter, please link a non parameter node to it";
+		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} linked is not parameter, please link a non parameter node to it`;
                 port.getNode().setSelected(true);
                 return false;
             }
@@ -121,7 +122,7 @@ export  class CustomPortModel extends DefaultPortModel  {
                     return;
                 }
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]="Port linked not correct data type (" + result[1] +")";
+		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} linked not correct data type (${result[1]})`;
                 port.getNode().setSelected(true);
                 //tested - add stuff
                 return false;
@@ -134,12 +135,12 @@ export  class CustomPortModel extends DefaultPortModel  {
                     return
                 }
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]= "Node link to this port must be a hyperparameter/literal";
+		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} is a (${thisPortType}) type, please connect port from (${thisPortType}) type`;
                 port.getNode().setSelected(true);
                 return false;
             }else if(Object.keys(port.getLinks()).length > 0){
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]= "Port has link, please delete the current link to proceed";
+		        port.getNode().getOptions().extras["tip"]= `Port ${thisLabel} has link, please delete the current link to proceed`;
                 port.getNode().setSelected(true);
                 return false;
             }

--- a/style/ComponentInfo.css
+++ b/style/ComponentInfo.css
@@ -37,6 +37,10 @@
     cursor: default;
 }
 
+.error-container{
+    width: 400px;
+}
+
 .error-container .close{
     right: 5px;
 }


### PR DESCRIPTION
# Description

This will fix the error tooltip to display the correct message. Next, I also change the error tooltip to use the markdown style for a richer text experience. In addition, all of the error messages have some changes to adapt with the new markdown style.

I added a `time.time` type symbol and default symbol which is to handle custom `types`.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Link incorrect type
   1. Drag 2 component with outPorts
   2. Connect a link with different type
   3. Error tooltip should pop up 
2. Check all updated messages. Does it make sense?
3. See default port type
   1. Drag a component with a specific/custom `type` (e.g CreateUnetModel)
   2. You should see its port type symbol [`◎`](https://en.wikipedia.org/wiki/%E2%97%8E)
4. See `time.time` port type
   1. Add a TimerComponent from branch fahreza/update-desc
   2. You should see its port type symbol, `𝘵`

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Let me know if all of the updated message makes sense or need some changes. I don't have a very good English vocabulary T.T