### PR TITLE
🐛 Fix Literal List and Dict compile

### DIFF
--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -1,7 +1,7 @@
 import ast
 import itertools
 import re
-
+import json
 import sys
 
 if sys.version_info >= (3, 9):
@@ -121,11 +121,16 @@ def main(args):
                 )
 
                 if port.source.id not in named_nodes:
+
                     # Literal
                     assignment_target += ".value"
                     tpl = ast.parse("%s = 1" % (assignment_target))
                     if port.source.name == "Literal String":
                         value = port.sourceLabel
+                    elif port.source.name == "Literal List":
+                        value = json.loads("[" + port.sourceLabel + "]")
+                    elif port.source.name == "Literal Dict":
+                        value = json.loads("{" + port.sourceLabel + "}")
                     else:
                         value = eval(port.sourceLabel)
                     tpl.body[0].value.value = value


### PR DESCRIPTION
# Description

Currently the new compiler crashes if a `Literal Dict` is used in a workflow, while compiling `Literal List` as tuples. This PR fixes both. 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Try compiling a workflow with both `Literal List` and / or `Literal Dict`. You can use the HelloTupleListDict component in the template library. It should compile correctly.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

If possible try out https://github.com/XpressAI/xircuits/pull/224 before merging this one. Thanks.

