### PR TITLE
🐛 Fix Extra Ports for Start and Finish Nodes

### DIFF
--- a/examples/KerasModelPredict.xircuits
+++ b/examples/KerasModelPredict.xircuits
@@ -182,27 +182,13 @@
                             ],
                             "in": false,
                             "label": "▶"
-                        },
-                        {
-                            "id": "0f10d023-f677-4be2-a64d-61cf0ea4a7b7",
-                            "type": "default",
-                            "x": 71.92187261745666,
-                            "y": 95.2812314389357,
-                            "name": "parameter-out-1",
-                            "alignment": "right",
-                            "parentNode": "c0aea849-8cc3-4005-be9c-a90d1c07f923",
-                            "links": [],
-                            "in": false,
-                            "label": "  "
                         }
                     ],
                     "name": "Start",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "d4448be4-dea1-41e8-9f4f-b60f9fc85349",
-                        "0f10d023-f677-4be2-a64d-61cf0ea4a7b7"
-                    ]
+                        "d4448be4-dea1-41e8-9f4f-b60f9fc85349"                    ]
                 },
                 "51d28ed7-01a1-489c-a3d0-b97d8e728d6b": {
                     "id": "51d28ed7-01a1-489c-a3d0-b97d8e728d6b",
@@ -228,25 +214,12 @@
                             ],
                             "in": true,
                             "label": "▶"
-                        },
-                        {
-                            "id": "0050b880-4ba5-4d80-a879-d5a94e3718ac",
-                            "type": "default",
-                            "x": 714.4062494394014,
-                            "y": 95.87498508282563,
-                            "name": "parameter-in-1",
-                            "alignment": "left",
-                            "parentNode": "51d28ed7-01a1-489c-a3d0-b97d8e728d6b",
-                            "links": [],
-                            "in": true,
-                            "label": "  "
                         }
                     ],
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "8d112ff6-070f-4baa-8082-55ae3daf620c",
-                        "0050b880-4ba5-4d80-a879-d5a94e3718ac"
+                        "8d112ff6-070f-4baa-8082-55ae3daf620c"
                     ],
                     "portsOutOrder": []
                 },

--- a/examples/KerasTrainImageClassifier.xircuits
+++ b/examples/KerasTrainImageClassifier.xircuits
@@ -491,27 +491,13 @@
                             ],
                             "in": false,
                             "label": "▶"
-                        },
-                        {
-                            "id": "1f742844-3d9b-4818-a7c3-4daba263ff78",
-                            "type": "default",
-                            "x": 128.825,
-                            "y": 70.675,
-                            "name": "parameter-out-1",
-                            "alignment": "right",
-                            "parentNode": "8ec5f3e7-30bc-4ffe-9362-99a9a7475fe8",
-                            "links": [],
-                            "in": false,
-                            "label": "  "
                         }
                     ],
                     "name": "Start",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "ea0d5274-a264-4e83-be99-98dfd344b694",
-                        "1f742844-3d9b-4818-a7c3-4daba263ff78"
-                    ]
+                        "ea0d5274-a264-4e83-be99-98dfd344b694"                    ]
                 },
                 "b9e041cf-27c7-4488-ada4-6623adb0ab30": {
                     "id": "b9e041cf-27c7-4488-ada4-6623adb0ab30",
@@ -537,25 +523,12 @@
                             ],
                             "in": true,
                             "label": "▶"
-                        },
-                        {
-                            "id": "e8a1caeb-514f-4d71-8afa-77d5cf4dac5e",
-                            "type": "default",
-                            "x": 1440.8,
-                            "y": 181.775,
-                            "name": "parameter-in-1",
-                            "alignment": "left",
-                            "parentNode": "b9e041cf-27c7-4488-ada4-6623adb0ab30",
-                            "links": [],
-                            "in": true,
-                            "label": "  "
                         }
                     ],
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "82ffb26d-208f-4c04-8b2c-c5342aae2641",
-                        "e8a1caeb-514f-4d71-8afa-77d5cf4dac5e"
+                        "82ffb26d-208f-4c04-8b2c-c5342aae2641"
                     ],
                     "portsOutOrder": []
                 },

--- a/examples/SparkLinePlot.xircuits
+++ b/examples/SparkLinePlot.xircuits
@@ -350,26 +350,13 @@
                             ],
                             "in": false,
                             "label": "▶"
-                        },
-                        {
-                            "id": "9bf69daf-f9c5-4257-992f-0796d9b45ba7",
-                            "type": "default",
-                            "x": 89.2031346483071,
-                            "y": 74.14062186501575,
-                            "name": "parameter-out-1",
-                            "alignment": "right",
-                            "parentNode": "9a3e5d27-ad2e-4b65-a152-672ff5a069b5",
-                            "links": [],
-                            "in": false,
-                            "label": "  "
                         }
                     ],
                     "name": "Start",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "2480113b-4f4e-47a4-a91f-04b884da053e",
