### PR TITLE
Make initializing In/OutArgs automatic.

### DIFF
--- a/xai_components/base.py
+++ b/xai_components/base.py
@@ -56,6 +56,19 @@ class ExecutionContext:
 
 
 class BaseComponent:
+
+    def __init__(self):
+        all_ports = self.__annotations__
+        for key, type_arg in all_ports.items():
+            if isinstance(type_arg, InArg[any].__class__):
+                setattr(self, key, InArg.empty())
+            elif isinstance(type_arg, InCompArg[any].__class__):
+                setattr(self, key, InCompArg.empty())
+            elif isinstance(type_arg, OutArg[any].__class__):
+                setattr(self, key, OutArg.empty())
+            elif type_arg == str(self.__class__):
+                setattr(self, key, None)
+
     @classmethod
     def set_execution_context(cls, context: ExecutionContext) -> None:
         cls.execution_context = context
@@ -70,6 +83,10 @@ class BaseComponent:
 class Component(BaseComponent):
     next: BaseComponent
     done: bool
+
+    def __init__(self):
+        super().__init__()
+        self.done = False
 
     def do(self, ctx) -> Tuple[bool, BaseComponent]:
         print(f"\nExecuting: {self.__class__.__name__}")

--- a/xai_components/xai_controlflow/branches.py
+++ b/xai_components/xai_controlflow/branches.py
@@ -1,17 +1,13 @@
 from xai_components.base import InArg, OutArg, InCompArg, Component, BaseComponent, xai_component
 
 @xai_component
-class BranchComponent(BaseComponent):
+class BranchComponent(Component):
     when_true: BaseComponent
     when_false: BaseComponent
     done: bool
 
     condition: InArg[bool]
     
-    def __init__(self):
-        self.done = False
-        self.condition = InArg.empty()
-
     def do(self, ctx) -> BaseComponent:
         if self.condition.value:
             next = self.when_true
@@ -30,10 +26,6 @@ class LoopComponent(Component):
 
     condition: InArg[bool]
     
-    def __init__(self):
-        self.done = False
-        self.condition = InArg.empty()
-
     def do(self, ctx) -> BaseComponent:
         while self.condition.value:
             is_done, next_body = self.body.do(ctx)
@@ -51,10 +43,7 @@ class CounterComponent(Component):
     state: any
     
     def __init__(self):
-        self.done = False
-        self.start_number = InArg.empty()
-        self.step = InArg.empty()
-        self.out_number = OutArg.empty()
+        super().__init__()
         self.state = None
         
     def execute(self, ctx) -> None:
@@ -73,14 +62,6 @@ class ComparisonComponent(Component):
     
     out: OutArg[bool]
 
-    
-    def __init__(self):
-        self.done = False
-        self.a = InArg.empty()
-        self.b = InArg.empty()
-        self.op = InArg.empty()
-        self.out = OutArg.empty()
-        
     def execute(self, ctx) -> None:
         self.out.value = eval(str(self.a.value) + " " + self.op.value + " " + str(self.b.value))
 
@@ -105,8 +86,7 @@ class GetVariableComponent(Component):
     value: OutArg[any]
     
     def __init__(self):
-        self.done = False
-        self.name = InArg.empty()
+        super().__init__()
         self.value = MutableVariable()
         
     def execute(self, ctx) -> None:
@@ -116,12 +96,7 @@ class GetVariableComponent(Component):
 class SetVariableComponent(Component):
     name: InArg[str]
     value: InArg[any]
-    
-    def __init__(self):
-        self.done = False
-        self.name = InArg.empty()
-        self.value = InArg.empty()
-        
+
     def execute(self, ctx) -> None:
         ctx[self.name.value] = self.value.value
 
@@ -134,9 +109,7 @@ class DefineVariableComponent(Component):
 
     
     def __init__(self):
-        self.done = False
-        self.name = InArg.empty()
-        self.value = InArg.empty()
+        super().__init__()
         self.ref = MutableVariable()
         
     def execute(self, ctx) -> None:

--- a/xai_components/xai_pytorch/quickstart.py
+++ b/xai_components/xai_pytorch/quickstart.py
@@ -30,14 +30,6 @@ class LoadTorchVisionDataset(Component):
     training_data: OutArg[torch.utils.data.Dataset]
     test_data: OutArg[torch.utils.data.Dataset]
 
-    def __init__(self):
-        self.done = False
-        self.dataset_name = InCompArg(None)
-        self.dataset_dir = InArg(None)
-
-        self.training_data = OutArg(None)
-        self.test_data = OutArg(None)
-
 
     def execute(self,ctx) -> None:
 
@@ -90,16 +82,6 @@ class TorchDataLoader(Component):
     train_dataloader: OutArg[torch.utils.data.DataLoader]
     test_dataloader: OutArg[torch.utils.data.DataLoader]
 
-    def __init__(self):
-        self.done = False
-
-        self.training_data = InCompArg(None)
-        self.test_data = InCompArg(None)
-        self.batch_size = InArg(None)
-
-        self.train_dataloader = OutArg(None)
-        self.test_dataloader = OutArg(None)
-
     def execute(self,ctx) -> None:
 
         from torch.utils.data import DataLoader
