### PR TITLE
🐛Fix node position changes

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -550,6 +550,8 @@ export function addNodeActionCommands(
                 case "True":
                 case "False":
                     return;
+                default:
+                    break;
             }
             const newTitle = `Update ${literalType}`;
             const dialogOptions = inputDialog(newTitle, oldValue, literalType, isStoreDataType, isTextareaInput);

--- a/src/components/state/MoveItemsState.ts
+++ b/src/components/state/MoveItemsState.ts
@@ -54,6 +54,7 @@ export class MoveItemsState<E extends CanvasEngine = CanvasEngine> extends Abstr
           element.setSelected(true);
           this.engine.repaintCanvas();
           this.initialPosition = element['position'];
+          this.finalPosition = element['position'];
         }
       })
     );
@@ -62,12 +63,10 @@ export class MoveItemsState<E extends CanvasEngine = CanvasEngine> extends Abstr
       new Action({
         type: InputType.MOUSE_UP,
         fire: () => {
-          // When node's position is empty, just return
-          if (this.initialPosition  == null || this.finalPosition == null) return;
           // When node in the same position, just return
           if (
-            this.initialPosition.x === this.finalPosition.x &&
-            this.initialPosition.y === this.finalPosition.y
+            this.initialPosition?.x === this.finalPosition?.x &&
+            this.initialPosition?.y === this.finalPosition?.y
           ) {
             return;
           }


### PR DESCRIPTION
# Description

This will fix detecting node's position changes. It's also indirectly fix editing `Literal` node by double click as just selecting a node won't change the xircuits.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Just selecting node after moving a different node wont detect its changes.
   1. Move a node
   2. Save xircuits
   3. Select a different node
   4. See that xircuits is **not in `dirty` state**.
   5. Repeat step 1-4 in a different branch. You will see that the xircuits in `dirty` state
2. Try double click any literal to edit it

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  