### PR TITLE
✨ Wrapper for Jupyter Launch Args

### DIFF
--- a/xircuits/handlers/request_folder.py
+++ b/xircuits/handlers/request_folder.py
@@ -38,4 +38,4 @@ def request_folder(folder, repo_name="XpressAi/Xircuits", branch="master"):
         try:
             request.urlretrieve(url, urls[url])
         except:
-            print("Error in retriving file " + urls[url] + ". Skipping...")
+            print("Unable to retrieve " + urls[url] + ". Skipping...")

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -41,23 +41,39 @@ def download_component_library():
         for component_lib in args.sublib:
             request_submodule_library(component_lib)
 
-
 def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--branch', nargs='?', default="master", help='pull files from a xircuits branch')
 
-    args = parser.parse_args()
-    branch_name = args.branch
+    parsed, extra_args = parser.parse_known_args()
 
+    for arg in extra_args:
+        if arg.startswith(("-", "--")):
+            parser.add_argument(arg.split('=')[0])
+
+    args = parser.parse_args()
+
+    # fetch xai_components
     component_library_path = Path(os.getcwd()) / "xai_components"
 
     if not component_library_path.exists():
         val = input("Xircuits Component Library is not found. Would you like to load it in the current path (Y/N)? ")
         if val.lower() == ("y" or "yes"):
-            request_folder("xai_components", branch=branch_name)
+            request_folder("xai_components", branch=args.branch)
+
+    # launch if extra arguments pro
+    if extra_args:
+        try:
+            launch_cmd = "jupyter lab" + " " + " ".join(extra_args)
+            os.system(launch_cmd)
+
+        except Exception as e:
+            print("Error in launch args! Error log:\n")
+            print(e)
     
-    os.system("jupyter lab")
+    else:
+        os.system("jupyter lab")
 
 print(
 '''


### PR DESCRIPTION
# Description

This PR allows users to launch xircuits with any jupyterlab launch configs, ie instead of `jupyter lab --ContentsManager.allow_hidden=True` you can run `xircuits --ContentsManager.allow_hidden=True` 

Especially useful when in need to configure the spark remote run options.


## References
https://github.com/XpressAI/xircuits/pull/164

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Enable show hidden files**
  1. Launch Xircuits with
    ```
    xircuits --ContentsManager.allow_hidden=True
    ```
  2. In the`View` panel, click `Show Hidden Files`. You should be able to see the `.xircuits` directory.
  
You can try other jupyter launch options that you know.

## Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Add if any.