@@ -132,13 +114,6 @@ class ExampleTorchModelConfig(Component):
     model_config: OutArg[nn.Module]
     loss_fn: OutArg[any]
     optimizer: OutArg[any]
-
-    def __init__(self):
-        self.done = False
-
-        self.model_config = OutArg(None)
-        self.loss_fn = OutArg(None)
-        self.optimizer = OutArg(None)
 
     def execute(self,ctx) -> None:
         
@@ -196,17 +171,6 @@ class TrainTorchModel(Component):
 
     trained_model: OutArg[nn.Module]
 
-    def __init__(self):
-        self.done = False
-
-        self.train_dataloader = InCompArg(None)
-        self.model_config = InCompArg(None)
-        self.loss_fn = InCompArg(None)
-        self.optimizer = InCompArg(None)
-        self.epochs = InArg(None)
-        
-        self.trained_model = OutArg(None)
-
     def execute(self,ctx) -> None:
 
         dataloader = self.train_dataloader.value
@@ -254,13 +218,7 @@ class TestTorchModel(Component):
 
     loss_fn: InCompArg[any]
     
-    def __init__(self):
-        self.done = False
-        
-        self.model = InCompArg(None)
-        self.test_dataloader = InCompArg(None)
-        self.loss_fn = InCompArg(None)
-        
+
     def execute(self,ctx) -> None:
         
         dataloader = self.test_dataloader.value
@@ -297,12 +255,6 @@ class SaveTorchModelState(Component):
     model: InCompArg[nn.Module]
     model_path: InArg[str]
 
-    def __init__(self):
-        self.done = False
-
-        self.model = InCompArg(None)
-        self.model_path = InArg(None)
-
     def execute(self,ctx) -> None:
         
         model_path = self.model_path.value if self.model_path.value else os.path.splitext(sys.argv[0])[0] + ".pth"
@@ -325,14 +277,6 @@ class LoadTorchModelState(Component):
     model_path: InCompArg[str]
 
     loaded_model: OutArg[nn.Module]
-
-    def __init__(self):
-
-        self.done = False
-        self.model_config = InCompArg(None)
-        self.model_path = InCompArg(None)
-
-        self.loaded_model = OutArg(None)
 
     def execute(self,ctx) -> None:
 
@@ -357,13 +301,6 @@ class TorchModelPredict(Component):
     model: InCompArg[nn.Module]
     test_data: InCompArg[any]
     class_list: InCompArg[list]
-
-    def __init__(self):
-
-        self.done = False
-        self.model = InCompArg(None)
-        self.test_data = InCompArg(None)
-        self.class_list = InCompArg(None)
 
     def execute(self,ctx) -> None:
 
@@ -398,14 +335,6 @@ class Image2TorchTensor(Component):
     resize: InArg[tuple]
 
     tensor: OutArg[torch.Tensor]
-
-    def __init__(self):
-
-        self.done = False
-        self.img_path = InCompArg(None)
-        self.resize = InArg(None)
-
-        self.tensor = OutArg(None)
 
     def execute(self,ctx) -> None:
 
@@ -442,13 +371,6 @@ class TorchModelPredictFromTensor(Component):
     model: InCompArg[nn.Module]
     tensor: InCompArg[torch.Tensor]
     class_list: InCompArg[list]
-
-    def __init__(self):
-
-        self.done = False
-        self.model = InCompArg(None)
-        self.tensor = InCompArg(None)
-        self.class_list = InCompArg(None)
 
     def execute(self,ctx) -> None:
 

--- a/xai_components/xai_pytorch/torch_nn_layers.py
+++ b/xai_components/xai_pytorch/torch_nn_layers.py
@@ -28,16 +28,9 @@ class TorchModel(Component):
     optimizer: OutArg[any]
 
     def __init__(self):
-        self.done = False
-
-        self.model_in = InArg.empty()
-        self.loss_in = InArg.empty()
-        self.learning_rate = InArg(1e-3)
-        self.optimizer_in = InArg.empty()
-        self.should_flatten = InArg(False)
-        self.model_config = OutArg.empty()
-        self.loss_fn = OutArg.empty()
-        self.optimizer = OutArg.empty()
+        super().__init__()
+        self.learning_rate.value = 1e-3
+        self.should_flatten.value = False
 
     def execute(self,ctx) -> None:
         should_flatten = self.should_flatten.value
@@ -99,15 +92,6 @@ class TorchAddLinearLayer(Component):
     bias: InArg[bool]
     model_out: OutArg[list]
 
-    def __init__(self):
-        self.done = False
-
-        self.model_in = InArg.empty()
-        self.in_features = InArg.empty()
-        self.out_features = InArg.empty()
-        self.bias = InArg.empty()
-        self.model_out = OutArg.empty()
-
     def execute(self,ctx) -> None:
         bias = True if self.bias.value is None else False
         in_size = self.in_features.value
@@ -139,21 +123,14 @@ class TorchAddConv1DLayer(Component):
 
 
     def __init__(self):
