### PR TITLE
Update Long String Overflow Display

### DIFF
--- a/src/components/port/CustomPortLabel.tsx
+++ b/src/components/port/CustomPortLabel.tsx
@@ -19,9 +19,9 @@ namespace S {
 	export const Label = styled.div`
 		padding: 0 5px;
 		flex-grow: 1;
-		text-overflow: ellipsis;
+		white-space: pre-wrap; // Preserve line breaks and wrap text to the next line
 		overflow:hidden;
-		max-width: 640px;
+		max-width: 40ch;
 	`;
 
 	export const SymbolContainer = styled.div<{ symbolType: string; selected: boolean; isOutPort: boolean }>`


### PR DESCRIPTION
# Description

Updates long string display to overflow. Currently the limit is set to be 40ch. 
For reference, this is how it looks currently, for 40ch and for 80ch.

Previous:
![image](https://user-images.githubusercontent.com/68586800/230270437-8f924f3d-5838-4665-9a3f-8e3967bcc752.png)

40ch
![image](https://user-images.githubusercontent.com/68586800/230267928-82d55351-4edb-4230-bd47-5cb76fc1bb20.png)

80ch
![image](https://user-images.githubusercontent.com/68586800/230267876-79361c82-ae5f-4cff-9be1-f02897c42db9.png)


## References
https://github.com/XpressAI/xircuits/pull/190


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Drag in a string component. Give it a long text, maybe from [here](https://www.lipsum.com/). Rate the aesthetic quality.
2. Run the workflow. Ensure that it can perform its function correctly.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  