### PR TITLE
🗝️ Add Literal Secret Component

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -547,7 +547,10 @@ export function addNodeActionCommands(
                 case "Dict":
                     isStoreDataType = true;
                     break;
-                case "True":
+                case "Secret":
+                    isStoreDataType = false;
+                    break;
+                    case "True":
                 case "False":
                     return;
                 default:

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -550,7 +550,7 @@ export function addNodeActionCommands(
                 case "Secret":
                     isStoreDataType = false;
                     break;
-                    case "True":
+                case "True":
                 case "False":
                     return;
                 default:

--- a/src/components/port/CustomPortLabel.tsx
+++ b/src/components/port/CustomPortLabel.tsx
@@ -97,7 +97,10 @@ export class CustomPortLabel extends React.Component<CustomPortLabelProps> {
 			case "union":
 				symbolLabel = ' U';
 				break;
-			case "any":
+			case "secret":
+				symbolLabel = '🗝️';
+				break;
+				case "any":
 				symbolLabel = '[_]';
 				break;
 			case "0":
@@ -127,10 +130,12 @@ export class CustomPortLabel extends React.Component<CustomPortLabelProps> {
 					{symbolLabel}
 				</S.Symbol>
 			</S.SymbolContainer>);
+		
+		const nodeType = this.props.node.getOptions().name
 
 		const label = (
-			<S.Label style={{textAlign: (!this.props.port.getOptions().in && this.props.port.getOptions().label === '▶') ? 'right': 'left'}}>
-				{this.props.port.getOptions().label}
+			<S.Label style={{ textAlign: (!this.props.port.getOptions().in && this.props.port.getOptions().label === '▶') ? 'right' : 'left' }}>
+				{nodeType === "Literal Secret" ? "*****" : this.props.port.getOptions().label}
 			</S.Label>);
 
 		return (

--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -153,7 +153,8 @@ export  class CustomPortModel extends DefaultPortModel  {
             nodeModelType === 'string' ||
             nodeModelType === 'list' ||
             nodeModelType === 'tuple' ||
-            nodeModelType === 'dict'
+            nodeModelType === 'dict' ||
+            nodeModelType === 'secret'
         );
     }
 
@@ -226,7 +227,8 @@ export  class CustomPortModel extends DefaultPortModel  {
                 nodeType != 'string' &&
                 nodeType != 'list' &&
                 nodeType != 'tuple' &&
-                nodeType != 'dict'){
+                nodeType != 'dict' &&
+                nodeType != 'secret'){
             //console.log("Curent sourceNode:", sourceNode.getOptions()["name"]);
             let inPorts = sourceNode.getInPorts();
             

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -177,7 +177,15 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 					style={{ width: 350 }}
 					defaultValue={oldValue} />
 			);
-		}
+		} else if (type == 'Secret') {
+        return (
+            <input
+                name={title}
+                type="password"
+                style={{ width: 350 }}
+                defaultValue={oldValue} />
+        );
+    }
 		return null;
 	}
 

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -95,7 +95,7 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 		setChecked(!checked);
 	};
 
-	function DictExample() {
+	function InputDialogueMessageDisplay() {
 		if (type == 'Dict') {
 			return (
 				<h5 style={{ marginTop: 0, marginBottom: 5 }}>
@@ -106,6 +106,13 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 			return (
 				<h5 style={{ marginTop: 0, marginBottom: 5 }}>
 					For Example: "a", "b", "c"
+				</h5>
+			);
+		} else if (type == 'Secret') {
+			return (
+				<h5 style={{ marginTop: 0, marginBottom: 5 }}>
+					Warning: Literal Secrets are masked in the frontend only. <br />
+					They can still be accessed in the raw .xircuits file or appear as strings in the compiled script.
 				</h5>
 			);
 		} else if (type == 'Variable'){
@@ -182,7 +189,7 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
             <input
                 name={title}
                 type="password"
-                style={{ width: 350 }}
+                style={{ width: 480 }}
                 defaultValue={oldValue} />
         );
     }
@@ -196,7 +203,7 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 					Enter {title.includes('parameter') ? 'Argument Name' : `${type} Value`} ({isStoreDataType ? 'Without Brackets' : 'Without Quotes'}):
 				</h3>
 				: null}
-			<DictExample />
+			<InputDialogueMessageDisplay />
 			<InputValueDialog />
 		</form>
 	);