-        self.done = False
-
-        self.model_in = InArg.empty()
-
-        self.in_channels = InCompArg.empty()
-        self.out_channels = InCompArg.empty()
-        self.kernel_size = InCompArg.empty()
-        self.stride = InArg(1)
-        self.padding = InArg(0)
-        self.dilation = InArg(1)
-        self.groups = InArg(1)
-        self.bias = InArg(True)
-        self.padding_mode = InArg('zeros')
-
-        self.model_out = OutArg.empty()
+        super().__init__()
+        self.stride.value = 1
+        self.padding.value = 0
+        self.dilation.value = 1
+        self.groups.value = 1
+        self.bias.value = True
+        self.padding_mode.value = 'zeros'
+        
 
     def execute(self,ctx) -> None:
 
@@ -193,21 +170,13 @@ class TorchAddConv2DLayer(Component):
 
 
     def __init__(self):
-        self.done = False
-
-        self.model_in = InArg.empty()
-
-        self.in_channels = InCompArg.empty()
-        self.out_channels = InCompArg.empty()
-        self.kernel_size = InCompArg.empty()
-        self.stride = InArg(1)
-        self.padding = InArg(0)
-        self.dilation = InArg(1)
-        self.groups = InArg(1)
-        self.bias = InArg(True)
-        self.padding_mode = InArg('zeros')
-
-        self.model_out = OutArg.empty()
+        super().__init__()
+        self.stride.value = 1
+        self.padding.value = 0
+        self.dilation.value = 1
+        self.groups.value = 1
+        self.bias.value = True
+        self.padding_mode.value = 'zeros'
 
     def execute(self,ctx) -> None:
 
@@ -245,20 +214,14 @@ class TorchAddTransformerEncoderLayer(Component):
 
 
     def __init__(self):
-        self.done = False
+        super().__init__()
 
-        self.model_in = InArg.empty()
-
-        self.d_model = InCompArg.empty()
-        self.nhead = InCompArg.empty()
-        self.dim_feedforward = InArg(2048)
-        self.dropout = InArg(0.1)
-        self.activation = InArg('relu')
-        self.layer_norm_eps = InArg(1e-05)
-        self.batch_first = InArg(False)
-        self.norm_first = InArg(False)
-
-        self.model_out = OutArg.empty()
+        self.dim_feedforward.value = 2048
+        self.dropout.value = 0.1
+        self.activation.value = 'relu'
+        self.layer_norm_eps.value = 1e-05
+        self.batch_first.value = False
+        self.norm_first.value = False
 
     def execute(self,ctx) -> None:
 
@@ -295,20 +258,13 @@ class TorchAddTransformerDecoderLayer(Component):
 
 
     def __init__(self):
-        self.done = False
-
-        self.model_in = InArg.empty()
-
-        self.d_model = InCompArg.empty()
-        self.nhead = InCompArg.empty()
-        self.dim_feedforward = InArg(2048)
-        self.dropout = InArg(0.1)
-        self.activation = InArg('relu')
-        self.layer_norm_eps = InArg(1e-05)
-        self.batch_first = InArg(False)
-        self.norm_first = InArg(False)
-
-        self.model_out = OutArg.empty()
+        super().__init__()
+        self.dim_feedforward.value = 2048
+        self.dropout.value = 0.1
+        self.activation.value = 'relu'
+        self.layer_norm_eps.value = 1e-05
+        self.batch_first.value = False
+        self.norm_first.value = False
 
     def execute(self,ctx) -> None:
 
@@ -346,20 +302,14 @@ class TorchLSTM(Component):
 
 
     def __init__(self):
-        self.done = False
+        super().__init__()
 
-        self.model_in = InArg.empty()
-
-        self.input_size = InCompArg.empty()
-        self.hidden_size = InCompArg.empty()
-        self.num_layers = InArg(1)
-        self.bias = InArg(True)
-        self.batch_first = InArg(False)
-        self.dropout = InArg(0)
-        self.bidirectional = InArg(False)
-        self.proj_size = InArg(0)
-
-        self.model_out = OutArg.empty()
+        self.num_layers.value = 1
+        self.bias.value = True
+        self.batch_first.value = False
+        self.dropout.value = 0
+        self.bidirectional.value = False
+        self.proj_size.value = 0
 
     def execute(self,ctx) -> None:
 
@@ -383,13 +333,7 @@ class TorchAddReluLayer(Component):
     
     model_in: InArg[list]
     model_out: OutArg[list]
-    
-    def __init__(self):
-        self.done = False
-        
-        self.model_in = InArg.empty()
-        self.model_out = OutArg.empty()
-    
+
     def execute(self, ctx) -> None:
         if self.model_in.value is None:
             self.model_out.value = [nn.ReLU()]
@@ -403,13 +347,7 @@ class TorchAddDropoutLayer(Component):
     model_in: InArg[list]
     prob_zero: InArg[float]
     model_out: OutArg[list]
-    
-    def __init__(self):
-        self.done = False
-        
-        self.model_in = InArg.empty()
-        self.prob_zero = InArg.empty()
-        self.model_out = OutArg.empty()
+
     
     def execute(self, ctx) -> None:
         prob = 0.5

