### PR TITLE
🧹 Remove unused debugger code from component libraries

### DIFF
--- a/xai_components/base.py
+++ b/xai_components/base.py
@@ -82,17 +82,12 @@ class BaseComponent:
 
 class Component(BaseComponent):
     next: BaseComponent
-    done: bool
-
-    def __init__(self):
-        super().__init__()
-        self.done = False
 
     def do(self, ctx) -> Tuple[bool, BaseComponent]:
         print(f"\nExecuting: {self.__class__.__name__}")
         self.execute(ctx)
 
-        return self.done, self.next
+        return self.next
 
     def debug_repr(self) -> str:
         return "<h1>Component</h1>"
@@ -107,8 +102,8 @@ class SubGraphExecutor:
         comp = self.comp
         
         while comp is not None:
-            is_done, comp = comp.do(ctx)
-        return is_done, None
+            comp = comp.do(ctx)
+        return None
 
 
 def execute_graph(args: Namespace, start: BaseComponent, ctx) -> None:

--- a/xai_components/xai_controlflow/branches.py
+++ b/xai_components/xai_controlflow/branches.py
@@ -4,7 +4,6 @@ from xai_components.base import InArg, OutArg, InCompArg, Component, BaseCompone
 class BranchComponent(Component):
     when_true: BaseComponent
     when_false: BaseComponent
-    done: bool
 
     condition: InArg[bool]
     
@@ -14,11 +13,11 @@ class BranchComponent(Component):
         else:
             next = self.when_false
         while next:
-            is_done, next = next.do(ctx)
+            next = next.do(ctx)
         try:
-            return self.done, self.next
+            return self.next
         except:
-            return self.done, None
+            return None
     
 @xai_component
 class LoopComponent(Component):
@@ -28,11 +27,11 @@ class LoopComponent(Component):
     
     def do(self, ctx) -> BaseComponent:
         while self.condition.value:
-            is_done, next_body = self.body.do(ctx)
+            next_body = self.body.do(ctx)
             while next_body:
-                is_done, next_body = next_body.do(ctx)
-            return self.done, self
-        return self.done, self.next
+                next_body = next_body.do(ctx)
+            return self
+        return self.next
     
 @xai_component
 class CounterComponent(Component):

--- a/xai_components/xai_pytorch/quickstart.py
+++ b/xai_components/xai_pytorch/quickstart.py
@@ -57,7 +57,6 @@ class LoadTorchVisionDataset(Component):
 
         self.training_data.value = training_data
         self.test_data.value = test_data
-        self.done = True
 
 @xai_component
 class TorchDataLoader(Component):

--- a/xai_components/xai_spark/pyspark_core.py
+++ b/xai_components/xai_spark/pyspark_core.py
@@ -50,8 +50,6 @@ class xSparkSession(Component):
             spark = SparkSession.builder.getOrCreate()
         
         self.sparksession.value = spark
-        self.done = True
-
 
 @xai_component
 class SparkReadPandas(Component):
@@ -80,8 +78,6 @@ class SparkReadPandas(Component):
 
         self.out_sparksession.value = spark
         self.out_dataframe.value = spark_df
-
-        self.done = True
 
 @xai_component
 class SparkReadFile(Component):
@@ -128,8 +124,6 @@ class SparkReadFile(Component):
 
         self.out_sparksession.value = spark
         self.out_dataframe.value = df
-        self.done = True
-
 
 @xai_component
 class SparkReadCSV(Component):
@@ -167,8 +161,6 @@ class SparkReadCSV(Component):
 
         self.out_sparksession.value = spark
         self.out_dataframe.value = df
-        self.done = True
-
 
 @xai_component
 class SparkWriteFile(Component):
@@ -207,8 +199,6 @@ class SparkWriteFile(Component):
             df.write.orc(filepath)
         else:
             print("Unrecognized file format! Please input csv / parquet / orc.")
