### PR TITLE
✨Directly connect parameter inPort to its literal node

### DIFF
--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -745,6 +745,16 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		return pythonCode;
 	}
 
+	const showErrorDialog = (title: string, errorMsg: string) => {
+		showDialog({
+			title,
+			body: (
+				<pre>{errorMsg}</pre>
+			),
+			buttons: [Dialog.warnButton({ label: 'OK' })]
+		});
+	}
+
 	const checkAllNodesConnected = (): boolean | null => {
 		let nodeModels = xircuitsApp.getDiagramEngine().getModel().getNodes();
 
@@ -1585,7 +1595,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		let portType = linkName.split("-")[1];
 		let nodeType: string = portType;
 		let varInput: string = '';
-
+		let errorMsg: string;
 		switch (portType) {
 			case 'int':
 				nodeType = 'Integer';
@@ -1608,10 +1618,15 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 				if (portAnyType == undefined) return;
 				nodeType = portAnyType.nodeType;
 				varInput = portAnyType.varInput;
+				errorMsg = portAnyType.errorMsg;
 				break;
 			default:
 				nodeType = portType.charAt(0).toUpperCase() + portType.slice(1);
 				break;
+		}
+		if (errorMsg != undefined) {
+			showErrorDialog('Error : Input have non-numeric values', errorMsg);
+			return;
 		}
 		let current_node = await fetchNodeByName('Literal ' + nodeType);
 		let node = await GeneralComponentLibrary({ model: current_node, variableValue: varInput });

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -1625,7 +1625,11 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 				break;
 		}
 		if (errorMsg != undefined) {
-			showErrorDialog('Error : Input have non-numeric values', errorMsg);
+			if (nodeType == ('Float' || 'Integer')) {
+				showErrorDialog('Error : Input have non-numeric values', errorMsg);
+			} else {
+				showErrorDialog('Error : Type undefined', errorMsg);
+			}
 			return;
 		}
 		let current_node = await fetchNodeByName('Literal ' + nodeType);

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -1605,6 +1605,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			case 'any':
 				// When inPort is 'any' type, get the correct literal type based on the first character inputed
 				let portAnyType = await getItsLiteralType();