--- a/xai_components/xai_spark/pyspark_core.py
+++ b/xai_components/xai_spark/pyspark_core.py
@@ -34,15 +34,6 @@ class xSparkSession(Component):
     config: InArg[str]
     sparksession: OutArg[any]
 
-    def __init__(self):
-
-        self.done = False
-        self.master = InArg(None)
-        self.appname = InArg(None)
-        self.config = InArg(None)
-        self.sparksession = OutArg(None)
-
-
     def execute(self, ctx) -> None:
 
         master_url = self.master.value if self.master.value else "local"
@@ -80,16 +71,6 @@ class SparkReadPandas(Component):
     out_sparksession: OutArg[any]
     out_dataframe: OutArg[any]
 
-
-    def __init__(self):
-
-        self.done = False
-        self.in_sparksession = InCompArg(None)
-        self.pandas_dataframe = InCompArg(None)
-        self.out_sparksession = OutArg(None)
-        self.out_dataframe = OutArg(None)
-
-
     def execute(self, ctx) -> None:
 
         spark = self.in_sparksession.value
@@ -119,15 +100,6 @@ class SparkReadFile(Component):
     file_input: InCompArg[str]
     out_sparksession: OutArg[any]
     out_dataframe: OutArg[any]
-
-    def __init__(self):
-
-        self.done = False
-        self.in_sparksession = InCompArg(None)
-        self.file_input = InCompArg(None)
-        self.out_sparksession = OutArg(None)
-        self.out_dataframe = OutArg(None)
-
 
     def execute(self, ctx) -> None:
 
@@ -180,17 +152,6 @@ class SparkReadCSV(Component):
     out_sparksession: OutArg[any]
     out_dataframe: OutArg[any]
 
-    def __init__(self):
-
-        self.done = False
-        self.in_sparksession = InCompArg(None)
-        self.file_input = InCompArg(None)
-        self.separator = InArg(None)
-        self.header = InArg(True)
-        self.out_sparksession = OutArg(None)
-        self.out_dataframe = OutArg(None)
-
-
     def execute(self, ctx) -> None:
 
         spark = self.in_sparksession.value
@@ -228,12 +189,8 @@ class SparkWriteFile(Component):
     out_sparksession: OutArg[any]
 
     def __init__(self):
-
-        self.done = False
-        self.dataframe = InCompArg(None)
-        self.output_name = InCompArg(None)
-        self.header = InArg(True)
-        self.out_sparksession = OutArg(None)
+        super().__init__()
+        self.header.value = True
 
     def execute(self, ctx) -> None:
 
@@ -274,18 +231,6 @@ class SparkSQL(Component):
 
     out_sparksession: OutArg[any]
     sql_dataframe: OutArg[any]
-
-
-    def __init__(self):
-
-        self.done = False
-        self.in_sparksession = InCompArg(None)
-        self.dataframe = InCompArg(None)
-        self.sql_string = InCompArg(None)
-        self.table_name = InArg(None)
-
-        self.out_sparksession = OutArg(None)
-        self.sql_dataframe = OutArg(None)
 
     def execute(self, ctx) -> None:
 
@@ -328,16 +273,6 @@ class SparkVisualize(Component):
     x_axis: InCompArg[str]
     y_axis: InArg[str]
     output_name: InArg[str]
-
-    def __init__(self):
-        
-        self.done = False
-        self.dataframe = InCompArg(None)
-        self.plot_type = InArg(None)
-        self.x_axis = InCompArg(None)
-        self.y_axis = InArg(None)    
-        self.output_name = InArg(None)    
-
 
     def execute(self, ctx) -> None:
         

--- a/xai_components/xai_spark/pyspark_mllib.py
+++ b/xai_components/xai_spark/pyspark_mllib.py
@@ -25,12 +25,6 @@ class SparkSparseVector(Component):
     vector_list: InCompArg[list]
     sparse_vector: OutArg[SparseVector]
 
-    def __init__(self):
-
-        self.done = False
-        self.vector_list = InCompArg(None)
-        self.sparse_vector = OutArg(None)
-
     def execute(self, ctx) -> None:
         
         from pyspark.mllib.linalg import SparseVector
@@ -69,16 +63,6 @@ class SparkLabeledPoint(Component):
 
     labeled_point: OutArg[any]
 
-
-    def __init__(self):
-
-        self.done = False
-        self.label = InCompArg(None)
-        self.dense_vector = InArg(None)
-        self.sparse_vector = InArg(None)
-
-        self.labeled_point = OutArg(None)
-
     def execute(self, ctx) -> None:
         
         from pyspark.mllib.regression import LabeledPoint
@@ -113,16 +97,6 @@ class SparkLoadImageFolder(Component):
 
     out_sparksession: OutArg[any]
     out_dataframe: OutArg[any]
-
-    def __init__(self):
-
-        self.done = False
-        self.in_sparksession = InCompArg(None)
-        self.folder_path = InCompArg(None)
-
-        self.out_sparksession = OutArg(None)
-        self.out_dataframe = OutArg(None)
-
 
     def execute(self, ctx) -> None:
 
@@ -160,19 +134,6 @@ class SparkSplitDataFrame(Component):
 
     train_dataframe: OutArg[any]
     test_dataframe: OutArg[any]