-
-        self.done = True
 
 @xai_component
 class SparkSQL(Component):
@@ -252,8 +242,6 @@ class SparkSQL(Component):
         
         self.out_sparksession.value = spark
         self.sql_dataframe.value = sql_df
-        self.done = True
-
 @xai_component
 class SparkVisualize(Component):
     """Visualizes a Spark dataframe.
@@ -297,4 +285,3 @@ class SparkVisualize(Component):
         plt.tight_layout()
         plt.savefig(output_name)
         plt.show()
-        self.done = True

--- a/xai_components/xai_spark/pyspark_mllib.py
+++ b/xai_components/xai_spark/pyspark_mllib.py
@@ -35,7 +35,6 @@ class SparkSparseVector(Component):
         sparse_vector
 
         self.sparse_vector.value = sparse_vector
-        self.done = True
 
 
 @xai_component
@@ -74,7 +73,6 @@ class SparkLabeledPoint(Component):
         print(labeled_point)
 
         self.labeled_point.value = labeled_point
-        self.done = True
 
 
 @xai_component
@@ -109,7 +107,6 @@ class SparkLoadImageFolder(Component):
         self.out_sparksession.value = spark
         self.out_dataframe.value = df
 
-        self.done = True
 
 @xai_component
 class SparkSplitDataFrame(Component):
@@ -153,7 +150,6 @@ class SparkSplitDataFrame(Component):
 
         self.train_dataframe.value = train
         self.test_dataframe.value = test
-        self.done = True
 
 
 @xai_component
@@ -190,7 +186,6 @@ class SparkLoadLIBSVM(Component):
 
         self.out_sparksession.value = spark
         self.out_dataframe.value = df
-        self.done = True
 
 
 @xai_component
@@ -241,7 +236,6 @@ class SparkLogisticRegression(Component):
             print("Intercept: " + str(model.intercept))
 
         self.model.value = model
-        self.done = True
 
 
 @xai_component
@@ -265,4 +259,3 @@ class SparkPredict(Component):
 
         test_result.predictions.show()
 
-        self.done = True

--- a/xai_components/xai_template/example_components.py
+++ b/xai_components/xai_template/example_components.py
@@ -12,8 +12,6 @@ class HelloComponent(Component):
         creator_name = os.getlogin()
         print("Hello, " + creator_name)
 
-        self.done = True
-
 
 @xai_component
 class HelloHyperparameter(Component):
@@ -27,8 +25,6 @@ class HelloHyperparameter(Component):
     def execute(self, ctx) -> None:
         input_str = self.input_str.value
         print("Hello " + str(input_str))
-        self.done = True
-
 @xai_component
 class CompulsoryHyperparameter(Component):
     """A component that uses Compulsory inPorts. 
@@ -52,8 +48,6 @@ class CompulsoryHyperparameter(Component):
         print("Hello, " + str(input_str))
         print("I'm " + str(comp_str))
         print("Me " + str(comp_int))
-
-        self.done = True
 
 @xai_component
 class HelloListTupleDict(Component):
@@ -82,8 +76,6 @@ class HelloListTupleDict(Component):
         print(input_tuple)
         print("\nDisplaying Dict: ")
         print(input_dict)
-
-        self.done = True
 
 @xai_component
 class MultiType(Component):
@@ -115,15 +107,12 @@ class HelloContext(Component):
         ctx.update(context_dict)
 
         print(f"After Adding Context:\n{ctx}")
-
-        self.done = True
         
 @xai_component
 class MultiBranchComponent(BaseComponent):
     if_A: BaseComponent
     if_B: BaseComponent
     if_C: BaseComponent
-    done: bool
 
     abc: InArg[str]
 
@@ -138,8 +127,8 @@ class MultiBranchComponent(BaseComponent):
             next = None
         
         while next:
-            is_done, next = next.do(ctx)
+            next = next.do(ctx)
         try:
