### PR TITLE
🐛 Update xircuits-components to fetch from local

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup_args = dict(
         'console_scripts': [
             'xircuits = xircuits.start_xircuits:main',
             'xircuits-examples = xircuits.start_xircuits:download_examples',
-            'xircuits-components = xircuits.start_xircuits:download_component_library',
+            'xircuits-components = xircuits.start_xircuits:fetch_component_library',
             'xircuits-submodules = xircuits.start_xircuits:download_submodule_library',
             'xircuits-compile = xircuits.compiler.compiler:main'
             ]}

--- a/xircuits/handlers/request_submodule.py
+++ b/xircuits/handlers/request_submodule.py
@@ -43,3 +43,18 @@ def request_submodule_library(component_library_query):
     
     print("Cloning " + submodule_path + " from " + submodule_url)
     Repo.clone_from(submodule_url, submodule_path, progress=Progress())
+
+
+def get_submodules(repo, ref="master"):
+    try:
+        gitmodules_content = repo.get_contents(".gitmodules", ref=ref)
+        gitmodules = gitmodules_content.decoded_content.decode("utf-8")
+        
+        submodules = []
+        for line in gitmodules.split("\n"):
+            if "path = " in line:
+                submodules.append(line.split(" = ")[-1].strip())
+        return submodules
+    
+    except:
+        return []

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -12,10 +12,20 @@ from .handlers.request_submodule import get_submodule_config, request_submodule_
 
 def init_xircuits():
 
+    package_name = 'xircuits'
+    copy_from_installed_wheel(package_name, 
+                              resource='.xircuits', 
+                              dest_path='.xircuits')
 
-    path = ".xircuits"
-    config_path = pkg_resources.resource_filename('xircuits', '.xircuits')
-    shutil.copytree(config_path, path)
+
+def copy_from_installed_wheel(package_name, resource="", dest_path=None):
+    
+    if dest_path is None:
+        dest_path = package_name
+
+    resource_path = pkg_resources.resource_filename(package_name, resource)
+    shutil.copytree(resource_path, dest_path)
+
 
 def download_examples():
     
@@ -28,18 +38,22 @@ def download_examples():
     request_folder("datasets", branch=args.branch)
 
 
-def download_component_library():
-
+def fetch_component_library():
     parser = argparse.ArgumentParser()
+    parser.add_argument("--download", default=False, action='store_true')
     parser.add_argument('--branch', nargs='?', default="master", help='pull files from a xircuits branch')
     parser.add_argument('--sublib', nargs='*', help='pull component library from a xircuits submodule')
-
     args = parser.parse_args()
-    if not args.sublib:
-        request_folder("xai_components", branch=args.branch)
+
+    if args.download:
+        if not args.sublib:
+            request_folder("xai_components", branch=args.branch)
+        else:
+            for component_lib in args.sublib:
+                request_submodule_library(component_lib)
     else:
-        for component_lib in args.sublib:
-            request_submodule_library(component_lib)
+        copy_from_installed_wheel("xai_components")
+
 
 def download_submodule_library():
     
@@ -77,8 +91,7 @@ def main():
         val = input("Xircuits Component Library is not found. Would you like to load it in the current path (Y/N)? ")
         if val.lower() == ("y" or "yes"):
             if args.branch is None:
-                xai_component_path = pkg_resources.resource_filename('xai_components', '')
-                shutil.copytree(xai_component_path, "xai_components")
+                copy_from_installed_wheel('xai_components', '', 'xai_components')
 
             else:
                 request_folder("xai_components", branch=args.branch)


### PR DESCRIPTION
# Description

This PR updates the default way `xircuits-components` fetches the components from pulling each file recursively to simply copying it from the site-packages (this behavior already exists if you run `xircuits` without xai_components present in your working dir, but it now the default for `xircuits-components` as well). 

If users would still want to fetch the components online or from a specific online branch, they can add the `--download` tag. This PR also updates several error messages in this process.

## References

https://github.com/XpressAI/xircuits/pull/152

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [x] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Tests

Install Xircuits from this PR's wheel and verify that:
1. when you run `xircuits-components`, it copies it from site-packages.
2. when you run `xircuits-components --download` it will download the components from an online source. Verify also that the error messages such as, `unable to retrieve xai_components/xai_submodulename cannot be retrieved, skipping...` no longer exist in this command.
3. Bonus - if you call `xircuits-components --download` multiple times in an hour, you will be greeted with the pyGithub error message.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  