### PR TITLE
🐛 Fix Linux-based submodule install

### DIFF
--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -2,13 +2,14 @@
 """A wrapper to start xircuits and offer to start to XAI-components"""
 
 from pathlib import Path
-from urllib import request
 import os
 import argparse
 import pkg_resources
 import shutil
 from .handlers.request_folder import request_folder
 from .handlers.request_submodule import get_submodule_config, request_submodule_library
+import subprocess
+import platform
 
 def init_xircuits():
 
@@ -68,8 +69,11 @@ def download_submodule_library():
         submodule_path, _ = get_submodule_config(args.submodule_library)
 
         print("Installing " + args.submodule_library + "...")
-        install_cmd = "cmd /c pip install -r " + submodule_path + "/requirements.txt"
-        os.system(install_cmd)
+        if platform.system() == "Windows":
+            install_cmd = ["cmd", "/c", "pip", "install", "-r", submodule_path + "/requirements.txt"]
+        else:
+            install_cmd = ["pip", "install", "-r", submodule_path + "/requirements.txt"]
+        subprocess.run(install_cmd, check=True)
 
 def main():
 

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -9,7 +9,7 @@ import shutil
 from .handlers.request_folder import request_folder
 from .handlers.request_submodule import get_submodule_config, request_submodule_library
 import subprocess
-import platform
+import sys
 
 def init_xircuits():
 
@@ -69,11 +69,7 @@ def download_submodule_library():
         submodule_path, _ = get_submodule_config(args.submodule_library)
 
         print("Installing " + args.submodule_library + "...")
-        if platform.system() == "Windows":
-            install_cmd = ["cmd", "/c", "pip", "install", "-r", submodule_path + "/requirements.txt"]
-        else:
-            install_cmd = ["pip", "install", "-r", submodule_path + "/requirements.txt"]
-        subprocess.run(install_cmd, check=True)
+        subprocess.run([sys.executable, "-m", "pip", "install", "-r",  submodule_path + "/requirements.txt"], check=True)
 
 def main():
 


### PR DESCRIPTION
# Description

This patch fixes a bug that was causing the installation of submodule libraries to fail on Linux systems in the xircuits project. The issue was due to the usage of the os.system function with a command that is specific to Windows. The code has now been refactored to use the subprocess.run function instead and directly calls pip as a module using the current Python executable. This approach is more reliable and portable across different Python environments and operating systems. 

## References
https://github.com/XpressAI/xircuits/pull/226

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Run `xircuits-submodules component-lib-name` on a Linux based system. Verify that the component is pulled and installed.


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  