### PR TITLE
🐛 Fix compulsory inPort args in new compiler

### DIFF
--- a/xircuits/compiler/compiler.py
+++ b/xircuits/compiler/compiler.py
@@ -17,7 +17,7 @@ def compile(input_file, output_file, component_python_paths=None):
 def main():
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument('source_file', type=argparse.FileType('r'))
+    parser.add_argument('source_file', type=argparse.FileType('r', encoding='utf-8'))
     parser.add_argument('out_file', type=argparse.FileType('w'))
     parser.add_argument("python_paths_file", nargs='?', default=None, type=argparse.FileType('r'),
                         help="JSON file with a mapping of component name to required python path. "

--- a/xircuits/compiler/parser.py
+++ b/xircuits/compiler/parser.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from xircuits.compiler.node import Node
 from xircuits.compiler.port import Port
@@ -11,6 +12,7 @@ class XircuitsFileParser:
         self.links = {}
 
     def parse(self, input_file):
+
         xircuits_file = json.load(input_file)
 
         self.nodes = [n for n in xircuits_file['layers'] if n['type'] == 'diagram-nodes'][0]['models']
@@ -38,6 +40,7 @@ class XircuitsFileParser:
 
     def traverse_ports(self, node):
         out = []
+
         for port in node['ports']:
             for linkId in port['links']:
                 link = self.links[linkId]
@@ -47,12 +50,16 @@ class XircuitsFileParser:
 
                 sourceLabel = [p for p in source_node['ports'] if p['id'] == link['sourcePort']][0]['label']
 
+                # filter compulsory port [★] label from port name
+                sourceLabel = re.sub(r"★", "", sourceLabel)
+                targetLabel = re.sub(r"★", "", port['label'])
+
                 p = Port(
                     name=port['name'],
                     type=link['type'],
                     target=self.traverse_node(target_node),
                     source=self.traverse_node(source_node),
-                    targetLabel=port['label'],
+                    targetLabel=targetLabel,
                     sourceLabel=sourceLabel,
                     direction="in" if port['in'] else "out"
                 )

--- a/xircuits/handlers/compile_xircuits.py
+++ b/xircuits/handlers/compile_xircuits.py
@@ -25,7 +25,7 @@ class CompileXircuitsFileRouteHandler(APIHandler):
 
         component_python_paths = input_data["pythonPaths"]
 
-        with open(self.__get_notebook_absolute_path__(input_file_path), 'r') as infile:
+        with open(self.__get_notebook_absolute_path__(input_file_path), 'r', encoding='utf-8') as infile:
             with open(self.__get_notebook_absolute_path__(output_file_path), 'w') as outfile:
                 compile(infile, outfile, component_python_paths)
 


### PR DESCRIPTION
# Description

Currently the new compiler does not compile any xircuits canvas that has compulsory inPorts which is indicated as [★]. As currently Xircuits bakes the ★ into the label, it breaks the compiler due to ★ being a a special character. 
This PR updates the compiler to read .xircuits files using utf-8 encoding, then filters ★ from port strings.

## References
https://github.com/XpressAI/xircuits/pull/209
https://github.com/XpressAI/xircuits/issues/210

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests
Take the wheel and try compiling `examples/KerasTrainImageClassifier.xircuits`. It should correctly compile.


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

In the future we should rethink baking the ★ in the label.