### PR TITLE
🔤 Fix Canvas Size Effect on Literal String

### DIFF
--- a/src/helpers/DemoCanvasWidget.tsx
+++ b/src/helpers/DemoCanvasWidget.tsx
@@ -12,6 +12,7 @@ export interface DemoCanvasWidgetProps {
 		background-color: ${(p) => p.background};
 		background-size: 50px 50px;
 		display: flex;
+		width : 15360px; // Prevent Dev tool effects on smaller monitors  
 
 		> * {
 			height: 100%;


### PR DESCRIPTION
# Description

- The literal string component had a resize issue when the canvas width become limited on a small monitor or when the dev tool limits the canvas window. 

- The fix sets the canvas width to limit canvas window size effects on components.    


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests


  1. Create a Xircuits file and add a literal string component. 
  2. Fill the literal string component with a paragraph of 1000 words or more 
  3. Open the Dev tool `F12` and change its size to limit the canvas window size.
  4. Make sure the literal string component dimensions are not changing


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Add if any.