-
-
-    def __init__(self):
-
-        self.done = False
-        self.in_dataframe = InArg(None)
-        self.train_split = InArg(None)
-        self.seed = InArg(None)
-
-        self.train_dataframe = OutArg(None)
-        self.test_dataframe = OutArg(None)
-
-
 
     def execute(self, ctx) -> None:
 
@@ -212,17 +173,6 @@ class SparkLoadLIBSVM(Component):
     options: InArg[any]
     out_sparksession: OutArg[any]
     out_dataframe: OutArg[any]
-
-    def __init__(self):
-
-        self.done = False
-        self.in_sparksession = InCompArg(None)
-        self.file_input = InCompArg(None)
-        self.options = InArg(None)
-
-        self.out_sparksession = OutArg(None)
-        self.out_dataframe = OutArg(None)
-
 
     def execute(self, ctx) -> None:
 
@@ -266,16 +216,6 @@ class SparkLogisticRegression(Component):
 
     model: OutArg[any]
 
-    def __init__(self):
-
-        self.done = False
-        self.train_dataframe = InCompArg(None)
-        self.family = InArg(None)
-        self.options = InArg(None)
-
-        self.model = OutArg(None)
-
-
     def execute(self, ctx) -> None:
 
         from pyspark.ml.classification import LogisticRegression
@@ -316,12 +256,6 @@ class SparkPredict(Component):
     """    
     model: InCompArg[any]
     test_df: InCompArg[any]
-
-    def __init__(self):
-
-        self.done = False
-        self.model = InCompArg(None)
-        self.test_df = InCompArg(None)
 
     def execute(self, ctx) -> None:
 

--- a/xai_components/xai_template/example_components.py
+++ b/xai_components/xai_template/example_components.py
@@ -4,10 +4,6 @@ from xai_components.base import InArg, OutArg, InCompArg, Component, BaseCompone
 class HelloComponent(Component):
     """The simplest component that greets the user. 
     """
-    def __init__(self):
-
-        self.done = False
-
     def execute(self, ctx) -> None:
         
         #If the import is only exclusive to 1 component, it is a good practice to import inside execute()
@@ -27,11 +23,6 @@ class HelloHyperparameter(Component):
     - input_str: try connecting a Literal String or Hyperparameter String.
     """
     input_str: InArg[str]
-
-    def __init__(self):
-
-        self.done = False
-        self.input_str = InArg.empty()
 
     def execute(self, ctx) -> None:
         input_str = self.input_str.value
@@ -53,12 +44,6 @@ class CompulsoryHyperparameter(Component):
     #if your component requires a certain parameter to be supplied, use In-Comp(ulsory)-Argument ports.
     comp_str: InCompArg[str]
     comp_int: InCompArg[int]
-
-    def __init__(self):
-        self.done = False
-        self.input_str = InArg.empty()
-        self.comp_str = InCompArg.empty()
-        self.comp_int = InCompArg.empty()
 
     def execute(self, ctx) -> None:
         input_str = self.input_str.value
@@ -83,12 +68,6 @@ class HelloListTupleDict(Component):
     input_list: InArg[list]
     input_tuple: InArg[tuple]
     input_dict: InArg[dict]
-
-    def __init__(self):
-        self.done = False
-        self.input_tuple = InArg.empty()
-        self.input_list = InArg.empty()
-        self.input_dict = InArg.empty()
 
     def execute(self, ctx) -> None:
 
