### PR TITLE
Improve performance by introducing a flag to disable context change listener during internal updates

### DIFF
--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -123,14 +123,18 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 	const contextRef = useRef(context);
 	const notInitialRender = useRef(false);
 
+
+	let modelUpdateInProgress = false;
 	const onChange = useCallback(
 		(): void => {
 			if (contextRef.current.isReady) {
 				let currentModel = xircuitsApp.getDiagramEngine().getModel().serialize();
+				modelUpdateInProgress = true;
 				contextRef.current.model.fromString(
 					JSON.stringify(currentModel, replacer, 4)
 				);
 				setSaved(false);
+				modelUpdateInProgress = false;
 			}
 		}, []);
 
@@ -143,6 +147,8 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		const currentContext = contextRef.current;
 
 		const changeHandler = (): void => {
+			if(modelUpdateInProgress){ return; }
+
 			const modelStr = currentContext.model.toString();
 			if (!isJSON(modelStr)) {
 				// When context can't be parsed, just return


### PR DESCRIPTION
# Description

This pull request addresses a performance issue caused by redundant processing when updating the document model. The problem stems from the fact that the current implementation listens for a change and then sets the current document model to the serialized graph JSON. Shortly after, there is a document model change listener that reacts to this change and deserializes the new graph, setting the new model. This results in unnecessary work being done during the update process.

To fix this issue, a `modelUpdateInProgress` flag has been introduced. This flag is used to disable the context change listener when the update is initiated from within the context. By doing so, we prevent the redundant processing and improve overall performance.


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)


## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Manual testing with both small and large xircuits files. Previously a distinct slowdown was apparent, afterwards it is gone.


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

