### PR TITLE
💾  Re-arrange the main Toolbar

### DIFF
--- a/src/xircuitFactory.ts
+++ b/src/xircuitFactory.ts
@@ -260,16 +260,16 @@ export class XircuitFactory extends ABCWidgetFactory<DocumentWidget> {
       }
     });
 
-    widget.toolbar.insertItem(0, 'xircuits-add-save', saveButton);
-    widget.toolbar.insertItem(1, 'xircuits-add-undo', undoButton);
-    widget.toolbar.insertItem(2, 'xircuits-add-redo', redoButton);
-    widget.toolbar.insertItem(3, 'xircuits-add-reload', reloadButton);
-    widget.toolbar.insertItem(4, 'xircuits-add-cut', cutButton);
-    widget.toolbar.insertItem(5, 'xircuits-add-copy', copyButton);
-    widget.toolbar.insertItem(6, 'xircuits-add-paste', pasteButton);
-    widget.toolbar.insertItem(7, 'xircuits-add-lock', lockButton);
-    widget.toolbar.insertItem(8, 'xircuits-add-log', logButton);
-    widget.toolbar.insertItem(9, 'xircuits-add-test', testButton);
+    widget.toolbar.insertItem(0, 'xircuits-add-undo', undoButton);
+    widget.toolbar.insertItem(1, 'xircuits-add-redo', redoButton);
+    widget.toolbar.insertItem(2, 'xircuits-add-reload', reloadButton);
+    widget.toolbar.insertItem(3, 'xircuits-add-cut', cutButton);
+    widget.toolbar.insertItem(4, 'xircuits-add-copy', copyButton);
+    widget.toolbar.insertItem(5, 'xircuits-add-paste', pasteButton);
+    widget.toolbar.insertItem(6, 'xircuits-add-lock', lockButton);
+    widget.toolbar.insertItem(7, 'xircuits-add-log', logButton);
+    widget.toolbar.insertItem(8, 'xircuits-add-test', testButton);
+    widget.toolbar.insertItem(9, 'xircuits-add-save', saveButton);
     widget.toolbar.insertItem(10, 'xircuits-add-compile', compileButton);
     widget.toolbar.insertItem(11, 'xircuits-add-run', compileAndRunButton);
     widget.toolbar.insertItem(12, 'xircuits-run-type', new RunSwitcher(this));


### PR DESCRIPTION


# Description

Re-arrange the main Toolbar, move the save icon closer to the compile and run icons 

## References

![image](https://user-images.githubusercontent.com/20488299/229463116-eb7bd38d-e3b9-4840-ac79-9ebfe943a3e2.png)


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Test A**

    1. Build Xircuits
    2. Check and test the new toolbar arrangement 
    3. save, compile, run and Xircuits template 


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Add if any.