-                        "9bf69daf-f9c5-4257-992f-0796d9b45ba7"
+                        "2480113b-4f4e-47a4-a91f-04b884da053e"
                     ]
                 },
                 "88141312-0e4f-4392-8360-e5fd4b4367d1": {
@@ -395,25 +382,12 @@
                             ],
                             "in": true,
                             "label": "▶"
-                        },
-                        {
-                            "id": "148977e1-4118-4e3b-aae6-5aaadc5f4b3e",
-                            "type": "default",
-                            "x": 890.9999596536393,
-                            "y": 248.14061186608214,
-                            "name": "parameter-in-1",
-                            "alignment": "left",
-                            "parentNode": "88141312-0e4f-4392-8360-e5fd4b4367d1",
-                            "links": [],
-                            "in": true,
-                            "label": "  "
                         }
                     ],
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "0cc541b7-8e80-42c8-9fe7-ae79b1321b24",
-                        "148977e1-4118-4e3b-aae6-5aaadc5f4b3e"
+                        "0cc541b7-8e80-42c8-9fe7-ae79b1321b24"
                     ],
                     "portsOutOrder": []
                 },

--- a/examples/SparkLogisticRegressionSample.xircuits
+++ b/examples/SparkLogisticRegressionSample.xircuits
@@ -435,27 +435,13 @@
                             ],
                             "in": false,
                             "label": "▶"
-                        },
-                        {
-                            "id": "33c3a630-8288-4f4d-af80-b44a426d96e4",
-                            "type": "default",
-                            "x": 141.10938082620586,
-                            "y": 82.10936864787011,
-                            "name": "parameter-out-1",
-                            "alignment": "right",
-                            "parentNode": "9e648a24-3bbe-4d23-b31a-636df680a8ef",
-                            "links": [],
-                            "in": false,
-                            "label": "  "
                         }
                     ],
                     "name": "Start",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "8d6d0811-a3e2-4123-9cb5-f0f597c7a666",
-                        "33c3a630-8288-4f4d-af80-b44a426d96e4"
-                    ]
+                        "8d6d0811-a3e2-4123-9cb5-f0f597c7a666"                    ]
                 },
                 "ae7fc483-2d2d-4e73-a001-f43931dd4b39": {
                     "id": "ae7fc483-2d2d-4e73-a001-f43931dd4b39",
@@ -481,26 +467,12 @@
                             ],
                             "in": true,
                             "label": "▶"
-                        },
-                        {
-                            "id": "05163df4-8de8-4816-ba6d-086cec7e962e",
-                            "type": "default",
-                            "x": 1262.4374651207495,
-                            "y": 406.17189264506106,
-                            "name": "parameter-in-1",
-                            "alignment": "left",
-                            "parentNode": "ae7fc483-2d2d-4e73-a001-f43931dd4b39",
-                            "links": [],
-                            "in": true,
-                            "label": "  "
                         }
                     ],
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "ec6dbcc6-77d8-4919-a02b-ce1e515f0c3d",
-                        "05163df4-8de8-4816-ba6d-086cec7e962e"
-                    ],
+                        "ec6dbcc6-77d8-4919-a02b-ce1e515f0c3d"                    ],
                     "portsOutOrder": []
                 },
                 "06aa24db-f410-4d64-b75a-9d6ba9523250": {

--- a/examples/SparkPackageVenv.xircuits
+++ b/examples/SparkPackageVenv.xircuits
@@ -523,26 +523,13 @@
                             ],
                             "in": false,
                             "label": "▶"
-                        },
-                        {
-                            "id": "903129c7-2f6f-438f-a7c7-549a62892881",
-                            "type": "default",
-                            "x": -26.156242144505256,
-                            "y": 83.54687114434485,
-                            "name": "parameter-out-1",
-                            "alignment": "right",
-                            "parentNode": "b5daecce-45ec-492e-ad41-5f1d211b8f00",
-                            "links": [],
-                            "in": false,
-                            "label": "  "
                         }
                     ],
                     "name": "Start",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "0fd1020e-95f1-44d0-a830-cb74ed882f85",
-                        "903129c7-2f6f-438f-a7c7-549a62892881"
+                        "0fd1020e-95f1-44d0-a830-cb74ed882f85"
                     ]
                 },
                 "6edcb94a-d6dc-48f6-afd2-b8f6e24287fe": {
@@ -569,25 +556,12 @@
                             ],
                             "in": true,
                             "label": "▶"
-                        },
-                        {
-                            "id": "8fd82677-a3b9-464a-bd43-355ff3ff3915",
-                            "type": "default",
-                            "x": 1085.8750285891551,
-                            "y": 86.31250078409192,
-                            "name": "parameter-in-1",
-                            "alignment": "left",
-                            "parentNode": "6edcb94a-d6dc-48f6-afd2-b8f6e24287fe",
-                            "links": [],
-                            "in": true,
-                            "label": "  "
                         }
                     ],
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "76b1128e-8bf5-4f58-a201-5413561b7601",
-                        "8fd82677-a3b9-464a-bd43-355ff3ff3915"
+                        "76b1128e-8bf5-4f58-a201-5413561b7601"
                     ],
                     "portsOutOrder": []
                 },