@@ -120,10 +99,6 @@ class HelloContext(Component):
     """
     context_dict: InArg[dict]
 
-    def __init__(self):
-        self.done = False
-        self.context_dict = InArg.empty()
-
     def execute(self, ctx) -> None:
         
         print(f"Current Context:\n{ctx}")
@@ -143,10 +118,6 @@ class MultiBranchComponent(BaseComponent):
     done: bool
 
     abc: InArg[str]
-    
-    def __init__(self):
-        self.done = False
-        self.abc = InArg.empty()
 
     def do(self, ctx) -> BaseComponent:
         if self.abc.value == "a":

--- a/xai_components/xai_tensorflow_keras/keras_transfer_learning.py
+++ b/xai_components/xai_tensorflow_keras/keras_transfer_learning.py
@@ -69,19 +69,16 @@ class KerasTransferLearningModel(Component):
     model: OutArg[any]
 
     def __init__(self):
-        self.done = False
-        self.base_model_name = InArg.empty()
-        self.include_top = InArg(True)
-        self.weights = InArg("imagenet")
-        self.input_shape = InArg.empty()
-        self.freeze_all = InArg(True)
-        self.fine_tune_from = InArg(0)
-        self.classes = InArg(1000)
-        self.binary = InArg(False)
-        self.classifier_activation = InArg("softmax")
-        self.kwargs = InArg({})
+        super().__init__()
 
-        self.model = OutArg.empty()
+        self.include_top.value = True
+        self.weights.value = "imagenet"
+        self.freeze_all.value = True
+        self.fine_tune_from.value = 0
+        self.classes.value = 1000
+        self.binary.value = False
+        self.classifier_activation.value = "softmax"
+        self.kwargs.value = {}
 
     def execute(self, ctx):
 
@@ -209,15 +206,11 @@ class TFDataset(Component):
 
     def __init__(self):
         self.done = False
-        self.dataset_name = InCompArg.empty()
-        self.batch_size = InArg(32)
-        self.shuffle_files = InArg(False)
-        self.as_supervised = InArg(True)
-        self.kwargs = InArg({})
 
-        self.all_data = OutArg.empty()
-        self.train_data = OutArg.empty()
-        self.test_data = OutArg.empty()
+        self.batch_size.value = 32
+        self.shuffle_files.value = False
+        self.as_supervised.value = True
+        self.kwargs.value = {}
 
     def execute(self, ctx):
         import tensorflow_datasets as tfds
@@ -267,16 +260,8 @@ class TrainKerasModel(Component):
     training_metrics: OutArg[dict]
 
     def __init__(self):
-        self.done = False
-
-        self.model = InCompArg.empty()
-        self.training_data = InCompArg.empty()
-        self.batch_size = InCompArg.empty()
-        self.epochs = InCompArg.empty()
-        self.kwargs = InArg({})
-
-        self.trained_model = OutArg.empty()
-        self.training_metrics = OutArg.empty()
+        super().__init__()
+        self.kwargs.value = {}
 
     def execute(self, ctx):
 
@@ -320,12 +305,6 @@ class TFDSEvaluateAccuracy(Component):
     eval_dataset: InCompArg[any]
 
     metrics: OutArg[Dict[str, str]]
-
-    def __init__(self):
-        self.done = False
-        self.model = InCompArg.empty()
-        self.eval_dataset = InCompArg.empty()
-        self.metrics = OutArg.empty()
 
     def execute(self, ctx):
 
@@ -385,16 +364,6 @@ class KerasModelCompiler(Component):
     compiled_model: OutArg[any]
     model_config: OutArg[dict]
 
-    def __init__(self):
-        self.done = False
-        self.model = InCompArg.empty()
-        self.optimizer_identifier = InCompArg.empty()
-        self.loss_identifier = InCompArg.empty()
-        self.metrics = InCompArg.empty()
-
-        self.compiled_model = OutArg.empty()
-        self.model_config = OutArg.empty()
-
     def execute(self, ctx):
 
         assert isinstance(
@@ -430,11 +399,6 @@ class SaveKerasModel(Component):
     """
     model: InCompArg[any]
     model_name: InCompArg[any]
-
-    def __init__(self):
-        self.done = False
-        self.model = InCompArg.empty()
-        self.model_name = InCompArg.empty()
 
     def execute(self, ctx):
 

--- a/xai_components/xai_tensorflow_keras/tf_keras.py
+++ b/xai_components/xai_tensorflow_keras/tf_keras.py
@@ -59,19 +59,6 @@ class LoadKerasModel(Component):
 
     model: OutArg[any]
 
-    def __init__(self):
-        self.done = False
-        self.model_name = InCompArg(None)
-        self.include_top = InArg(None)
-        self.weights = InArg(None)
-        self.input_tensor = InArg(None)
-        self.pooling = InArg(None)
-        self.classes = InArg(None)
-        self.args = InArg(None)
-
-        self.model = OutArg(None)
-
-
     def execute(self,ctx) -> None:
 
         args = self.args.value if self.args.value else {}
@@ -108,13 +95,6 @@ class KerasPredict(Component):
     img_string: InCompArg[str]
     class_list: InArg[any]
     target_shape: InArg[tuple]
-
-    def __init__(self):
-        self.done = False
-        self.model = InCompArg(None)
-        self.img_string = InCompArg(None)
-        self.class_list = InArg(None)
-        self.target_shape = InArg(None)
 
     def execute(self, ctx) -> None:
         model = self.model.value
@@ -284,17 +264,6 @@ class ResNet50(Component):
     kwargs: InArg[int]
     model: OutArg[any]
 
-    def __init__(self):
-        self.done = False
-        self.include_top = InArg(None)
-        self.weights = InArg(None)
-        self.input_tensor = InArg(None)
-        self.pooling = InArg(None)
-        self.classes = InArg(None)
-        self.kwargs = InArg(None)
-        self.model = OutArg(None)
-
-
     def execute(self, ctx) -> None:
         model_config = resnet_model_config()
 
@@ -368,17 +337,6 @@ class ResNet101(Component):
     classes: InArg[int]
     kwargs: InArg[int]
     model: OutArg[any]
-
-    def __init__(self):
-        self.done = False
-        self.include_top = InArg(None)
-        self.weights = InArg(None)
-        self.input_tensor = InArg(None)
-        self.pooling = InArg(None)
-        self.classes = InArg(None)
-        self.kwargs = InArg(None)
-        self.model = OutArg(None)
-
 
     def execute(self, ctx) -> None:
         model_config = resnet_model_config()
@@ -454,17 +412,6 @@ class ResNet152(Component):
     classes: InArg[int]
     kwargs: InArg[int]
     model: OutArg[any]
