### PR TITLE
Fix for multi-triangle components.

### DIFF
--- a/src/tray_library/AdvanceComponentLib.tsx
+++ b/src/tray_library/AdvanceComponentLib.tsx
@@ -32,7 +32,9 @@ export function AdvancedComponentLibrary(props: AdvancedComponentLibraryProps) {
             "type": nodeData.type,
             "path": nodeData.file_path,
             "description": nodeData.docstring,
-            "lineNo": nodeData.lineno
+            "lineNo": nodeData.lineno,
+            "template": nodeData.template,
+            "options": nodeData.options
         }
     });
     node.addInPortEnhance('▶', 'in-0');
@@ -48,7 +50,7 @@ export function AdvancedComponentLibrary(props: AdvancedComponentLibraryProps) {
         let name = variable["name"];
         let type = type_name_remappings[variable["type"]] || variable["type"];
         // if node type includes comma, then multiple types are accepted for that node (ex: str,float; str,int; etc.)
-        if (type.includes(',')) {
+        if (type && type.includes(',')) {
             // take care of remapping, even when multiple types are accepted for the node
             for (let mapping in type_name_remappings) {
                 type = type.replace(mapping, type_name_remappings[mapping]);


### PR DESCRIPTION
# Description

Triangle components don't have a type like normal ports.  Add a check to skip the new logic if the port is a triangle.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [X] Mac  
- [ ] Others  (State here -> xxx )  