-            return self.done, self.next
+            return self.next
         except:
-            return self.done, None
+            return None

--- a/xai_components/xai_tensorflow_keras/keras_transfer_learning.py
+++ b/xai_components/xai_tensorflow_keras/keras_transfer_learning.py
@@ -161,8 +161,6 @@ class KerasTransferLearningModel(Component):
 
         self.model.value = model
 
-        self.done = True
-
 
 @xai_component()
 class TFDataset(Component):
@@ -205,8 +203,7 @@ class TFDataset(Component):
     test_data: OutArg[any]
 
     def __init__(self):
-        self.done = False
-
+        super().__init__()
         self.batch_size.value = 32
         self.shuffle_files.value = False
         self.as_supervised.value = True
@@ -230,8 +227,6 @@ class TFDataset(Component):
         self.all_data.value = ds
         self.train_data.value = ds.get("train")
         self.test_data.value = ds.get("test")
-
-        self.done = True
 
 
 @xai_component(type="train")
@@ -285,8 +280,6 @@ class TrainKerasModel(Component):
         self.trained_model.value = model
         self.training_metrics.value = training_metrics
 
-        self.done = True
-
 
 @xai_component(type="eval")
 class TFDSEvaluateAccuracy(Component):
@@ -314,8 +307,6 @@ class TFDSEvaluateAccuracy(Component):
         print(metrics)
 
         self.metrics.value = metrics
-
-        self.done = True
 
 
 @xai_component
@@ -385,8 +376,6 @@ class KerasModelCompiler(Component):
 
         self.model_config.value = model_config
 
-        self.done = True
-
 
 @xai_component
 class SaveKerasModel(Component):
@@ -410,5 +399,3 @@ class SaveKerasModel(Component):
 
         print(f"Saving Tensorflow Keras model to: {Path.cwd()}")
         self.model.value.save(f"{self.model_name.value}.h5")
-
-        self.done = True

--- a/xai_components/xai_tensorflow_keras/tf_keras.py
+++ b/xai_components/xai_tensorflow_keras/tf_keras.py
@@ -73,7 +73,6 @@ class LoadKerasModel(Component):
             if self.model_name.value:
                 print(f"model_name:{e} not found!\nPlease refer to the official keras list of supported models: https://keras.io/api/applications/")
 
-        self.done = True
 
 
 @xai_component
@@ -192,7 +191,6 @@ class KerasPredict(Component):
             print(preds)
 
 
-        self.done = True
 
 class resnet_model_config:
     include_top: bool #true
@@ -281,7 +279,6 @@ class ResNet50(Component):
 
         model = applications.ResNet50(model_config)
         self.model.value = model
-        self.done = True
 
 @xai_component
 class ResNet101(Component):
@@ -355,7 +352,6 @@ class ResNet101(Component):
 
         model = applications.ResNet101(model_config)
         self.model.value = model
-        self.done = True
 
 
 @xai_component
@@ -429,7 +425,6 @@ class ResNet152(Component):
 
         model = applications.ResNet152(model_config)
         self.model.value = model
-        self.done = True
 
 
 class vgg_model_config:
@@ -529,7 +524,6 @@ class VGG16(Component):
 
         model = applications.VGG16(model_config)
         self.model.value = model
-        self.done = True
 
 
 @xai_component
@@ -609,7 +603,6 @@ class VGG19(Component):
 
         model = applications.VGG19(model_config)
         self.model.value = model
-        self.done = True
 
 @xai_component
 class Xception(Component):
@@ -688,7 +681,6 @@ class Xception(Component):
 
         model = applications.Xception(model_config)
         self.model.value = model
-        self.done = True
 
 
 class mobile_model_config:
@@ -810,4 +802,3 @@ class MobileNet(Component):
 
         model = applications.MobileNet(model_config)
         self.model.value = model
-        self.done = True

