### PR TITLE
Make input ports support multiple input types

### DIFF
--- a/src/components/port/CustomPortLabel.tsx
+++ b/src/components/port/CustomPortLabel.tsx
@@ -64,6 +64,12 @@ export class CustomPortLabel extends React.Component<CustomPortLabelProps> {
 		} else {
 			portType = portName.split("-")[1];
 		}
+		// if multiple types provided, show the symbol for the first provided type
+		if (portType.includes(',')) {
+			portType = portType.replace('Union', '');
+			portType = portType.replace(/[\[\]]/g, '');
+			portType = portType.split(',')[0];
+		}
 
 		switch (portType) {
 			case "string":

--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -73,8 +73,8 @@ export  class CustomPortModel extends DefaultPortModel  {
         const thisLabel: string = "**" + port.getOptions()["label"] + "**";
         const sourcePortName: string = thisPort.getName();
         const thisPortType: string = thisName.split('-')[1];
-        const thisPortTypeText: string = "*`" + thisPortType + "`*";
         const sourcePortType: string = sourcePortName.split('-')[2];
+        let thisPortTypeText: string = "*`" + thisPortType + "`*";
 
         if (this.isParameterNode(thisNodeModelType) == true){
             // if the port you are trying to link ready has other links
@@ -82,6 +82,10 @@ export  class CustomPortModel extends DefaultPortModel  {
             console.log("parameter port: ", port.getNode().getInPorts());
             if (Object.keys(port.getLinks()).length > 0){
 		        port.getNode().getOptions().extras["borderColor"]="red";
+                // if port supports multiple types
+                if (thisPortTypeText.includes(',')) {
+                    thisPortTypeText = this.parsePortType(thisPortTypeText);
+                }
 		        port.getNode().getOptions().extras["tip"]=`Port ${thisLabel} doesn't allow multi-links of ${thisPortTypeText} type.`;
                 port.getNode().setSelected(true);
                 return false;
@@ -105,14 +109,24 @@ export  class CustomPortModel extends DefaultPortModel  {
             let thisLinkedName = port.getNode().getInPorts()[index].getOptions()["name"];
             let regEx = /\-([^-]+)\-/;
             let result = thisLinkedName.match(regEx);
+            let thisLinkedPortType = result[1];
 
-            if(thisNodeModelType != result[1]){
+            if(thisNodeModelType != thisLinkedPortType){
                 // Skip 'any' type check
-                if(result[1] == 'any'){
+                if(thisLinkedPortType == 'any'){
+                    return;
+                }
+                // if multiple types are accepted by target node port, check if source port type is among them
+                if(thisLinkedPortType.includes(thisNodeModelType)) {
                     return;
                 }
 		        port.getNode().getOptions().extras["borderColor"]="red";
-		        port.getNode().getOptions().extras["tip"]= `Incorrect data type. Port ${thisLabel} is a type ` + "*`" + result[1] + "`*.";
+
+                // if a list of types is provided for the port, parse it a bit to display it nicer
+                if (thisLinkedPortType.includes(',')) {
+                    thisLinkedPortType = this.parsePortType(thisLinkedPortType)
+                }
+		        port.getNode().getOptions().extras["tip"]= `Incorrect data type. Port ${thisLabel} is of type ` + "*`" + thisLinkedPortType + "`*.";
                 port.getNode().setSelected(true);
                 //tested - add stuff
                 return false;
@@ -291,6 +305,19 @@ export  class CustomPortModel extends DefaultPortModel  {
         }
 
         return true;
+    }
+
+    /**
+     * When a port supports multiple types, parse them to display them nicer
+     * Parsed type looks like: type1 or type2
+     * @param portType - unparsed port type (looks like: "Union[type1, type2]")
+     */
+    parsePortType = (portType: string) => {
+        // port type is of form: Union[type1, type2]
+        portType = portType.replace('Union', '');    // remove Union word
+        portType = portType.replace(/[\[\]]/g, '');  // remove square brackets
+        portType = portType.replace(', ', ' or ');
+        return portType;
     }
 
 }

--- a/src/tray_library/AdvanceComponentLib.tsx
+++ b/src/tray_library/AdvanceComponentLib.tsx
@@ -47,6 +47,16 @@ export function AdvancedComponentLibrary(props: AdvancedComponentLibraryProps) {
     nodeData["variables"].forEach(variable => {
         let name = variable["name"];
         let type = type_name_remappings[variable["type"]] || variable["type"];
+        // if node type includes comma, then multiple types are accepted for that node (ex: str,float; str,int; etc.)
+        if (type.includes(',')) {
+            // take care of remapping, even when multiple types are accepted for the node
+            for (let mapping in type_name_remappings) {
+                type = type.replace(mapping, type_name_remappings[mapping]);
+            }
+        }
+        else {
+            type = type_name_remappings[type] || type;
+        }
 
         switch (variable["kind"]) {
             case "InCompArg":

--- a/xai_components/xai_multiple_types_test/multiple_types_test.py
+++ b/xai_components/xai_multiple_types_test/multiple_types_test.py
@@ -1,0 +1,18 @@
+from typing import Union
+
+from xai_components.base import InArg, Component, xai_component
+
+
+@xai_component(color='rgb(85, 37, 130)')
+class MultipleTypesTest(Component):
+    a: InArg[Union[float, int]]
+
+    def __init__(self):
+        self.done = False
+        self.a = InArg(None)
+
+    def execute(self, ctx) -> None:
+        print(self.a.value)
+        print(type(self.a.value))
+
+


### PR DESCRIPTION

# Description

Hello! 
I am part of the TVB team that has been using the Xircuits extension for a while to develop our own JupyterLab extension (see [tvb-ext-xircuits](https://github.com/the-virtual-brain/tvb-ext-xircuits))
As part of our development process, we found that we needed to have input ports that support more than just one input type (for example floats _and_ ints). So, we implemented this feature and wanted to ask if you would find it appropriate to merge this feature in your original code base.

On the React side we worked mostly on the validation part, when trying to link a Literal to an input port.

On the Python side there was no modification, but if you want to use this feature you should specify in your component's code that an input argument accepts multiple types. You should do it like this: `a: InArg[Union[float, int]]`. I also provided an example component with such a port to demonstrate how it can be used.


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Happy flow**

 1. Drag the MultipleTypesTest component on the canvas.
 2. Drag a Literal Float on the canvas.
 3. Try linking the float to the component's only port. Link the Start and Finish nodes and the run the workflow. Parameter a's value and type will be displayed. 
 4. Redo step 2 and 3 using a Literal Integer.


**2. Unhappy flow**

1. Drag the MultipleTypesTest component on the canvas.
2. Drag a Literal String on the canvas.
3. Try linking the string to the component's only port. An error message will be displayed: Incorrect data type. Port a is of type float or int.



## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

