### PR TITLE
🐛Fix hyperparameter dialog handling

### DIFF
--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -103,7 +103,7 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 		<form>
 			{type != 'Boolean' ?
 				<h3 style={{ marginTop: 0, marginBottom: 5 }}>
-					Enter {type} Value ({isStoreDataType ? 'Without Brackets' : 'Without Quotes'}):
+					Enter {title.includes('parameter') ? 'Hyperparameter Name' : `${type} Value`} ({isStoreDataType ? 'Without Brackets' : 'Without Quotes'}):
 				</h3>
 				: null}
 			<DictExample />

--- a/src/dialog/RunDialog.tsx
+++ b/src/dialog/RunDialog.tsx
@@ -167,7 +167,7 @@ export const RunDialog = ({
 									padding: '2px 2.26ex 2px 2px',
 									borderRadius: '6px 3px 3px 6px',
 									fontSize: 20,
-									width: '10vw'
+									width: '60%'
 								},
 								input: {
 									borderRadius: '6px 3px 3px 6px',
@@ -176,7 +176,7 @@ export const RunDialog = ({
 									marginRight: 4,
 									display: 'block',
 									fontWeight: 100,
-									width: '11.3vw'
+									width: '100%'
 								},
 								plus: {
 									background: 'rgba(255, 255, 255, 100)'
@@ -217,7 +217,7 @@ export const RunDialog = ({
 									padding: '2px 2.26ex 2px 2px',
 									borderRadius: '6px 3px 3px 6px',
 									fontSize: 20,
-									width: '10vw'
+									width: '60%'
 								},
 								input: {
 									borderRadius: '6px 3px 3px 6px',
@@ -226,7 +226,7 @@ export const RunDialog = ({
 									marginRight: 4,
 									display: 'block',
 									fontWeight: 100,
-									width: '11.3vw'
+									width: '100%'
 								},
 								plus: {
 									background: 'rgba(255, 255, 255, 100)'

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -17,6 +17,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
     let node = null;
     const nodeData = props.model;
     const nodeName = nodeData.task;
+    const hyperparameterTitle = 'Please define parameter';
     // For now, comment this first until we've use for it
     // if (props.type === 'math') {
 
@@ -53,10 +54,10 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
         }
         else {
 
-            const dialogOptions = inputDialog('String', "", 'String');
+            const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const strValue = dialogResult["value"]['String'];
+            const strValue = dialogResult["value"][hyperparameterTitle];
             node = new CustomNodeModel({ name: "Hyperparameter (String): " + strValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
 
@@ -74,10 +75,10 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
             node.addOutPortEnhance(intValue, 'out-0');
 
         } else {
-            const dialogOptions = inputDialog('Integer', "", 'Integer');
+            const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const intValue = dialogResult["value"]['Integer'];
+            const intValue = dialogResult["value"][hyperparameterTitle];
             node = new CustomNodeModel({ name: "Hyperparameter (Int): " + intValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
 
@@ -96,10 +97,12 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         } else {
 
-            const dialogOptions = inputDialog('Float', "", 'Float');
+            const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const floatValue = dialogResult["value"]['Float'];
+            const floatValue = dialogResult["value"][hyperparameterTitle];
+            console.log(dialogResult);
+            
             node = new CustomNodeModel({ name: "Hyperparameter (Float): " + floatValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
 
@@ -117,10 +120,10 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         } else {
 
-            const dialogOptions = inputDialog('Boolean', "", 'Boolean');
+            const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const boolValue = dialogResult["value"]['Boolean'];
+            const boolValue = dialogResult["value"][hyperparameterTitle];
             node = new CustomNodeModel({ name: "Hyperparameter (Boolean): " + boolValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
 
@@ -139,10 +142,10 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         } else {
 
-            const dialogOptions = inputDialog('List', "", 'List');
+            const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const listValue = dialogResult["value"]['List'];
+            const listValue = dialogResult["value"][hyperparameterTitle];
             node = new CustomNodeModel({ name: "Hyperparameter (List): " + listValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
 
@@ -161,10 +164,10 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         } else {
 
-            const dialogOptions = inputDialog('Tuple', "", 'Tuple');
+            const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const tupleValue = dialogResult["value"]['Tuple'];
+            const tupleValue = dialogResult["value"][hyperparameterTitle];
             node = new CustomNodeModel({ name: "Hyperparameter (Tuple): " + tupleValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
         }
@@ -182,10 +185,10 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         } else {
 
-            const dialogOptions = inputDialog('Dict', "", 'Dict');
+            const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const dictValue = dialogResult["value"]['Dict'];
+            const dictValue = dialogResult["value"][hyperparameterTitle];
             node = new CustomNodeModel({ name: "Hyperparameter (Dict): " + dictValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
 


### PR DESCRIPTION
# Description

This will fix run dialog for hyperparameter node. Also, fix the width of `integer` and `float` input.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Add any hyperparameter node.
2. Please input the prompted dialog.
3. Connect to any node with the correct type.
4. Save and click run
5. The dialog prompt should display what you define at step (2) and show its type
6. Make sure the hyperparameter node is able to use properly by clicking `Run` in the dialog.

## Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  