+				if (portAnyType == undefined) return;
 				nodeType = portAnyType.nodeType;
 				varInput = portAnyType.varInput;
 				break;

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -34,24 +34,27 @@ export async function getItsLiteralType(){
 	if (cancelDialog(dialogResult)) return;
 	const varValue = dialogResult["value"][varOfAnyTypeTitle];
 	const varType = varValue.charAt(0);
+	const varInput : string = varValue.slice(1);
 	switch (varType) {
 		case '"':
-			nodeType = 'String'
+			nodeType = 'String';
 			break;
 		case '#':
-			nodeType = 'Integer'
-			break;
-		case '.':
-			nodeType = 'Float'
+			const isInputFloat = varInput.search('.');
+			if (isInputFloat == 0) {
+				nodeType = 'Float';
+			} else {
+				nodeType = 'Integer';
+			}
 			break;
 		case '[':
-			nodeType = 'List'
+			nodeType = 'List';
 			break;
 		case '(':
-			nodeType = 'Tuple'
+			nodeType = 'Tuple';
 			break;
 		case '{':
-			nodeType = 'Dict'
+			nodeType = 'Dict';
 			break;
 		case '!':
 			let boolValue = varValue.slice(1);
@@ -60,19 +63,19 @@ export async function getItsLiteralType(){
 				case 'True':
 				case '1':
 				case 't':
-					nodeType = 'True'
+					nodeType = 'True';
 					break;
 				case 'false':
 				case 'False':
 				case '0':
 				case 'nil':
-					nodeType = 'False'
+					nodeType = 'False';
 					break;
 			}
 			break;
 		default:
 			// When type is undefined, set to string type
-			nodeType = 'String'
+			nodeType = 'String';
 			break;
 	}
 	let varInput = varValue.slice(1);
@@ -107,6 +110,7 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 					<p>Determine your variable type by inserting the first char as below: </p>
 					<li> " : String</li>
 					<li> # : Integer</li>
+					<li> # with '.' : Float</li>
 					<li> [ : List</li>
 					<li> ( : Tuple</li>
 					<li> {dictSymbol} : Dict</li>

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 import { formDialogWidget } from "./formDialogwidget";
 import { Dialog } from '@jupyterlab/apputils';
 import Switch from "react-switch";
+import { showFormDialog } from './FormDialog';
+import { cancelDialog } from '../tray_library/GeneralComponentLib';
 
 export function inputDialog(titleName: string, oldValue: any, type: string, isStoreDataType?: boolean, inputType?: string) {
 	let title = titleName;
@@ -21,6 +23,60 @@ export function inputDialog(titleName: string, oldValue: any, type: string, isSt
 		focusNodeSelector: inputType == 'textarea' ? 'textarea' : 'input'
 	};
 	return dialogOptions;
+}
+
+export async function getItsLiteralType(){
+	// When inPort is 'any' type, get the correct literal type based on the first character inputed
+	let nodeType: string;
+	let varOfAnyTypeTitle = 'Enter your variable value';
+	const dialogOptions = inputDialog(varOfAnyTypeTitle, "", 'Variable');
+	const dialogResult = await showFormDialog(dialogOptions);
+	if (cancelDialog(dialogResult)) return;
+	const varValue = dialogResult["value"][varOfAnyTypeTitle];
+	const varType = varValue.charAt(0);
+	switch (varType) {
+		case '"':
+			nodeType = 'String'
+			break;
+		case '#':
+			nodeType = 'Integer'
+			break;
+		case '.':
+			nodeType = 'Float'
+			break;
+		case '[':
+			nodeType = 'List'
+			break;
+		case '(':
+			nodeType = 'Tuple'
+			break;
+		case '{':
+			nodeType = 'Dict'
+			break;
+		case '!':
+			let boolValue = varValue.slice(1);
+			switch (boolValue) {
+				case 'true':
+				case 'True':
+				case '1':
+				case 't':
+					nodeType = 'True'
+					break;
+				case 'false':
+				case 'False':
+				case '0':
+				case 'nil':
+					nodeType = 'False'
+					break;
+			}
+			break;
+		default:
+			// When type is undefined, set to string type
+			nodeType = 'String'
+			break;
+	}
+	let varInput = varValue.slice(1);
+	return { nodeType, varInput}
 }
 
 export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inputType }): JSX.Element => {
@@ -42,6 +98,21 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 			return (
 				<h5 style={{ marginTop: 0, marginBottom: 5 }}>
 					For Example: "a", "b", "c"
+				</h5>
+			);
+		} else if (type == 'Variable'){
+			let dictSymbol = '{';
+			return (
+				<h5 style={{ marginTop: 0, marginBottom: 5 }}>
+					<p>Determine your variable type by inserting the first char as below: </p>
+					<li> " : String</li>
+					<li> # : Integer</li>
+					<li> [ : List</li>
+					<li> ( : Tuple</li>
+					<li> {dictSymbol} : Dict</li>
+					<li> !true / !True / !1 / !t : True</li>
+					<li> !false / !False / !0 / !nil : False</li>
+					<p>For Example: "Hello World or #15 or !true</p>
 				</h5>
 			);
 		}
@@ -72,11 +143,12 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 			);
 		} else if (type == 'Boolean') {
 			return (
-				<div style={{ paddingLeft: 5 }}>
+				<div style={{ paddingLeft: 5, paddingTop: 5}}>
 					<Switch
 						checked={checked}
 						name={title}
 						onChange={() => handleChecked()}
+						boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
 						handleDiameter={25}
 						height={20}
 						width={48}
@@ -87,7 +159,8 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 			(type == 'String' && inputType != 'textarea') ||
 			type == 'List' ||
 			type == 'Tuple' ||
-			type == 'Dict'
+			type == 'Dict' || 
+			type == 'Variable'
 		) {
 			return (
 				<input
@@ -101,7 +174,7 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 
 	return (
 		<form>
-			{type != 'Boolean' ?
+			{type != 'Boolean' && type != 'Variable' ?
 				<h3 style={{ marginTop: 0, marginBottom: 5 }}>
 					Enter {title.includes('parameter') ? 'Hyperparameter Name' : `${type} Value`} ({isStoreDataType ? 'Without Brackets' : 'Without Quotes'}):
 				</h3>

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -35,12 +35,18 @@ export async function getItsLiteralType(){
 	const varValue = dialogResult["value"][varOfAnyTypeTitle];
 	const varType = varValue.charAt(0);
 	const varInput : string = varValue.slice(1);
+	let errorMsg : string;
 	switch (varType) {
 		case '"':
 			nodeType = 'String';
 			break;
 		case '#':
 			const isInputFloat = varInput.search('.');
+			let onlyNum = Number(varInput);
+			if (isNaN(onlyNum)){
+				errorMsg = `Variable's input (${varInput}) contain non-numeric value. Only allow '.' for Float` ;
+				break;
+			}
 			if (isInputFloat == 0) {
 				nodeType = 'Float';
 			} else {
@@ -78,8 +84,7 @@ export async function getItsLiteralType(){
 			nodeType = 'String';
 			break;
 	}
-	let varInput = varValue.slice(1);
-	return { nodeType, varInput}
+	return { nodeType, varInput, errorMsg}
 }
 
 export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inputType }): JSX.Element => {

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -80,8 +80,8 @@ export async function getItsLiteralType(){
 			}
 			break;
 		default:
-			// When type is undefined, set to string type
-			nodeType = 'String';
+			// When type is undefined, show error
+			errorMsg = `Type is undefined or not provided. Please insert the first chararacter as shown in example` ;
 			break;
 	}
 	return { nodeType, varInput, errorMsg}

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -3,9 +3,10 @@ import { inputDialog } from "../dialog/LiteralInputDialog";
 import { showFormDialog } from "../dialog/FormDialog";
 interface GeneralComponentLibraryProps{
     model : any;
+    variableValue?: any;
 }
 
-function cancelDialog(dialogResult) {
+export function cancelDialog(dialogResult) {
     if (dialogResult["button"]["label"] == 'Cancel') {
         // When Cancel is clicked on the dialog, just return
         return true;
@@ -16,8 +17,13 @@ function cancelDialog(dialogResult) {
 export async function GeneralComponentLibrary(props: GeneralComponentLibraryProps){
     let node = null;
     const nodeData = props.model;
+    const variableValue = props.variableValue;
     const nodeName = nodeData.task;
     const hyperparameterTitle = 'Please define parameter';
+    let inputValue;
+    if (variableValue != ''){
+        inputValue = variableValue;
+    }
     // For now, comment this first until we've use for it
     // if (props.type === 'math') {
 
@@ -44,42 +50,43 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
     if (nodeData.type === 'string') {
 
         if ((nodeName).startsWith("Literal")) {
-            const dialogOptions = inputDialog('String', "", 'String', false ,'textarea');
-            const dialogResult = await showFormDialog(dialogOptions);
-            if (cancelDialog(dialogResult)) return;
-            const strValue = dialogResult["value"]['String'];
+            if (variableValue == '') {
+                const dialogOptions = inputDialog('String', "", 'String', false ,'textarea');
+                const dialogResult = await showFormDialog(dialogOptions);
+                if (cancelDialog(dialogResult)) return;
+                inputValue = dialogResult["value"]['String'];
+            }
 
             node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(strValue, 'out-0');
+            node.addOutPortEnhance(inputValue, 'out-0');
         }
         else {
-
             const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const strValue = dialogResult["value"][hyperparameterTitle];
-            node = new CustomNodeModel({ name: "Hyperparameter (String): " + strValue, color: nodeData.color, extras: { "type": nodeData.type } });
+            inputValue = dialogResult["value"][hyperparameterTitle];
+            node = new CustomNodeModel({ name: "Hyperparameter (String): " + inputValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
-
         }
 
     } else if (nodeData.type === 'int') {
 
         if ((nodeName).startsWith("Literal")) {
-
-            const dialogOptions = inputDialog('Integer', "", 'Integer');
-            const dialogResult = await showFormDialog(dialogOptions);
-            if (cancelDialog(dialogResult)) return;
-            const intValue = dialogResult["value"]['Integer'];
+            if (variableValue == '') {
+                const dialogOptions = inputDialog('Integer', "", 'Integer');
+                const dialogResult = await showFormDialog(dialogOptions);
+                if (cancelDialog(dialogResult)) return;
+                inputValue = dialogResult["value"]['Integer'];
+            }
             node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(intValue, 'out-0');
+            node.addOutPortEnhance(inputValue, 'out-0');
 
         } else {
             const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const intValue = dialogResult["value"][hyperparameterTitle];
-            node = new CustomNodeModel({ name: "Hyperparameter (Int): " + intValue, color: nodeData.color, extras: { "type": nodeData.type } });
+            inputValue = dialogResult["value"][hyperparameterTitle];
+            node = new CustomNodeModel({ name: "Hyperparameter (Int): " + inputValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
 
         }
@@ -87,23 +94,24 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
     } else if (nodeData.type === 'float') {
 
         if ((nodeName).startsWith("Literal")) {
-
-            const dialogOptions = inputDialog('Float', "", 'Float');
-            const dialogResult = await showFormDialog(dialogOptions);
-            if (cancelDialog(dialogResult)) return;
-            const floatValue = dialogResult["value"]['Float'];
+            if (variableValue == '') {
+                const dialogOptions = inputDialog('Float', "", 'Float');
+                const dialogResult = await showFormDialog(dialogOptions);
+                if (cancelDialog(dialogResult)) return;
+                inputValue = dialogResult["value"]['Float'];
+            }
             node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(floatValue, 'out-0');
+            node.addOutPortEnhance(inputValue, 'out-0');
 
         } else {
 
             const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const floatValue = dialogResult["value"][hyperparameterTitle];
+            inputValue = dialogResult["value"][hyperparameterTitle];
             console.log(dialogResult);
             
-            node = new CustomNodeModel({ name: "Hyperparameter (Float): " + floatValue, color: nodeData.color, extras: { "type": nodeData.type } });
+            node = new CustomNodeModel({ name: "Hyperparameter (Float): " + inputValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
 
         }
@@ -123,8 +131,8 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
             const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const boolValue = dialogResult["value"][hyperparameterTitle];
-            node = new CustomNodeModel({ name: "Hyperparameter (Boolean): " + boolValue, color: nodeData.color, extras: { "type": nodeData.type } });
+            inputValue = dialogResult["value"][hyperparameterTitle];
+            node = new CustomNodeModel({ name: "Hyperparameter (Boolean): " + inputValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
 
         }
@@ -133,20 +141,22 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         if ((nodeName).startsWith("Literal")) {
 
-            const dialogOptions = inputDialog('List', "", 'List', true);
-            const dialogResult = await showFormDialog(dialogOptions);
-            if (cancelDialog(dialogResult)) return;
-            const listValue = dialogResult["value"]['List'];
+            if (variableValue == '') {
+                const dialogOptions = inputDialog('List', "", 'List', true);
+                const dialogResult = await showFormDialog(dialogOptions);
+                if (cancelDialog(dialogResult)) return;
+                inputValue = dialogResult["value"]['List'];
+            }
             node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(listValue, 'out-0');
+            node.addOutPortEnhance(inputValue, 'out-0');
 
         } else {
 
             const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const listValue = dialogResult["value"][hyperparameterTitle];
-            node = new CustomNodeModel({ name: "Hyperparameter (List): " + listValue, color: nodeData.color, extras: { "type": nodeData.type } });
+            inputValue = dialogResult["value"][hyperparameterTitle];
+            node = new CustomNodeModel({ name: "Hyperparameter (List): " + inputValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
 
         }
@@ -155,20 +165,22 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         if ((nodeName).startsWith("Literal")) {
 
-            const dialogOptions = inputDialog('Tuple', "", 'Tuple', true);
-            const dialogResult = await showFormDialog(dialogOptions);
-            if (cancelDialog(dialogResult)) return;
-            const tupleValue = dialogResult["value"]['Tuple'];
+            if (variableValue == '') {
+                const dialogOptions = inputDialog('Tuple', "", 'Tuple', true);
+                const dialogResult = await showFormDialog(dialogOptions);
+                if (cancelDialog(dialogResult)) return;
+                inputValue = dialogResult["value"]['Tuple'];
+            }
             node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(tupleValue, 'out-0');
+            node.addOutPortEnhance(inputValue, 'out-0');
 
         } else {
 
             const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const tupleValue = dialogResult["value"][hyperparameterTitle];
-            node = new CustomNodeModel({ name: "Hyperparameter (Tuple): " + tupleValue, color: nodeData.color, extras: { "type": nodeData.type } });
+            inputValue = dialogResult["value"][hyperparameterTitle];
+            node = new CustomNodeModel({ name: "Hyperparameter (Tuple): " + inputValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
         }
 
@@ -176,20 +188,22 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         if ((nodeName).startsWith("Literal")) {
 
-            const dialogOptions = inputDialog('Dict', "", 'Dict', true);
-            const dialogResult = await showFormDialog(dialogOptions);
-            if (cancelDialog(dialogResult)) return;
-            const dictValue = dialogResult["value"]['Dict'];
+            if (variableValue == '') {
+                const dialogOptions = inputDialog('Dict', "", 'Dict', true);
+                const dialogResult = await showFormDialog(dialogOptions);
+                if (cancelDialog(dialogResult)) return;
+                inputValue = dialogResult["value"]['Dict'];
+            }
             node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(dictValue, 'out-0');
+            node.addOutPortEnhance(inputValue, 'out-0');
 
         } else {
 
             const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
-            const dictValue = dialogResult["value"][hyperparameterTitle];
-            node = new CustomNodeModel({ name: "Hyperparameter (Dict): " + dictValue, color: nodeData.color, extras: { "type": nodeData.type } });
+            inputValue = dialogResult["value"][hyperparameterTitle];
+            node = new CustomNodeModel({ name: "Hyperparameter (Dict): " + inputValue, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance('▶', 'parameter-out-0');
 
         }

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -50,7 +50,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
     if (nodeData.type === 'string') {
 
         if ((nodeName).startsWith("Literal")) {
-            if (variableValue == '') {
+            if (variableValue == '' || variableValue == undefined) {
                 const dialogOptions = inputDialog('String', "", 'String', false ,'textarea');
                 const dialogResult = await showFormDialog(dialogOptions);
                 if (cancelDialog(dialogResult)) return;
@@ -72,7 +72,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
     } else if (nodeData.type === 'int') {
 
         if ((nodeName).startsWith("Literal")) {
-            if (variableValue == '') {
+            if (variableValue == '' || variableValue == undefined) {
                 const dialogOptions = inputDialog('Integer', "", 'Integer');
                 const dialogResult = await showFormDialog(dialogOptions);
                 if (cancelDialog(dialogResult)) return;
@@ -94,7 +94,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
     } else if (nodeData.type === 'float') {
 
         if ((nodeName).startsWith("Literal")) {
-            if (variableValue == '') {
+            if (variableValue == '' || variableValue == undefined) {
                 const dialogOptions = inputDialog('Float', "", 'Float');
                 const dialogResult = await showFormDialog(dialogOptions);
                 if (cancelDialog(dialogResult)) return;
@@ -141,7 +141,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         if ((nodeName).startsWith("Literal")) {
 
-            if (variableValue == '') {
+            if (variableValue == '' || variableValue == undefined) {
                 const dialogOptions = inputDialog('List', "", 'List', true);
                 const dialogResult = await showFormDialog(dialogOptions);
                 if (cancelDialog(dialogResult)) return;
@@ -165,7 +165,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         if ((nodeName).startsWith("Literal")) {
 
-            if (variableValue == '') {
+            if (variableValue == '' || variableValue == undefined) {
                 const dialogOptions = inputDialog('Tuple', "", 'Tuple', true);
                 const dialogResult = await showFormDialog(dialogOptions);
                 if (cancelDialog(dialogResult)) return;
@@ -188,7 +188,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         if ((nodeName).startsWith("Literal")) {
 
-            if (variableValue == '') {
+            if (variableValue == '' || variableValue == undefined) {
                 const dialogOptions = inputDialog('Dict', "", 'Dict', true);
                 const dialogResult = await showFormDialog(dialogOptions);
                 if (cancelDialog(dialogResult)) return;


### PR DESCRIPTION
# Description

This will automatically connect to its literal node when link is dropped from a parameter `InPort`. There are 2 type of implementation:

1. `Non-any` type - Drag a link should automatically render the correct literal node.

![non-any type literal](https://user-images.githubusercontent.com/84708008/190984128-7fd60102-6078-4dc6-87b7-ce420c662b0f.gif)

2. `any` type - The literal node's type is render based on the **first character of the given input**.

![any type literal](https://user-images.githubusercontent.com/84708008/190984991-023255c1-e1f3-465c-b1f2-b6eb3f955e99.gif)

Types taken into consideration for `any` type are :

1. 1 - Int
2. . - Float
4. " - String
5. [ - List
6. ( - Tuple
7. { - dict
8. !true / !True/ !1/ !t - True
9. !false / !False / !0 / !nil - False

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Drag link from `non-any` type `InPorts`
   1. Drag a node which have `inPorts` with `non-any` type
   4. Dropped a link from the port
   5. A input dialog should popup based on its type
   6. Insert any input and submit it
   7. That port should be connected to its literal node 
2. Drag link from `any` type `InPorts`
   1. Drag a node which have `inPorts` with `any` type
   2. Dropped a link from the port
   3. A input dialog should popup
   4. Insert the first character mentioned above based on the type you want. Follow by, the input and submit it.
   5. That port should be connected to its literal node.

## Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  