--- a/examples/SparkSQLPlotBar.xircuits
+++ b/examples/SparkSQLPlotBar.xircuits
@@ -434,27 +434,13 @@
                             ],
                             "in": false,
                             "label": "▶"
-                        },
-                        {
-                            "id": "07e10895-cb31-4eaa-b432-d93fdd44f2e8",
-                            "type": "default",
-                            "x": 84.20313134661713,
-                            "y": 94.14062726399794,
-                            "name": "parameter-out-1",
-                            "alignment": "right",
-                            "parentNode": "867a89f7-0711-46d2-84cf-969e891db82c",
-                            "links": [],
-                            "in": false,
-                            "label": "  "
                         }
                     ],
                     "name": "Start",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "70695e04-f534-4781-9632-edea5690b4fc",
-                        "07e10895-cb31-4eaa-b432-d93fdd44f2e8"
-                    ]
+                        "70695e04-f534-4781-9632-edea5690b4fc"                    ]
                 },
                 "9d575810-382c-4763-a0df-7eb87594b3e1": {
                     "id": "9d575810-382c-4763-a0df-7eb87594b3e1",
@@ -479,25 +465,12 @@
                             ],
                             "in": true,
                             "label": "▶"
-                        },
-                        {
-                            "id": "312e0621-e268-45e9-a331-b82f48a47b5c",
-                            "type": "default",
-                            "x": 1150.437501039212,
-                            "y": 409.21877880102227,
-                            "name": "parameter-in-1",
-                            "alignment": "left",
-                            "parentNode": "9d575810-382c-4763-a0df-7eb87594b3e1",
-                            "links": [],
-                            "in": true,
-                            "label": "  "
                         }
                     ],
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "ea8458de-21d3-49fb-a66d-2c74e5dedfbd",
-                        "312e0621-e268-45e9-a331-b82f48a47b5c"
+                        "ea8458de-21d3-49fb-a66d-2c74e5dedfbd"
                     ],
                     "portsOutOrder": []
                 },

--- a/examples/UtilsZipDirectory.xircuits
+++ b/examples/UtilsZipDirectory.xircuits
@@ -239,26 +239,13 @@
                             ],
                             "in": false,
                             "label": "▶"
-                        },
-                        {
-                            "id": "903129c7-2f6f-438f-a7c7-549a62892881",
-                            "type": "default",
-                            "x": 121.53126713121263,
-                            "y": 82.3750069346073,
-                            "name": "parameter-out-1",
-                            "alignment": "right",
-                            "parentNode": "b5daecce-45ec-492e-ad41-5f1d211b8f00",
-                            "links": [],
-                            "in": false,
-                            "label": "  "
                         }
                     ],
                     "name": "Start",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "0fd1020e-95f1-44d0-a830-cb74ed882f85",
-                        "903129c7-2f6f-438f-a7c7-549a62892881"
+                        "0fd1020e-95f1-44d0-a830-cb74ed882f85"
                     ]
                 },
                 "6edcb94a-d6dc-48f6-afd2-b8f6e24287fe": {
@@ -285,25 +272,12 @@
                             ],
                             "in": true,
                             "label": "▶"
-                        },
-                        {
-                            "id": "8fd82677-a3b9-464a-bd43-355ff3ff3915",
-                            "type": "default",
-                            "x": 823.8125063997566,
-                            "y": 84.74999888601526,
-                            "name": "parameter-in-1",
-                            "alignment": "left",
-                            "parentNode": "6edcb94a-d6dc-48f6-afd2-b8f6e24287fe",
-                            "links": [],
-                            "in": true,
-                            "label": "  "
                         }
                     ],
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "76b1128e-8bf5-4f58-a201-5413561b7601",
-                        "8fd82677-a3b9-464a-bd43-355ff3ff3915"
+                        "76b1128e-8bf5-4f58-a201-5413561b7601"
                     ],
                     "portsOutOrder": []
                 },


### PR DESCRIPTION
# Description

Earlier Xircuits workflows has an extra port for the Start and Finish nodes. This PR removes them. The updated workflows are:

- KerasModelPredict
- KerasTrainImageClassifier
- SparkLinePlot
- SparkLogisticRegression
- SparkPackageVenv
- SparkSQLPlotBar
- UtilsZipDirectory

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

### 1. Integrity Check 

1. Clone the repo, checkout to `fahreza/fix-original-ports`, install xircuits
2. Verify that the above examples does not have extra ports.
3. Verify that you are able to compile and run it. You don't have to run all of them.


## Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Add if any.
