### PR TITLE
Align the text for Triangle ports.

### DIFF
--- a/src/components/port/CustomPortLabel.tsx
+++ b/src/components/port/CustomPortLabel.tsx
@@ -122,7 +122,7 @@ export class CustomPortLabel extends React.Component<CustomPortLabelProps> {
 			</S.SymbolContainer>);
 
 		const label = (
-			<S.Label>
+			<S.Label style={{textAlign: (!this.props.port.getOptions().in && this.props.port.getOptions().label === '▶') ? 'right': 'left'}}>
 				{this.props.port.getOptions().label}
 			</S.Label>);
 


### PR DESCRIPTION
# Description

Align in triangles to the left and right triangles to the right.

![image](https://user-images.githubusercontent.com/122480/231686048-4cd61673-25ef-42de-ba2b-0badcbae5569.png)

## Pull Request Type

- [X] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

See screenshot.

## Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [X] Mac  
- [ ] Others  (State here -> xxx )  