--- a/xai_components/xai_tensorflow_keras/training.py
+++ b/xai_components/xai_tensorflow_keras/training.py
@@ -136,8 +136,6 @@ class ReadKerasDataSet(Component):
             print("Dataset was not found!")
 
 
-        self.done = True
-
 @xai_component
 class FlattenImageData(Component):
 
@@ -161,8 +159,6 @@ class FlattenImageData(Component):
 
         self.resized_dataset.value = (x, self.dataset.value[1])
         print(f"resized_dataset = {np.shape(self.resized_dataset.value)}")
-
-        self.done = True
 
 
 @xai_component
@@ -218,8 +214,6 @@ class TrainTestSplit(Component):
 
         self.train.value = train
         self.test.value = test
-        self.done = True
-
 @xai_component
 class KerasCreate1DInputModel(Component):
     """Takes a 1D dataset tuple and creates a 1D Keras model.
@@ -251,8 +245,6 @@ class KerasCreate1DInputModel(Component):
         )
 
         self.model.value = model
-
-        self.done = True
 
 @xai_component
 class KerasCreate2DInputModel(Component):
@@ -306,8 +298,6 @@ class KerasCreate2DInputModel(Component):
         self.model.value = model
         self.model_config.value = model_config
 
-        self.done = True
-
 
 @xai_component
 class KerasTrainImageClassifier(Component):
@@ -350,8 +340,6 @@ class KerasTrainImageClassifier(Component):
 
         self.trained_model.value = model
         self.training_metrics.value = training_metrics
-        self.done = True
-
 
 @xai_component
 class KerasEvaluateAccuracy(Component):
@@ -379,8 +367,6 @@ class KerasEvaluateAccuracy(Component):
         print(metrics)
 
         self.metrics.value = metrics
-
-        self.done = True
 
 
 @xai_component
@@ -424,8 +410,6 @@ class ShouldStop(Component):
         else:
             print('Unable to achieve target accuracy.  Giving up.')
             self.should_retrain.value = False
-        self.done = True
-
 @xai_component
 class SaveKerasModel(Component):
     """Saves current Keras model.
@@ -448,5 +432,3 @@ class SaveKerasModel(Component):
         model.save(model_name)
         print(f"Saving Keras h5 model at: {model_name}")
         self.model_h5_path.value = model_name
-
-        self.done = True

--- a/xai_components/xai_utils/utils.py
+++ b/xai_components/xai_utils/utils.py
@@ -8,7 +8,6 @@ import time
 @xai_component
 class Print(Component):
     msg: InArg[any]
-    done: bool
     
     def execute(self, ctx) -> None:
         print(str(self.msg.value))
@@ -18,7 +17,6 @@ class ConcatString(Component):
     a: InArg[str]
     b: InArg[str]
     out: OutArg[str]
-    done: bool
 
     def execute(self, cts) -> None:
         self.out.value = self.a.value + self.b.value
@@ -100,8 +98,6 @@ class ZipDirectory(Component):
 
         zipObj.close()        
        
-        self.done = True
-
 @xai_component
 class DeleteFile(Component):
     """Deletes a file.
@@ -119,8 +115,6 @@ class DeleteFile(Component):
           os.remove(filename)
         else:
           print(filename + " does not exist.") 
-
-        self.done = True
 
 @xai_component(color="green")
 class TimerComponent(Component):

--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -169,7 +169,7 @@ def main(args):
         trailer = """
 next_component = %s
 while next_component:
-    is_done, next_component = next_component.do(ctx)        
+    next_component = next_component.do(ctx)        
         """ % (named_nodes[self.graph.ports[0].target.id])
         code.append(ast.parse(trailer))
 


### PR DESCRIPTION
# Description

This PR cleans the self.done which was a part of the old debugger.

## References

https://github.com/XpressAI/xircuits/pull/237

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [x] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor / Cleanup

# Tests

Run any workflows. It should work as expected. If possible run the branch workflow components as well.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