-
-    def __init__(self):
-        self.done = False
-        self.include_top = InArg(None)
-        self.weights = InArg(None)
-        self.input_tensor = InArg(None)
-        self.pooling = InArg(None)
-        self.classes = InArg(None)
-        self.kwargs = InArg(None)
-        self.model = OutArg(None)
-
 
     def execute(self, ctx) -> None:
         model_config = resnet_model_config()
@@ -564,17 +511,6 @@ class VGG16(Component):
     classifier_activation: InArg[int]
     model: OutArg[any]
 
-    def __init__(self):
-        self.done = False
-        self.include_top = InArg(None)
-        self.weights = InArg(None)
-        self.input_tensor = InArg(None)
-        self.pooling = InArg(None)
-        self.classes = InArg(None)
-        self.classifier_activation = InArg(None)
-        self.model = OutArg(None)
-
-
     def execute(self, ctx) -> None:
 
         model_config = vgg_model_config()
@@ -655,17 +591,6 @@ class VGG19(Component):
     classifier_activation: InArg[int]
     model: OutArg[any]
 
-    def __init__(self):
-        self.done = False
-        self.include_top = InArg(None)
-        self.weights = InArg(None)
-        self.input_tensor = InArg(None)
-        self.pooling = InArg(None)
-        self.classes = InArg(None)
-        self.classifier_activation = InArg(None)
-        self.model = OutArg(None)
-
-
     def execute(self, ctx) -> None:
 
         model_config = vgg_model_config()
@@ -743,17 +668,6 @@ class Xception(Component):
     classes: InArg[int]
     classifier_activation: InArg[int]
     model: OutArg[any]
-
-    def __init__(self):
-        self.done = False
-        self.include_top = InArg(None)
-        self.weights = InArg(None)
-        self.input_tensor = InArg(None)
-        self.pooling = InArg(None)
-        self.classes = InArg(None)
-        self.classifier_activation = InArg(None)
-        self.model = OutArg(None)
-
 
     def execute(self, ctx) -> None:
         
@@ -877,24 +791,6 @@ class MobileNet(Component):
     kwargs: InArg[any]
     
     model: OutArg[any]
-
-    def __init__(self):
-
-        self.done = False
-        self.input_shape = InArg(None)
-        self.alpha = InArg(None)  
-        self.depth_multiplier = InArg(None)   
-        self.dropout = InArg(None)
-        self.include_top = InArg(None)
-        self.weights = InArg(None)
-        self.input_tensor = InArg(None)   
-        self.pooling = InArg(None)
-        self.classes = InArg(None)
-        self.classifier_activation = InArg(None)
-        self.kwargs = InArg(None)
-
-        self.model = OutArg(None)
-
 
     def execute(self, ctx) -> None:
 

--- a/xai_components/xai_tensorflow_keras/training.py
+++ b/xai_components/xai_tensorflow_keras/training.py
@@ -39,14 +39,6 @@ class ReadKerasDataSet(Component):
     dataset: OutArg[Tuple[np.array, np.array]]
     class_dict: OutArg[dict]
 
-
-    def __init__(self):
-        self.done = False
-        self.dataset_name = InCompArg.empty()
-        self.dataset = OutArg.empty()
-        self.class_dict = OutArg.empty()
-
-
     def execute(self, ctx) -> None:
 
         if self.dataset_name.value == 'mnist':
@@ -162,11 +154,6 @@ class FlattenImageData(Component):
     dataset: InCompArg[Tuple[np.array, np.array]]
     resized_dataset: OutArg[Tuple[np.array, np.array]]
 
-    def __init__(self):
-        self.done = False
-        self.dataset = InCompArg.empty()
-        self.resized_dataset = OutArg.empty()
-
     def execute(self, ctx) -> None:
 
         x = self.dataset.value[0]
@@ -206,16 +193,6 @@ class TrainTestSplit(Component):
     stratify: InArg[any]
     train: OutArg[Tuple[np.array, np.array]] 
     test: OutArg[Tuple[np.array, np.array]] 
-
-    def __init__(self):
-        self.done = False
-        self.dataset = InCompArg.empty()
-        self.train_split = InArg.empty()
-        self.random_state = InArg.empty()
-        self.shuffle = InArg.empty()
-        self.stratify = InArg.empty()
-        self.train = OutArg.empty()
-        self.test = OutArg.empty()
 
     def execute(self, ctx) -> None:
         
@@ -257,11 +234,6 @@ class KerasCreate1DInputModel(Component):
     training_data: InCompArg[Tuple[np.array, np.array]]
     model: OutArg[keras.Sequential]
 
-    def __init__(self):
-        self.done = False
-        self.training_data = InCompArg.empty()
-        self.model = OutArg.empty()
-
     def execute(self, ctx) -> None:
         x_shape = self.training_data.value[0].shape
         y_shape = self.training_data.value[1].shape
@@ -298,14 +270,6 @@ class KerasCreate2DInputModel(Component):
 
     model: OutArg[keras.Sequential]
     model_config: OutArg[dict]
-
-
-    def __init__(self):
-        self.done = False
-        self.training_data = InCompArg.empty()
-        self.model = OutArg.empty()
-        self.model_config = OutArg.empty()
-
 
     def execute(self, ctx) -> None:
 
