### PR TITLE
🐛 Fix Save and compile run from not compiling correctly

### DIFF
--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -562,7 +562,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		return true;
 	}
 
-	const handleSaveClick = () => {
+	const handleSaveClick = async () => {
 		// Only save xircuit if it is currently in focus
 		// This must be first to avoid unnecessary complication
 		if (shell.currentWidget?.id !== widgetId) {
@@ -571,7 +571,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		onChange()
 		setInitialize(true);
 		setSaved(true);
-		commands.execute(commandIDs.saveDocManager);
+		await commands.execute(commandIDs.saveDocManager);
 	}
 
 	const handleCompileClick = () => {


### PR DESCRIPTION
# Description

This PR fixes the bug that happens when a user presses compile and run without saving. The dialog will offer to save the canvas, but it is not saved by the time it is parsed by the compiler, and therefore will incorrectly run the previous state of the workflow.

To reproduce:
1. Create a new xircuits file
2.  Complete a workflow
3. Without pressing save -> compile, run Xircuits file.

Previously:
A python file will be generated, but it will be empty.

With this PR:
The compilation will perform correctly. 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests
1. Create a new xircuits file
2.  Complete a workflow
3. Without pressing save -> compile, run Xircuits file. 
Verify that the compilation is performed correctly. 

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

