### PR TITLE
🐛Disable canvas scrolled when scrolling description tooltip

### DIFF
--- a/src/components/CustomNodeWidget.tsx
+++ b/src/components/CustomNodeWidget.tsx
@@ -322,7 +322,9 @@ export class CustomNodeWidget extends React.Component<DefaultNodeProps> {
                                 </button>
                                 <S.DescriptionName color={this.props.node.getOptions().color}>{this.props.node.getOptions()["name"]}</S.DescriptionName>
                                 <p className='description-title'>Description:</p>
-                                <div className='description-container'>
+                                <div 
+                                    onWheel={(e) => e.stopPropagation()}
+                                    className='description-container'>
                                     <div className='markdown-body' dangerouslySetInnerHTML={this.renderText(this.state.descriptionStr)} />
                                 </div>
                             </div>}

--- a/style/ComponentInfo.css
+++ b/style/ComponentInfo.css
@@ -10,7 +10,6 @@
     width: 450px;
     height: 250px;
     overflow: auto;
-    position: relative;
 }
 
 .description-title{


### PR DESCRIPTION
# Description

This will prevents propagation of the wheel event of canvas from being called.

## References

This will fix #182 

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Open node's description
2. Try to use mouse wheel to scroll
3. The canvas will not scroll

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  