### PR TITLE
✨ 🐛 Enhancing Copy-Paste Functionality and Keyboard Events

### DIFF
--- a/src/commands/CustomActionEvent.tsx
+++ b/src/commands/CustomActionEvent.tsx
@@ -8,20 +8,29 @@ interface CustomActionEventOptions {
 
 export class CustomActionEvent extends Action {
     constructor(options: CustomActionEventOptions) {
+        
         super({
             type: InputType.KEY_DOWN,
             fire: (event: ActionEvent<React.KeyboardEvent>) => {
                 const app = options.app;
                 const keyCode = event.event.key;
                 const ctrlKey = event.event.ctrlKey;
+                
+                const executeIf = (condition, command) => {
+                    if(condition){
+                        // @ts-ignore
+                        event.event.stopImmediatePropagation();
+                        app.commands.execute(command)
+                    }
+                }
 
-                if (ctrlKey && keyCode === 'z') app.commands.execute(commandIDs.undo);
-                if (ctrlKey && keyCode === 'y') app.commands.execute(commandIDs.redo);
-                if (ctrlKey && keyCode === 's') app.commands.execute(commandIDs.saveXircuit);
-                if (ctrlKey && keyCode === 'x') app.commands.execute(commandIDs.cutNode);
-                if (ctrlKey && keyCode === 'c') app.commands.execute(commandIDs.copyNode);
-                if (ctrlKey && keyCode === 'v') app.commands.execute(commandIDs.pasteNode);
-                if (keyCode == 'Delete' || keyCode == 'Backspace') app.commands.execute(commandIDs.deleteNode);
+                executeIf(ctrlKey && keyCode === 'z', commandIDs.undo);
+                executeIf(ctrlKey && keyCode === 'y', commandIDs.redo);
+                executeIf(ctrlKey && keyCode === 's', commandIDs.saveXircuit);
+                executeIf(ctrlKey && keyCode === 'x', commandIDs.cutNode);
+                executeIf(ctrlKey && keyCode === 'c', commandIDs.copyNode);
+                executeIf(ctrlKey && keyCode === 'v', commandIDs.pasteNode);
+                executeIf(keyCode == 'Delete' || keyCode == 'Backspace', commandIDs.deleteNode);
             }
         });
     }

--- a/src/commands/CustomActionEvent.tsx
+++ b/src/commands/CustomActionEvent.tsx
@@ -18,11 +18,9 @@ export class CustomActionEvent extends Action {
                 if (ctrlKey && keyCode === 'z') app.commands.execute(commandIDs.undo);
                 if (ctrlKey && keyCode === 'y') app.commands.execute(commandIDs.redo);
                 if (ctrlKey && keyCode === 's') app.commands.execute(commandIDs.saveXircuit);
-                // Comment this first until the TODO below is fix
-                // if (ctrlKey && keyCode === 'x') app.commands.execute(commandIDs.cutNode);
-                // if (ctrlKey && keyCode === 'c') app.commands.execute(commandIDs.copyNode);
-                // TODO: Fix this paste issue where it paste multiple times.
-                // if (ctrlKey && keyCode === 'v') app.commands.execute(commandIDs.pasteNode);
+                if (ctrlKey && keyCode === 'x') app.commands.execute(commandIDs.cutNode);
+                if (ctrlKey && keyCode === 'c') app.commands.execute(commandIDs.copyNode);
+                if (ctrlKey && keyCode === 'v') app.commands.execute(commandIDs.pasteNode);
                 if (keyCode == 'Delete' || keyCode == 'Backspace') app.commands.execute(commandIDs.deleteNode);
             }
         });

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -476,7 +476,6 @@ export function addNodeActionCommands(
         const widget = tracker.currentWidget?.content as XPipePanel;
 
         if (!widget) return;
-        console.log("copy called!")
 
         const copies = widget.xircuitsApp.getDiagramEngine().getModel().getSelectedEntities().map(entity =>
             entity.serialize(),
@@ -487,7 +486,6 @@ export function addNodeActionCommands(
 
     function pasteNode(): void {
         const widget = tracker.currentWidget?.content as XPipePanel;
-    
         if (!widget) return;
     
         const engine = widget.xircuitsApp.getDiagramEngine();
@@ -506,6 +504,12 @@ export function addNodeActionCommands(
         let totalX = 0, totalY = 0, nodesCount = clipboardNodes.length;
     
         clipboardNodes.forEach(serializedNode => {
+
+            if (serializedNode.name === 'Start' || serializedNode.name === 'Finish') {
+                console.log(serializedNode.name, " cannot be copied!")
+                return;
+            }
+
             let originalNodeInstance = model.getNodes().find(node => node.getID() === serializedNode.id);
             let clonedNodeModelInstance;
     

--- a/src/components/XircuitsApp.ts
+++ b/src/components/XircuitsApp.ts
@@ -113,7 +113,9 @@ export class XircuitsApplication {
                                 // Set points on link if exist
                                 const points = [];
                                 linkPoints.map((point)=> {
-                                        points.push(new PointModel({ id:point.id, link: link, position: new Point(point.x, point.y) }));
+                                        let newPoint = new PointModel({ id:point.id, link: link, position: new Point(point.x, point.y) })
+                                        if (point.selected) { newPoint.setSelected(true) };
+                                        points.push(newPoint)
                                 })
 
                                 newLink.setSourcePort(sourcePort);

--- a/src/components/link/CustomLinkFactory.tsx
+++ b/src/components/link/CustomLinkFactory.tsx
@@ -28,7 +28,7 @@ namespace S {
 
 export class CustomLinkFactory extends DefaultLinkFactory {
 	constructor() {
-		super('custom');
+		super('custom-link');
 	}
 
 	generateModel(): CustomLinkModel {
@@ -49,7 +49,7 @@ export class CustomLinkFactory extends DefaultLinkFactory {
 
 export class TriangleLinkFactory extends DefaultLinkFactory {
 	constructor() {
-		super('triangle');
+		super('triangle-link');
 	}
 
 	generateModel(): TriangleLinkModel {

--- a/src/components/link/CustomLinkModel.ts
+++ b/src/components/link/CustomLinkModel.ts
@@ -5,7 +5,7 @@ import { CustomPortModel } from '../port/CustomPortModel';
 export class CustomLinkModel extends DefaultLinkModel {
 	constructor(options: DefaultLinkModelOptions = {}) {
 		super({
-			type: 'custom',
+			type: 'custom-link',
 			width: 3,
 			...options
 		});
@@ -22,7 +22,7 @@ export class CustomLinkPortModel extends CustomPortModel {
 export class TriangleLinkModel extends DefaultLinkModel {
 	constructor(options: DefaultLinkModelOptions = {}) {
 		super({
-			type: 'triangle',
+			type: 'triangle-link',
 			width: 3,
 			...options
 		});

--- a/src/xircuitWidget.tsx
+++ b/src/xircuitWidget.tsx
@@ -3,8 +3,7 @@ import { ILabShell, JupyterFrontEnd } from '@jupyterlab/application';
 import { Signal } from '@lumino/signaling';
 import { Context } from '@jupyterlab/docregistry';
 import { BodyWidget } from './components/xircuitBodyWidget';
-import React, {  } from 'react';
-import * as _ from 'lodash';
+import React from 'react';
 import { ServiceManager } from '@jupyterlab/services';
 import { XircuitsApplication } from './components/XircuitsApp';
 
@@ -26,6 +25,9 @@ export class XPipePanel extends ReactWidget {
   lockNodeSignal: Signal<this, any>;
   reloadAllNodesSignal: Signal<this, any>;
 
+  // Add mousePosition state
+  mousePosition = { x: 0, y: 0 };
+
   constructor(options: any) {
     super(options);
     this.app = options.app;
@@ -44,20 +46,18 @@ export class XPipePanel extends ReactWidget {
   }
 
   handleEvent(event: Event): void {
-    if(event.type === 'mouseup'){
-      // force focus on the editor in order stop key event propagation (e.g. "Delete" key) into unintended
-      // parts of jupyter lab.
+    if (event instanceof MouseEvent && event.type === 'mouseup') {
+      // Update mousePosition state with current mouse position
+      this.mousePosition = { x: event.clientX, y: event.clientY };
+      
       this.node.focus();
-      // Just to enable back the loses focus event
       this.node.addEventListener('blur', this, true);
-    }else if(event.type === 'blur'){
-      // Unselect any selected nodes when the editor loses focus
+    } else if (event.type === 'blur') {
       const deactivate = x => x.setSelected(false);
       const model = this.xircuitsApp.getDiagramEngine().getModel();
       model.getNodes().forEach(deactivate);
       model.getLinks().forEach(deactivate);
-    }else if(event.type === 'contextmenu'){
-      // Disable loses focus event when opening context menu
+    } else if (event.type === 'contextmenu') {
       this.node.removeEventListener('blur', this, true);
     }
   }

--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -101,7 +101,7 @@ def main(args):
         for node in component_nodes:
             # Handle argument connections
             for port in (p for p in node.ports if
-                         p.direction == 'in' and p.type == 'triangle' and p.source.name.startswith('Argument ')):
+                         p.direction == 'in' and p.type == 'triangle-link' and p.source.name.startswith('Argument ')):
                 # Unfortunately, we don't have the information anywhere else and updating the file format isn't an option at the moment
                 pattern = re.compile(r'^Argument \(.+?\): (.+)$')
                 arg_name = pattern.match(port.source.name).group(1)
@@ -115,7 +115,7 @@ def main(args):
                 code.append(tpl)
 
             # Handle regular connections
-            for port in (p for p in node.ports if p.direction == 'in' and p.type != 'triangle'):
+            for port in (p for p in node.ports if p.direction == 'in' and p.type != 'triangle-link'):
                 assignment_target = "%s.%s" % (
                     named_nodes[port.target.id],
                     port.targetLabel
@@ -148,7 +148,7 @@ def main(args):
         # Set up control flow
         for node in component_nodes:
             has_next = False
-            for port in (p for p in node.ports if p.direction == "out" and p.type == "triangle"):
+            for port in (p for p in node.ports if p.direction == "out" and p.type == "triangle-link"):
                 has_next = True
                 if port.name == "out-0":
                     assignment_target = "%s.next" % named_nodes[port.source.id]


### PR DESCRIPTION
# Description

This PR fixes bugs and enhances the cut-copy-pasting related functions and refines the event handling process. Specifically:

1. Prevent keyboard events from being fired multiple times when having multiple canvas tabs.
2. Enabled spawning on mouse coordinates. 
3. Enabled cross-canvas paste. 
4. Enabled cut-copy-pasting from the keyboard shortcuts.
5. Enabled links and link points for cut-copy-pasting.
6. Updated clone action from happening during the copy process.

## References

https://github.com/XpressAI/xircuits/pull/105
https://github.com/XpressAI/xircuits/issues/184

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Test for Spawning on Mouse Coordinates**

    1. Cut / copy a component
    2. Right click on a canvas area and paste spawn
    3. Ensure that the new component appears around at the mouse coordinates.

**2. Test for Cut-Copy-Pasting from the Keyboard**

    1. Select a component and cut or copy using keyboard commands.
    2. Paste using keyboard commands.
    3. Ensure the component is cut-copied-pasted correctly.
    
**3. Test for Keyboard Events on Multiple Canvas Tabs**

    1. Open multiple canvas tabs.
    2. Fire a keyboard event (like cut-copy-paste).
    5. Ensure the event is fired and processed only once.
   
**4. Test for Cross-Canvas Paste**

    1. Copy a component from one canvas.
    2. Switch to a different canvas and paste.
    3. Ensure the component appears in the new canvas.

**5. Test for Cut-Copy-Pasting Links and Link Points**

    1. Create link points on a link and perform a cut or copy operation.
    2. Paste it.
    3. Ensure that the link and link points is cut-copied-pasted correctly.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Currently we're hardcoding the CustomNodeActions in the source code. In the future we should properly implement them as [Jupyterlab configs](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#plugin-settings).