### PR TITLE
🔗 Reduce Resource Consumption for Link Animation

### DIFF
--- a/src/components/link/CustomLinkFactory.tsx
+++ b/src/components/link/CustomLinkFactory.tsx
@@ -16,7 +16,7 @@ namespace S {
 
 	const selected = css`
 		stroke-dasharray: 10, 2;
-		animation: ${Keyframes} 1s linear infinite;
+		animation: ${Keyframes} 1s step(24) infinite;
 	`;
 
 	export const Path = styled.path<{ selected: boolean }>`

--- a/src/components/link/CustomLinkFactory.tsx
+++ b/src/components/link/CustomLinkFactory.tsx
@@ -16,7 +16,7 @@ namespace S {
 
 	const selected = css`
 		stroke-dasharray: 10, 2;
-		animation: ${Keyframes} 1s step(24) infinite;
+		animation: ${Keyframes} 1s steps(24) infinite;
 	`;
 
 	export const Path = styled.path<{ selected: boolean }>`


### PR DESCRIPTION
# Description

The current canvas renders link animation in 60 fps, which builds up the resource consumption if you have lots of those. This PR limits it to 24 fps.

Before:
![image](https://github.com/XpressAI/xircuits/assets/68586800/92eff26a-e4fe-4738-bbfe-ef85d93d373e)
16.6ms for every new frame

Now:
![image](https://github.com/XpressAI/xircuits/assets/68586800/8cbff564-fc29-469a-8b66-6bae9627fec4)
30ms ~ 50 ms 


## References

https://github.com/XpressAI/xircuits/pull/134

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Test the resource consumption before and after using this PR's wheel. 

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
