### PR TITLE
🐛 Stop event propagating between different active widgets

### DIFF
--- a/src/commands/CustomActionEvent.tsx
+++ b/src/commands/CustomActionEvent.tsx
@@ -24,14 +24,18 @@ export class CustomActionEvent extends Action {
                     }
                 }
 
-                executeIf(ctrlKey && keyCode === 'z', commandIDs.undo);
-                executeIf(ctrlKey && keyCode === 'y', commandIDs.redo);
-                executeIf(ctrlKey && keyCode === 's', commandIDs.saveXircuit);
-                executeIf(ctrlKey && keyCode === 'x', commandIDs.cutNode);
-                executeIf(ctrlKey && keyCode === 'c', commandIDs.copyNode);
-                executeIf(ctrlKey && keyCode === 'v', commandIDs.pasteNode);
-                executeIf(keyCode == 'Delete' || keyCode == 'Backspace', commandIDs.deleteNode);
+                // @ts-ignore
+                if (app.shell._tracker._activeWidget && app.shell._tracker._activeWidget.node.contains(event.event.target)){
+                    executeIf(ctrlKey && keyCode === 'z', commandIDs.undo);
+                    executeIf(ctrlKey && keyCode === 'y', commandIDs.redo);
+                    executeIf(ctrlKey && keyCode === 's', commandIDs.saveXircuit);
+                    executeIf(ctrlKey && keyCode === 'x', commandIDs.cutNode);
+                    executeIf(ctrlKey && keyCode === 'c', commandIDs.copyNode);
+                    executeIf(ctrlKey && keyCode === 'v', commandIDs.pasteNode);
+                    executeIf(keyCode == 'Delete' || keyCode == 'Backspace', commandIDs.deleteNode);
+                }
             }
+
         });
     }
 }


### PR DESCRIPTION
# Description

This patch addresses an issue of event propagation between different active widgets (such as an input dialogue panel or the tray widget) in the Xircuits application. Previously, keyboard shortcuts (ctrl+z, ctrl+y, ctrl+s, ctrl+x, ctrl+c, ctrl+v, Delete, and Backspace) were executed regardless of the active widget, which resulted in unintended consequences.

The change ensures that the shortcuts are only executed when the event's target is within the currently active widget. This is achieved by adding a condition to check if the target of the event is contained within the active widget before executing any commands.

## References
https://github.com/XpressAI/xircuits/pull/253

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Copy a node. Then open an active panel (such as the tray widget or a string input dialogue panel).
2. Verify that on paste, it does not propagate the paste node.


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Add if any.
