### PR TITLE
⚡ make output panel auto-scroll and spawn on the right

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -233,7 +233,7 @@ const xircuits: JupyterFrontEndPlugin<void> = {
     async function createPanel(): Promise<OutputPanel> {
       outputPanel = new OutputPanel(app.serviceManager, rendermime, widgetFactory, translator);
       app.shell.add(outputPanel, 'main', {
-        mode: 'split-bottom'
+        mode: 'split-right'
       });
       return outputPanel;
     }

--- a/src/kernel/panel.ts
+++ b/src/kernel/panel.ts
@@ -22,9 +22,20 @@ import { XircuitFactory } from '../xircuitFactory';
  */
 const PANEL_CLASS = 'jp-RovaPanel';
 
-/**
- * A panel with the ability to add other children.
- */
+class CustomOutputArea extends SimplifiedOutputArea {
+    constructor(options) {
+        super(options);
+
+        // Listen to the content change signal of the output area model
+        this.model.changed.connect(this._scrollToBottom, this);
+    }
+
+    private _scrollToBottom(): void {
+        // Scroll the output area to the bottom
+        this.node.scrollTop = this.node.scrollHeight;
+    }
+}
+
 export class OutputPanel extends StackedPanel {
     constructor(
         manager: ServiceManager.IManager,
@@ -49,7 +60,7 @@ export class OutputPanel extends StackedPanel {
         });
 
         this._outputareamodel = new OutputAreaModel();
-        this._outputarea = new SimplifiedOutputArea({
+        this._outputarea = new CustomOutputArea({
             model: this._outputareamodel,
             rendermime: rendermime,
         });
@@ -129,7 +140,7 @@ export class OutputPanel extends StackedPanel {
     }
 
     private _sessionContext: SessionContext;
-    private _outputarea: SimplifiedOutputArea;
+    private _outputarea: CustomOutputArea;
     private _outputareamodel: OutputAreaModel;
     private _xircuitFactory: XircuitFactory;
 

--- a/src/log/LogPlugin.ts
+++ b/src/log/LogPlugin.ts
@@ -132,7 +132,7 @@ export const logPlugin: JupyterFrontEndPlugin<void> = {
         app.commands.notifyCommandChanged();
       });
 
-      app.shell.add(logConsoleWidget, 'main', { mode: 'split-bottom' });
+      app.shell.add(logConsoleWidget, 'main', { mode: 'split-right' });
       loggertracker.add(logConsoleWidget);
 
       logConsoleWidget.update();


### PR DESCRIPTION
# Description

People with wide monitors have requested this update. I guess it makes sense for the output panel to spawn on the right side so it doesn't occupy 50% of the screen.

This PR also updates the output panel so it auto-scrolls to the bottom with each output. 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

## Spawn Right Test
0. ~~Buy wide monitor~~
1. Grab the wheel for this PR
2. Install it and run any workflows
3. Verify it looks better


## Auto-scroll Test
1. Run a Xircuits workflow with a lot of outputs, eg ControlflowLoop.xircuits.
2. Verify that the output panel auto-scrolls with the new outputs

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