@@ -366,15 +330,6 @@ class KerasTrainImageClassifier(Component):
     trained_model: OutArg[keras.Sequential]
     training_metrics: OutArg[dict]
 
-    def __init__(self):
-        self.done = False
-
-        self.model = InCompArg.empty()
-        self.training_data = InCompArg.empty()
-        self.training_epochs = InArg.empty()
-        self.trained_model = OutArg.empty()
-        self.training_metrics = OutArg.empty()
-
     def execute(self, ctx) -> None:
 
         model = self.model.value
@@ -415,12 +370,6 @@ class KerasEvaluateAccuracy(Component):
 
     metrics: OutArg[Dict[str, str]]
 
-    def __init__(self):
-        self.done = False
-        self.model = InCompArg.empty()
-        self.eval_dataset = InCompArg.empty()
-        self.metrics = OutArg.empty()
-
     def execute(self, ctx) -> None:
         (loss, acc) = self.model.value.evaluate(self.eval_dataset.value[0], self.eval_dataset.value[1], verbose=0)
         metrics = {
@@ -454,12 +403,8 @@ class ShouldStop(Component):
     should_retrain: OutArg[bool]
 
     def __init__(self):
-        self.done = False
-        self.target_accuracy = InCompArg.empty()
-        self.metrics = InArg.empty()
-        self.max_retries = InArg.empty()
-
-        self.should_retrain = OutArg(True)
+        super().__init__()
+        self.should_retrain.value = True
         self.retries = 0
 
     def execute(self, ctx) -> None:
@@ -496,13 +441,6 @@ class SaveKerasModel(Component):
     model: InCompArg[any]
     model_name: InArg[str]
     model_h5_path: OutArg[str]
-
-    def __init__(self):
-        self.done = False
-        self.model = InCompArg.empty()
-        self.model_name = InArg.empty()
-
-        self.model_h5_path = OutArg.empty()
 
     def execute(self, ctx) -> None:
         model = self.model.value

--- a/xai_components/xai_utils/utils.py
+++ b/xai_components/xai_utils/utils.py
@@ -10,10 +10,6 @@ class Print(Component):
     msg: InArg[any]
     done: bool
     
-    def __init__(self):
-        self.msg = InArg.empty()
-        self.done = False
-        
     def execute(self, ctx) -> None:
         print(str(self.msg.value))
         

--- a/xai_components/xai_utils/utils.py
+++ b/xai_components/xai_utils/utils.py
@@ -19,17 +19,9 @@ class ConcatString(Component):
     b: InArg[str]
     out: OutArg[str]
     done: bool
-    
-    def __init__(self):
-        self.a = InArg.empty()
-        self.b = InArg.empty()
-        self.out = InArg.empty()
-        self.done = False
-    
+
     def execute(self, cts) -> None:
         self.out.value = self.a.value + self.b.value
-
-
     
 @xai_component
 class ZipDirectory(Component):
@@ -69,13 +61,6 @@ class ZipDirectory(Component):
     zip_fn: InArg[str]
     dir_name: InCompArg[str]
     include_dir: InArg[bool]
-
-    def __init__(self):
-
-        self.done = False
-        self.zip_fn = InArg.empty()
-        self.dir_name = InCompArg.empty()
-        self.include_dir = InArg.empty()
 
     def execute(self, ctx) -> None:
         
@@ -126,11 +111,6 @@ class DeleteFile(Component):
     """
     filename: InCompArg[str]
 
-    def __init__(self):
-
-        self.done = False
-        self.filename = InArg.empty()
-
     def execute(self, ctx) -> None:
 
         filename = self.filename.value if self.filename.value else None
@@ -161,17 +141,6 @@ class TimerComponent(Component):
     out_timer: OutArg[time.time]
     elapsed_time: OutArg[int]
     
-    def __init__(self):
-
-        self.done = False
-        
-        self.in_timer = InArg.empty()
-        self.timer_message = InArg.empty()
-
-        self.out_timer = OutArg.empty()
-        self.elapsed_time = OutArg.empty()
-        
-
     def execute(self, ctx) -> None:
                 
         current_time = time.time()
@@ -199,12 +168,6 @@ class SleepComponent(Component):
     """    
     sleep_timer: InArg[float]
 
-    def __init__(self):
-
-        self.done = False
-        
-        self.sleep_timer = InArg.empty()
-                
     def execute(self, ctx) -> None:
         
         sleep_timer = self.sleep_timer.value if self.sleep_timer.value else 5.0


### PR DESCRIPTION
Only need __init__ functions when you want to specify a default value.

# Description

One of the more annoying things when creating a component is having to type InArg/OutArg over and over.  With this change we use `__annotations__` to get what args are defined on the component and automatically initialize those to In/OutArg.empty().

With this change you no longer need to implement `__init__` when creating components unless you want to give your args default values.

Example:
```
def __init__(self):
    super().__init__()
    self.learning_rate.value = 1e-3
    self.should_flatten.value = False
```

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [X] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Converted the branch and pytorch components to use the new `__init__`-less style.  Able to compile and run with no issues.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [x] Mac  
- [ ] Others  (State here -> xxx )  

#N