### PR TITLE
🐛Fix delete multiple nodes at the same time

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -607,28 +607,31 @@ export function addNodeActionCommands(
                 // When no node selected, just return
                 return;
             }
-            if (node.getOptions()["name"] !== "undefined") {
-                let modelName = node.getOptions()["name"];
-                const errorMsg = `${modelName} node cannot be deleted!`
-                if (modelName !== 'Start' && modelName !== 'Finish') {
-                    if (!node.isLocked()) {
-                        node.remove()
-                    } else {
+            const selectedEntities = widget.xircuitsApp.getDiagramEngine().getModel().getSelectedEntities();
+            selectedEntities.forEach((node) => {
+                if (node.getOptions()["name"] !== "undefined") {
+                    let modelName = node.getOptions()["name"];
+                    const errorMsg = `${modelName} node cannot be deleted!`
+                    if (modelName !== 'Start' && modelName !== 'Finish') {
+                        if (!node.isLocked()) {
+                            node.remove()
+                        } else {
+                            showDialog({
+                                title: 'Locked Node',
+                                body: errorMsg,
+                                buttons: [Dialog.warnButton({ label: 'OK' })]
+                            });
+                        }
+                    }
+                    else {
                         showDialog({
-                            title: 'Locked Node',
+                            title: 'Undeletable Node',
                             body: errorMsg,
                             buttons: [Dialog.warnButton({ label: 'OK' })]
                         });
                     }
                 }
-                else {
-                    showDialog({
-                        title: 'Undeletable Node',
-                        body: errorMsg,
-                        buttons: [Dialog.warnButton({ label: 'OK' })]
-                    });
-                }
-            }
+            })
             widget.xircuitsApp.getDiagramEngine().repaintCanvas();
         }
     }


### PR DESCRIPTION
# Description

This will allow multiple nodes to be deleted at the same time.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Select multiple nodes
2. Press `delete` or `backspace`
3. All of the nodes will be deleted at the same time except `Start` and `Finish` node

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  