--- a/src/helpers/InputSanitizer.tsx
+++ b/src/helpers/InputSanitizer.tsx
@@ -4,6 +4,7 @@ function checkInput(input: any, datatype: string): boolean {
 
     switch (lowercaseDatatype) {
         case "string":
+        case "secret":
             wrappedInput = `"${input}"`;
             break;
         case "tuple":
@@ -40,7 +41,8 @@ function checkInput(input: any, datatype: string): boolean {
         // Add example message
         switch (lowercaseDatatype) {
             case "string":
-                example = '"example_string"';
+            case "secret":
+            example = '"example_string"';
                 break;
             case "tuple":
                 example = '"item1", "item2", "item3"';

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -258,6 +258,16 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
                 if (cancelDialog(dialogResult)) return;
                 inputValue = dialogResult["value"]['Secret'];
             }
+
+            while (!checkInput(inputValue, 'secret')){
+                const dialogOptions = inputDialog('Secret', "", 'Secret', false);
+                const dialogResult = await showFormDialog(dialogOptions);
+
+                if (cancelDialog(dialogResult)) return;
+                inputValue = dialogResult["value"]['Secret'];
+            }
+
+        }
             node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance(inputValue, 'out-0');
 

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -266,8 +266,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
                 if (cancelDialog(dialogResult)) return;
                 inputValue = dialogResult["value"]['Secret'];
             }
-
-        }
+            
             node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance(inputValue, 'out-0');
 

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -213,7 +213,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
         if ((nodeName).startsWith("Literal")) {
 
             if (variableValue == '' || variableValue == undefined) {
-                const dialogOptions = inputDialog('Secret', "", 'Secret', true);
+                const dialogOptions = inputDialog('Secret', "", 'Secret', false);
                 const dialogResult = await showFormDialog(dialogOptions);
                 if (cancelDialog(dialogResult)) return;
                 inputValue = dialogResult["value"]['Secret'];

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -208,6 +208,30 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         }
 
+    } else if (nodeData.type === 'secret') {
+
+        if ((nodeName).startsWith("Literal")) {
+
+            if (variableValue == '' || variableValue == undefined) {
+                const dialogOptions = inputDialog('Secret', "", 'Secret', true);
+                const dialogResult = await showFormDialog(dialogOptions);
+                if (cancelDialog(dialogResult)) return;
+                inputValue = dialogResult["value"]['Secret'];
+            }
+            node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
+            node.addOutPortEnhance(inputValue, 'out-0');
+
+        } else {
+
+            const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
+            const dialogResult = await showFormDialog(dialogOptions);
+            if (cancelDialog(dialogResult)) return;
+            inputValue = dialogResult["value"][hyperparameterTitle];
+            node = new CustomNodeModel({ name: "Argument (Secret): " + inputValue, color: nodeData.color, extras: { "type": nodeData.type } });
+            node.addOutPortEnhance('▶', 'parameter-out-0');
+
+        }
+
     // } else if (props.type === 'debug') {
     //     node = new CustomNodeModel({ name: props.name, color: props.color, extras: { "type": props.type } });
     //     node.addInPortEnhance('▶', 'in-0');

--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -131,6 +131,8 @@ def main(args):
                         value = json.loads("[" + port.sourceLabel + "]")
                     elif port.source.name == "Literal Dict":
                         value = json.loads("{" + port.sourceLabel + "}")
+                    elif port.source.name == "Literal Secret":
+                        value = port.sourceLabel
                     else:
                         value = eval(port.sourceLabel)
                     tpl.body[0].value.value = value

--- a/xircuits/handlers/components.py
+++ b/xircuits/handlers/components.py
@@ -36,6 +36,8 @@ DEFAULT_COMPONENTS = {
     10:{ "name": "Literal List", "returnType": "list","color":"yellow"},
     11:{ "name": "Literal Tuple", "returnType": "tuple","color":"purple"},
     12:{ "name": "Literal Dict", "returnType": "dict","color":"orange"},
+    13:{ "name": "Literal Secret", "returnType": "secret","color":"black"},
+
     # Comment this first since we don't use it
     # 1: { "name": "Math Operation", "returnType": "math"},
     # 2: { "name": "Convert to Aurora", "returnType": "convert"},


### PR DESCRIPTION
# Description

This pull request introduces the new `Literal Secret` component which users to input secret values such as passwords and API keys. The entered secrets are masked in the input dialogue and the canvas. Useful when demoing Xircuits while streaming.

Warning: Literal Secrets are masked in the frontend only. They can still be accessed in the raw .xircuits file or appear as strings in the compiled script.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Tests

1. drag in a Literal Secret component - confirm that the input dialogue for Secrets appear. Whatever is inserted in here is masked in dots.
2. confirm that on render, the canvas will only display ***** regardless of length
3. confirm that the Literal Secret component can be used normally as an input with other components such as print.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  