### PR TITLE
🐛 Fix Literal Integer and String Type Checks

### DIFF
--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -801,20 +801,12 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 				if (portAnyType == undefined) return;
 				nodeType = portAnyType.nodeType;
 				varInput = portAnyType.varInput;
-				errorMsg = portAnyType.errorMsg;
 				break;
 			default:
 				nodeType = portType.charAt(0).toUpperCase() + portType.slice(1);
 				break;
 		}
-		if (errorMsg != undefined) {
-			if (nodeType == ('Float' || 'Integer')) {
-				showErrorDialog('Error : Input have non-numeric values', errorMsg);
-			} else {
-				showErrorDialog('Error : Type undefined', errorMsg);
-			}
-			return;
-		}
+
 		let current_node = await fetchNodeByName('Literal ' + nodeType);
 		let node = await GeneralComponentLibrary({ model: current_node, variableValue: varInput });
 		if (node == undefined) return;

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -35,7 +35,7 @@ export async function getItsLiteralType(){
 	let varValue = dialogResult["value"][varOfAnyTypeTitle];
 	let varType = varValue.charAt(0);
 	let varInput : string = varValue.slice(1);
-	var { nodeType, errorMsg } = varTypeChecker(varType, varInput, varValue);
+	let nodeType = varTypeChecker(varType, varInput, varValue);
 	
 	while (!checkInput(varInput, nodeType)){
 
@@ -46,11 +46,11 @@ export async function getItsLiteralType(){
 		varValue = dialogResult["value"][varOfAnyTypeTitle];
 		varType = varValue.charAt(0);
 		varInput = varValue.slice(1);
-		var { nodeType, errorMsg } = varTypeChecker(varType, varInput, varValue);
+		 nodeType = varTypeChecker(varType, varInput, varValue);
 
 	}
 
-	return { nodeType, varInput, errorMsg}
+	return { nodeType, varInput }
 }
 
 export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inputType }): JSX.Element => {
@@ -86,8 +86,7 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 				<h5 style={{ marginTop: 0, marginBottom: 5 }}>
 					<p>Determine your variable type by inserting the first char as below: </p>
 					<li> " : String</li>
-					<li> # : Integer</li>
-					<li> # with '.' : Float</li>
+					<li> # : Integer or Float</li>
 					<li> [ : List</li>
 					<li> ( : Tuple</li>
 					<li> {'{'} : Dict</li>
@@ -174,53 +173,28 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 	);
 }
 
-function varTypeChecker(varType:string, varInput:string, varValue:string){
-	var nodeType;
-	var errorMsg;
+function varTypeChecker(varType, varInput, varValue){
+    const typeCheckDict = {
+        '"': () => 'String',
+        '#': () => Number.isInteger(Number(varInput)) ? 'Integer' : 'Float',
+        '[': () => 'List',
+        '(': () => 'Tuple',
+        '{': () => 'Dict',
+        '!': () => {
+            let boolValue = varValue.slice(1).toLowerCase();
+            if (boolValue === 'true' || boolValue === '1' || boolValue === 't') {
+                return 'True';
+            } else if (boolValue === 'false' || boolValue === '0' || boolValue === 'nil') {
+                return 'False';
+            }
+        }
+    };
 
-	switch (varType) {
-		case '"':
-			nodeType = 'String';
-			break;
-		case '#':
-			let onlyNum = Number(varInput);
-			if (isNaN(onlyNum)) {
-				errorMsg = `Variable's input (${varInput}) not a numeric value.`;
-				break;
-			}
-			nodeType = Number.isInteger(onlyNum) ? 'Integer' : 'Float';
-			break;
-		case '[':
-			nodeType = 'List';
-			break;
-		case '(':
-			nodeType = 'Tuple';
-			break;
-		case '{':
-			nodeType = 'Dict';
-			break;
-		case '!':
-			let boolValue = varValue.slice(1);
-			switch (boolValue) {
-				case 'true':
-				case 'True':
-				case '1':
-				case 't':
-					nodeType = 'True';
-					break;
-				case 'false':
-				case 'False':
-				case '0':
-				case 'nil':
-					nodeType = 'False';
-					break;
-			}
-			break;
-		default:
-			// When type is undefined, show error
-			errorMsg = `Type is undefined or not provided. Please insert the first character as shown in example.` ;
-			break;
-	}
+    let nodeType = typeCheckDict[varType] ? typeCheckDict[varType]() : 'undefined_any';
 
-	return { nodeType, errorMsg };
+    if (nodeType == 'undefined_any') {
+        console.error(`Type is undefined or not provided. Please insert the first character as shown in example.`);
+    }
+
+    return nodeType;
 }

--- a/src/helpers/InputSanitizer.tsx
+++ b/src/helpers/InputSanitizer.tsx
@@ -1,69 +1,79 @@
-function checkInput(input: any, datatype: string): boolean {
-    let wrappedInput = "";
-    let lowercaseDatatype = datatype.toLowerCase();
+function checkInput(input: any, dataType: string): boolean {
 
-    switch (lowercaseDatatype) {
+    const normalizedDataType = dataType.toLowerCase();
+    let processedInput = "";
+    let errorDetails = "";
+    let exampleInput = "";
+
+    const formatError = (detail: string, example: string) => `Invalid ${dataType} input: ${detail} \nExample of a correct ${dataType} format: ${example}`;
+    
+    switch (normalizedDataType) {
         case "int":
         case "integer":
         case "float":
-            wrappedInput = `${input}`;
+            if (isNaN(Number(input))) {
+                errorDetails = "Input is not a number.";
+                exampleInput = normalizedDataType === "float" ? "e.g. 3.14" : "e.g. 3";
+                alert(formatError(errorDetails, exampleInput));
+                return false;
+            }
+            processedInput = `${input}`;
+            break;
         case "string":
         case "secret":
-            wrappedInput = `"${input}"`;
+            processedInput = JSON.stringify(input);
             break;
         case "tuple":
-            wrappedInput = `(${input})`;
+            processedInput = `(${input})`;
             break;
         case "list":
-            wrappedInput = `[${input}]`;
+            processedInput = `[${input}]`;
             break;
         case "dict":
-            wrappedInput = `{${input}}`;
+            processedInput = `{${input}}`;
             break;
+        case "undefined_any":
+            //handler if called from any inputDialogue
+            alert(`Type is undefined or not provided. Please insert the first character as shown in example.`);
+            return false;
         default:
             alert("Invalid datatype: Please provide a valid datatype.");
             return false;
     }
 
     try {
-        JSON.parse(wrappedInput);
+        JSON.parse(processedInput);
     } catch (e) {
-        let errorMessage = "Invalid " + datatype + " input: ";
-        let exampleMessage = "\nExample of a correct " + datatype + " format: ";
-        let example = "";
-
-        if (wrappedInput.includes("'")) {
-            errorMessage += "Please use double quotes instead of single quotes.";
-        } else if (/(?:\{|\[|\()(?:\w+)/.test(wrappedInput)) {
-            errorMessage += "Please make sure to use double quotes for your variables.";
+        if (processedInput.includes("'")) {
+            errorDetails = "Please use double quotes instead of single quotes.";
+        } else if (/(?:\{|\[|\()(?:\w+)/.test(processedInput)) {
+            errorDetails = "Please ensure to use double quotes for your variables.";
         } else {
-            // Other JSON parsing errors
-            errorMessage += "Please check the console log for details.";
+            errorDetails = "Please check the console log for details.";
             console.error("Parsing error:", e.message);
         }
 
-        // Add example message
-        switch (lowercaseDatatype) {
+        switch (normalizedDataType) {
             case "string":
             case "secret":
-                example = '"example_string"';
+                exampleInput = '"example_string"';
                 break;
             case "tuple":
-                example = '"item1", "item2", "item3"';
+                exampleInput = '"item1", "item2", "item3"';
                 break;
             case "list":
-                example = '"item1", "item2", 123';
+                exampleInput = '"item1", "item2", 123';
                 break;
             case "dict":
-                example = '"key1": "value1", "key2": 123';
+                exampleInput = '"key1": "value1", "key2": 123';
                 break;
         }
 
-        if (lowercaseDatatype !== "secret") {
-            errorMessage += "\n\nYour input: " + input;
+        if (normalizedDataType !== "secret") {
+            errorDetails += "\n\nYour input: " + input;
         }
 
-        alert(errorMessage + "\n" + exampleMessage + example);
+        alert(formatError(errorDetails, exampleInput));
         return false;
     }
 

--- a/xircuits/compiler/compiler.py
+++ b/xircuits/compiler/compiler.py
@@ -18,7 +18,7 @@ def main():
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('source_file', type=argparse.FileType('r', encoding='utf-8'))
-    parser.add_argument('out_file', type=argparse.FileType('w'))
+    parser.add_argument('out_file', type=argparse.FileType('w', encoding='utf-8'))
     parser.add_argument("python_paths_file", nargs='?', default=None, type=argparse.FileType('r'),
                         help="JSON file with a mapping of component name to required python path. "
                              "e.g. {'MyComponent': '/some/path'}")

--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -31,7 +31,8 @@ class CodeGenerator:
             self._generate_trailer()
         ))
 
-        filelike.write(unparse(ast.Module(body=module_body, type_ignores=[])))
+        with open(filelike.name, 'w', encoding='utf-8') as f:
+            f.write(unparse(ast.Module(body=module_body, type_ignores=[])))
 
     def _generate_python_path(self):
         fixed_code = """


### PR DESCRIPTION
# Description
This PR
- Fixes integer literal from failing type check inputs.
- Fixes logic in rendering Literal Integers in `any` ports
- Fixes multiline strings
- Fixes compiler not being able to parse unicode characters strings like 🤗
<img src="https://github.com/XpressAI/xircuits/assets/68586800/bb7282fc-e346-4d2b-9b31-7759cf2dd797" width="500">


## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Drag in a `Literal Integer`. You should be able to enter the value as well as edit it.
2. Drag in a component with an `any` port like `Print`. Try using the lit integer syntax, ie #554. It should correctly render a Literal Integer.
3. Make a multiline string. You should be able to render and run it.
4. Make a component with special character. It should render and compile. 

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

## Notes
I've noticed that we're using both `int` and `integer` in our codebase. In a future refactor, we should make this consistent. 