### PR TITLE
✨ Literal Chat

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -680,13 +680,16 @@ export function addNodeActionCommands(
 
             let node = null;
             const links = widget.xircuitsApp.getDiagramEngine().getModel()["layers"][0]["models"];
-            const oldValue = selected_node.getPorts()["out-0"].getOptions()["label"];
+            var oldValue = selected_node.getPorts()["out-0"].getOptions()["label"];
             const literalType = selected_node["name"].split(" ")[1];
             let inputType: string = "";
             
             switch(literalType){
                 case "String":
                     inputType = 'textarea';
+                    break;
+                case "Chat":
+                    oldValue = JSON.parse(oldValue);
                     break;
                 case "True":
                 case "False":

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -683,20 +683,11 @@ export function addNodeActionCommands(
             const oldValue = selected_node.getPorts()["out-0"].getOptions()["label"];
             const literalType = selected_node["name"].split(" ")[1];
             let isStoreDataType: boolean = false;
-            let isTextareaInput: string = "";
+            let inputType: string = "";
             
             switch(literalType){
                 case "String":
-                    isTextareaInput = 'textarea';
-                    break;
-                case "List":
-                case "Tuple":
-                case "Dict":
-                case "Chat":
-                isStoreDataType = true;
-                    break;
-                case "Secret":
-                    isStoreDataType = false;
+                    inputType = 'textarea';
                     break;
                 case "True":
                 case "False":
@@ -705,7 +696,7 @@ export function addNodeActionCommands(
                     break;
             }
             const updateTitle = `Update ${literalType}`;
-            const dialogOptions = inputDialog(updateTitle, oldValue, literalType, isStoreDataType, isTextareaInput);
+            const dialogOptions = inputDialog({ title:updateTitle, oldValue:oldValue, type:literalType, inputType});
             const dialogResult = await showFormDialog(dialogOptions);
             if (dialogResult["button"]["label"] == 'Cancel') {
                 // When Cancel is clicked on the dialog, just return
@@ -715,7 +706,7 @@ export function addNodeActionCommands(
             var updatedContent = dialogResult["value"][updateTitle];
 
             while (!checkInput(updatedContent, literalType)){
-                const dialogOptions = inputDialog(updateTitle, updatedContent, literalType, isStoreDataType, isTextareaInput);
+                const dialogOptions = inputDialog({ title:updateTitle, oldValue:updatedContent, type:literalType, inputType});
                 const dialogResult = await showFormDialog(dialogOptions);
                 if (dialogResult["button"]["label"] == 'Cancel') return;
                 updatedContent = dialogResult["value"][updateTitle];

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -692,7 +692,8 @@ export function addNodeActionCommands(
                 case "List":
                 case "Tuple":
                 case "Dict":
-                    isStoreDataType = true;
+                case "Chat":
+                isStoreDataType = true;
                     break;
                 case "Secret":
                     isStoreDataType = false;

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -682,7 +682,6 @@ export function addNodeActionCommands(
             const links = widget.xircuitsApp.getDiagramEngine().getModel()["layers"][0]["models"];
             const oldValue = selected_node.getPorts()["out-0"].getOptions()["label"];
             const literalType = selected_node["name"].split(" ")[1];
-            let isStoreDataType: boolean = false;
             let inputType: string = "";
             
             switch(literalType){
@@ -703,15 +702,16 @@ export function addNodeActionCommands(
                 return;
             }
 
-            var updatedContent = dialogResult["value"][updateTitle];
+            var updatedContent = dialogResult["value"][updateTitle] || dialogResult["value"];
 
             while (!checkInput(updatedContent, literalType)){
                 const dialogOptions = inputDialog({ title:updateTitle, oldValue:updatedContent, type:literalType, inputType});
                 const dialogResult = await showFormDialog(dialogOptions);
                 if (dialogResult["button"]["label"] == 'Cancel') return;
-                updatedContent = dialogResult["value"][updateTitle];
+                updatedContent = dialogResult["value"][updateTitle] || dialogResult["value"];
             }
-            const strContent: string = updatedContent;
+
+            let strContent: string = (literalType == 'Chat') ? JSON.stringify(updatedContent) : updatedContent;
 
             node = new CustomNodeModel({ name: selected_node["name"], color: selected_node["color"], extras: { "type": selected_node["extras"]["type"] } });
             node.addOutPortEnhance(strContent, 'out-0');

--- a/src/components/port/CustomPortLabel.tsx
+++ b/src/components/port/CustomPortLabel.tsx
@@ -99,8 +99,10 @@ export class CustomPortLabel extends React.Component<CustomPortLabelProps> {
 				break;
 			case "secret":
 				symbolLabel = '🗝️';
+			case "chat":
+				symbolLabel = '🗨';
 				break;
-				case "any":
+			case "any":
 				symbolLabel = '[_]';
 				break;
 			case "0":

--- a/src/components/port/CustomPortLabel.tsx
+++ b/src/components/port/CustomPortLabel.tsx
@@ -64,54 +64,31 @@ export class CustomPortLabel extends React.Component<CustomPortLabelProps> {
 		} else {
 			portType = portName.split("-")[1];
 		}
-		// if multiple types provided, show the symbol for the first provided type
 		if (portType.includes(',')) {
 			portType = 'union';
 		}
 
-		switch (portType) {
-			case "string":
-				symbolLabel = '" "';
-				break;
-			case "int":
-				symbolLabel = ' 1';
-				break;
-			case "float":
-				symbolLabel = '1.0';
-				break;
-			case "boolean":
-				symbolLabel = '⊤⊥';
-				break;
-			case "time.time":
-				symbolLabel = '𝘵';
-				break;
-			case "list":
-				symbolLabel = '[ ]';
-				break;
-			case "tuple":
-				symbolLabel = '( )';
-				break;
-			case "dict":
-				symbolLabel = '{ }';
-				break;
-			case "union":
-				symbolLabel = ' U';
-				break;
-			case "secret":
-				symbolLabel = '🗝️';
-			case "chat":
-				symbolLabel = '🗨';
-				break;
-			case "any":
-				symbolLabel = '[_]';
-				break;
-			case "0":
-			case "flow":
-				symbolLabel = null;
-				break;
-			default:
-				symbolLabel = '◎';
-				break;
+		const symbolMap = {
+			"string": '" "',
+			"int": ' 1',
+			"float": '1.0',
+			"boolean": '⊤⊥',
+			"time.time": '𝘵',
+			"list": '[ ]',
+			"tuple": '( )',
+			"dict": '{ }',
+			"union": ' U',
+			"secret": '🗝️',
+			"chat": '🗨',
+			"any": '[_]',
+			"0": null,
+			"flow": null
+		};
+		
+		if (portType in symbolMap) {
+			symbolLabel = symbolMap[portType];
+		} else {
+			symbolLabel = '◎';
 		}
 
 		const port = (

--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -6,6 +6,12 @@ import {PortModel} from "@projectstorm/react-diagrams-core";
  * custom port model enable it can execute some rule
  * before it can link to another
  */
+
+const PARAMETER_NODE_TYPES = [
+    'boolean', 'int', 'float', 'string', 'list', 'tuple', 
+    'dict', 'secret', 'chat'
+];
+
 export  class CustomPortModel extends DefaultPortModel  {
 
 
@@ -146,16 +152,7 @@ export  class CustomPortModel extends DefaultPortModel  {
     }
 
     isParameterNode = (nodeModelType: string) => {
-        return (
-            nodeModelType === 'boolean' ||
-            nodeModelType === 'int' ||
-            nodeModelType === 'float' ||
-            nodeModelType === 'string' ||
-            nodeModelType === 'list' ||
-            nodeModelType === 'tuple' ||
-            nodeModelType === 'dict' ||
-            nodeModelType === 'secret'
-        );
+        return PARAMETER_NODE_TYPES.includes(nodeModelType);
     }
 
     canTriangleLinkToTriangle = (thisPort, port) => {
@@ -219,16 +216,7 @@ export  class CustomPortModel extends DefaultPortModel  {
 
         //console.log("sourceNode is:", sourceNode.getOptions()["name"], "\ntargetNode is:", targetNode.getOptions()["name"]);
 
-        while ((sourceNode != null) &&
-                nodeType != 'Start' &&
-                nodeType != 'boolean' &&
-                nodeType != 'int' &&
-                nodeType != 'float' &&
-                nodeType != 'string' &&
-                nodeType != 'list' &&
-                nodeType != 'tuple' &&
-                nodeType != 'dict' &&
-                nodeType != 'secret'){
+        while (sourceNode != null && nodeType != 'Start' && !PARAMETER_NODE_TYPES.includes(nodeType)) {
             //console.log("Curent sourceNode:", sourceNode.getOptions()["name"]);
             let inPorts = sourceNode.getInPorts();
             

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -23,7 +23,8 @@ import ComponentsPanel from '../context-menu/ComponentsPanel';
 import { cancelDialog, GeneralComponentLibrary } from '../tray_library/GeneralComponentLib';
 import { NodeActionsPanel } from '../context-menu/NodeActionsPanel';
 import { AdvancedComponentLibrary, fetchNodeByName } from '../tray_library/AdvanceComponentLib';
-import { inputDialog, getItsLiteralType } from '../dialog/LiteralInputDialog';
+import { inputDialog } from '../dialog/LiteralInputDialog';
+import { getItsLiteralType } from '../dialog/input-dialogues/VariableInput'
 import { lowPowerMode, setLowPowerMode } from './state/powerModeState';
 
 export interface BodyWidgetProps {
@@ -816,7 +817,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 				break;
 			case 'boolean':
 				let boolTitle = 'Enter boolean value: ';
-				const dialogOptions = inputDialog(boolTitle, "", 'Boolean');
+				const dialogOptions = inputDialog({ title:boolTitle, oldValue:"", type:'Boolean'});
 				const dialogResult = await showFormDialog(dialogOptions);
 				if (cancelDialog(dialogResult)) return;
 				let boolValue = dialogResult["value"][boolTitle];

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -1,12 +1,22 @@
-import TextareaAutosize from 'react-textarea-autosize';
-import React, { useState } from 'react';
+import React from 'react';
 import { formDialogWidget } from "./formDialogwidget";
 import { Dialog } from '@jupyterlab/apputils';
-import Switch from "react-switch";
 import { showFormDialog } from './FormDialog';
 import { cancelDialog } from '../tray_library/GeneralComponentLib';
 import { checkInput } from '../helpers/InputSanitizer';
+import { BooleanInput } from './input-dialogues/BooleanInput';
+import { StringInput } from './input-dialogues/StringInput';
+import { TextAreaInput } from './input-dialogues/TextAreaInput';
+import { NumberInput } from './input-dialogues/NumberInput';
+import { DictInput } from './input-dialogues/DictInput';
+import { TupleInput } from './input-dialogues/TupleInput';
+import { ListInput } from './input-dialogues/ListInput';
+import { ChatInput } from './input-dialogues/ChatInput';
+import { SecretInput } from './input-dialogues/SecretInput';
+import { VariableInput } from './input-dialogues/VariableInput';
+import { ParameterInput } from './input-dialogues/ParameterInput';
 
+  
 export function inputDialog(titleName: string, oldValue: any, type: string, isStoreDataType?: boolean, inputType?: string) {
 	let title = titleName;
 	const dialogOptions: Partial<Dialog.IOptions<any>> = {
@@ -55,135 +65,31 @@ export async function getItsLiteralType(){
 
 export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inputType }): JSX.Element => {
 
-	const [checked, setChecked] = useState<boolean>(true);
-
-	const handleChecked = () => {
-		setChecked(!checked);
+	const inputComponents = {
+		textarea: TextAreaInput,
+		Integer: NumberInput,
+		Float: NumberInput,
+		Boolean: BooleanInput,
+		String: StringInput,
+		Dict: DictInput,
+		List: ListInput,
+		Tuple: TupleInput,
+		Variable: VariableInput,
+		Secret: SecretInput,
+		Chat: ChatInput,
+		Parameter: ParameterInput,
 	};
 
-	function InputDialogueMessageDisplay() {
-		if (type == 'Dict') {
-			return (
-				<h5 style={{ marginTop: 0, marginBottom: 5 }}>
-					For Example: "a": "apple", "b": "banana", "c": 2022
-				</h5>
-			);
-		} else if (type == 'List' || type == 'Tuple') {
-			return (
-				<h5 style={{ marginTop: 0, marginBottom: 5 }}>
-					For Example: "a", "b", "c"
-				</h5>
-			);
-		} else if (type == 'Secret') {
-			return (
-				<h5 style={{ marginTop: 0, marginBottom: 5 }}>
-					Warning: Literal Secrets are masked in the frontend only. <br />
-					They can still be accessed in the raw .xircuits file or appear as strings in the compiled script.
-				</h5>
-			);
-		} else if (type == 'Chat') {
-			return (
-				<h5 style={{ marginTop: 0, marginBottom: 5 }}>
-					Placeholder for Literal Chat<br />
-				</h5>
-			);
-		} else if (type == 'Variable'){
-			return (
-				<h5 style={{ marginTop: 0, marginBottom: 5 }}>
-					<p>Determine your variable type by inserting the first char as below: </p>
-					<li> " : String</li>
-					<li> # : Integer or Float</li>
-					<li> [ : List</li>
-					<li> ( : Tuple</li>
-					<li> {'{'} : Dict</li>
-					<li> !true / !True / !1 / !t : True</li>
-					<li> !false / !False / !0 / !nil : False</li>
-					<p>For Example: "Hello World or #15 or !true</p>
-				</h5>
-			);
-		}
-		return null;
+	const InputValueDialog = () => {
+		const InputComponent = inputComponents[inputType === 'textarea' ? inputType : type];
+		
+		// The `type` prop is now passed to all components
+		const extraProps = { type };
+
+		return InputComponent ? <InputComponent title={title} oldValue={oldValue} {...extraProps} /> : null;
 	}
 
-	function InputValueDialog() {
-		if (inputType == 'textarea') {
-			return (
-				<div>
-					<TextareaAutosize
-						defaultValue={oldValue}
-						minRows={14}
-						name={title}
-						style={{ width: 400, height: 200, fontSize: 12 }}
-						autoFocus />
-				</div>
-			);
-		} else if (type == 'Integer' || type == 'Float') {
-			return (
-				<input
-					name={title}
-					type="number"
-					step={type == 'Float' ? "0.01" : "1"}
-					placeholder={type == 'Float' ? "0.00" : "0"}
-					style={{ width: 350 }}
-					defaultValue={oldValue} />
-			);
-		} else if (type == 'Boolean') {
-			return (
-				<div style={{ paddingLeft: 5, paddingTop: 5}}>
-					<Switch
-						checked={checked}
-						name={title}
-						onChange={() => handleChecked()}
-						boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
-						handleDiameter={25}
-						height={20}
-						width={48}
-					/>
-				</div>
-			);
-		} else if (
-			(type == 'String' && inputType != 'textarea') ||
-			type == 'List' ||
-			type == 'Tuple' ||
-			type == 'Dict' || 
-			type == 'Variable'
-		) {
-			return (
-				<input
-					name={title}
-					style={{ width: 350 }}
-					defaultValue={oldValue} />
-			);
-		} else if (type == 'Secret') {
-        return (
-            <input
-                name={title}
-                type="password"
-                style={{ width: 480 }}
-                defaultValue={oldValue} />
-        );
-    } else if (type == 'Chat') {
-        return (
-            <input
-                name={title}
-                style={{ width: 480 }}
-                defaultValue={oldValue} />
-        );
-    }
-		return null;
-	}
-
-	return (
-		<form>
-			{type != 'Boolean' && type != 'Variable' ?
-				<h3 style={{ marginTop: 0, marginBottom: 5 }}>
-					Enter {title.includes('parameter') ? 'Argument Name' : `${type} Value`} ({isStoreDataType ? 'Without Brackets' : 'Without Quotes'}):
-				</h3>
-				: null}
-			<InputDialogueMessageDisplay />
-			<InputValueDialog />
-		</form>
-	);
+	return <InputValueDialog />;
 }
 
 function varTypeChecker(varType, varInput, varValue){

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { formDialogWidget } from "./formDialogwidget";
 import { Dialog } from '@jupyterlab/apputils';
-import { showFormDialog } from './FormDialog';
-import { cancelDialog } from '../tray_library/GeneralComponentLib';
-import { checkInput } from '../helpers/InputSanitizer';
 import { BooleanInput } from './input-dialogues/BooleanInput';
 import { StringInput } from './input-dialogues/StringInput';
 import { TextAreaInput } from './input-dialogues/TextAreaInput';
@@ -16,17 +13,21 @@ import { SecretInput } from './input-dialogues/SecretInput';
 import { VariableInput } from './input-dialogues/VariableInput';
 import { ParameterInput } from './input-dialogues/ParameterInput';
 
+export interface InputDialogueProps {
+	title: string;
+	oldValue: any;
+	type: string;
+	inputType?: string;
+  }
   
-export function inputDialog(titleName: string, oldValue: any, type: string, isStoreDataType?: boolean, inputType?: string) {
-	let title = titleName;
+export function inputDialog({ title, oldValue, type, inputType }: InputDialogueProps) {
 	const dialogOptions: Partial<Dialog.IOptions<any>> = {
 		title,
 		body: formDialogWidget(
 			<LiteralInputDialog
-				title={titleName}
+				title={title}
 				oldValue={oldValue}
 				type={type}
-				isStoreDataType={isStoreDataType}
 				inputType={inputType} />
 		),
 		buttons: [Dialog.cancelButton(), Dialog.okButton({ label: ('Submit') })],
@@ -36,34 +37,7 @@ export function inputDialog(titleName: string, oldValue: any, type: string, isSt
 	return dialogOptions;
 }
 
-export async function getItsLiteralType(){
-	// When inPort is 'any' type, get the correct literal type based on the first character inputed
-	let varOfAnyTypeTitle = 'Enter your variable value';
-	const dialogOptions = inputDialog(varOfAnyTypeTitle, "", 'Variable');
-	const dialogResult = await showFormDialog(dialogOptions);
-	if (cancelDialog(dialogResult)) return;
-	let varValue = dialogResult["value"][varOfAnyTypeTitle];
-	let varType = varValue.charAt(0);
-	let varInput : string = varValue.slice(1);
-	let nodeType = varTypeChecker(varType, varInput, varValue);
-	
-	while (!checkInput(varInput, nodeType)){
-
-		const dialogOptions = inputDialog(varOfAnyTypeTitle, varValue, 'Variable');
-		const dialogResult = await showFormDialog(dialogOptions);
-		
-		if (cancelDialog(dialogResult)) return;
-		varValue = dialogResult["value"][varOfAnyTypeTitle];
-		varType = varValue.charAt(0);
-		varInput = varValue.slice(1);
-		 nodeType = varTypeChecker(varType, varInput, varValue);
-
-	}
-
-	return { nodeType, varInput }
-}
-
-export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inputType }): JSX.Element => {
+export const LiteralInputDialog = ({ title, oldValue, type, inputType }): JSX.Element => {
 
 	const inputComponents = {
 		textarea: TextAreaInput,
@@ -90,30 +64,4 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 	}
 
 	return <InputValueDialog />;
-}
-
-function varTypeChecker(varType, varInput, varValue){
-    const typeCheckDict = {
-        '"': () => 'String',
-        '#': () => Number.isInteger(Number(varInput)) ? 'Integer' : 'Float',
-        '[': () => 'List',
-        '(': () => 'Tuple',
-        '{': () => 'Dict',
-        '!': () => {
-            let boolValue = varValue.slice(1).toLowerCase();
-            if (boolValue === 'true' || boolValue === '1' || boolValue === 't') {
-                return 'True';
-            } else if (boolValue === 'false' || boolValue === '0' || boolValue === 'nil') {
-                return 'False';
-            }
-        }
-    };
-
-    let nodeType = typeCheckDict[varType] ? typeCheckDict[varType]() : 'undefined_any';
-
-    if (nodeType == 'undefined_any') {
-        console.error(`Type is undefined or not provided. Please insert the first character as shown in example.`);
-    }
-
-    return nodeType;
 }

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -81,6 +81,12 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
 					They can still be accessed in the raw .xircuits file or appear as strings in the compiled script.
 				</h5>
 			);
+		} else if (type == 'Chat') {
+			return (
+				<h5 style={{ marginTop: 0, marginBottom: 5 }}>
+					Placeholder for Literal Chat<br />
+				</h5>
+			);
 		} else if (type == 'Variable'){
 			return (
 				<h5 style={{ marginTop: 0, marginBottom: 5 }}>
@@ -153,6 +159,13 @@ export const LiteralInputDialog = ({ title, oldValue, type, isStoreDataType, inp
             <input
                 name={title}
                 type="password"
+                style={{ width: 480 }}
+                defaultValue={oldValue} />
+        );
+    } else if (type == 'Chat') {
+        return (
+            <input
+                name={title}
                 style={{ width: 480 }}
                 defaultValue={oldValue} />
         );

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -11,7 +11,7 @@ import { ListInput } from './input-dialogues/ListInput';
 import { ChatInput } from './input-dialogues/ChatInput';
 import { SecretInput } from './input-dialogues/SecretInput';
 import { VariableInput } from './input-dialogues/VariableInput';
-import { ParameterInput } from './input-dialogues/ParameterInput';
+import { ArgumentInput } from './input-dialogues/ArgumentInput';
 
 export interface InputDialogueProps {
 	title: string;
@@ -51,14 +51,14 @@ export const LiteralInputDialog = ({ title, oldValue, type, inputType }): JSX.El
 		Variable: VariableInput,
 		Secret: SecretInput,
 		Chat: ChatInput,
-		Parameter: ParameterInput,
+		Argument: ArgumentInput,
 	};
 
 	const InputValueDialog = () => {
 		const InputComponent = inputComponents[inputType === 'textarea' ? inputType : type];
 		
 		// The `type` prop is now passed to all components
-		const extraProps = { type };
+		const extraProps = { type, inputType };
 
 		return InputComponent ? <InputComponent title={title} oldValue={oldValue} {...extraProps} /> : null;
 	}

--- a/src/dialog/formDialogwidget.tsx
+++ b/src/dialog/formDialogwidget.tsx
@@ -11,13 +11,16 @@ export const formDialogWidget = (
   // order to trigger a render of the DOM nodes from the React element.
   MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
 
-  widget.getValue = (): any => {
+widget.getValue = (): any => {
     const form = widget.node.querySelector('form');
-    const formValues: { [key: string]: any } = {};
+    let formValues: { [key: string]: any } = {};
     for (const element of Object.values(
       form?.elements ?? []
     ) as HTMLInputElement[]) {
-      switch (element.type) {
+      switch (element.name) {
+        case 'messages':
+          formValues = JSON.parse(element.value);
+          break;
         case 'checkbox':
           formValues[element.name] = element.checked;
           break;

--- a/src/dialog/input-dialogues/ArgumentInput.tsx
+++ b/src/dialog/input-dialogues/ArgumentInput.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-export const ParameterInput = ({ title, oldValue, type }): JSX.Element => {
+export const ArgumentInput = ({ title, oldValue, inputType }): JSX.Element => {
     return (
         <form>
             <h3 style={{ marginTop: 0, marginBottom: 5 }}>
-                Enter {type} Argument Name (Without Quotes):
+                Enter {inputType} Argument Name:
             </h3>
         <input
             name={title}

--- a/src/dialog/input-dialogues/BooleanInput.tsx
+++ b/src/dialog/input-dialogues/BooleanInput.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import Switch from "react-switch";
+
+export const BooleanInput = ({ title, oldValue }): JSX.Element => {
+	const [checked, setChecked] = useState<boolean>(true);
+
+	const handleChecked = () => {
+		setChecked(!checked);
+	};
+
+	return (
+		<div style={{ paddingLeft: 5, paddingTop: 5 }}>
+			<Switch
+				checked={checked}
+				name={title}
+				onChange={() => handleChecked()}
+				boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
+				handleDiameter={25}
+				height={20}
+				width={48}
+			/>
+		</div>
+	);
+}

--- a/src/dialog/input-dialogues/ChatInput.tsx
+++ b/src/dialog/input-dialogues/ChatInput.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+
+export const ChatInput = ({ title, oldValue }): JSX.Element => {
+    const [messages, setMessages] = useState(oldValue.messages || [{ role: '', content: '' }]);
+
+    const addMessage = () => {
+        setMessages([...messages, { role: '', content: '' }]);
+    };
+    
+    const removeMessage = (index) => {
+        setMessages(messages.filter((message, i) => i !== index));
+    };
+    
+    const updateMessage = (index, field, value) => {
+        let newMessages = [...messages];
+        newMessages[index][field] = value;
+        setMessages(newMessages);
+    };
+
+    return (
+			<div>
+			  <label>Model</label>
+			  <select name="model" defaultValue={oldValue.model}>
+				<option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
+				{/* Add other options here as needed */}
+			  </select>
+		
+			  <label>Temperature</label>
+			  <input
+				name="temperature"
+				type="number"
+				min="0"
+				max="2"
+				step="0.01"
+				defaultValue={oldValue.temperature}
+			  />
+		
+			  <label>Top_p</label>
+			  <input
+				name="top_p"
+				type="number"
+				min="0"
+				max="1"
+				step="0.01"
+				defaultValue={oldValue.top_p}
+			  />
+		
+			  <label>Messages</label>
+			  {messages.map((message, index) => (
+				<div key={index}>
+				  <label>Role</label>
+				  <select
+					name={`role${index}`}
+					value={message.role}
+					onChange={(e) => updateMessage(index, 'role', e.target.value)}
+				  >
+					<option value="system">system</option>
+					<option value="user">user</option>
+					<option value="assistant">assistant</option>
+					<option value="function">function</option>
+				  </select>
+		
+				  <label>Content</label>
+				  <input
+					name={`content${index}`}
+					value={message.content}
+					onChange={(e) => updateMessage(index, 'content', e.target.value)}
+				  />
+		
+				  <button type="button" onClick={() => removeMessage(index)}>Remove</button>
+				</div>
+			  ))}
+		
+			  <button type="button" onClick={addMessage}>Add Message</button>
+			</div>
+		  );
+		}

--- a/src/dialog/input-dialogues/ChatInput.tsx
+++ b/src/dialog/input-dialogues/ChatInput.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import TextareaAutosize from 'react-textarea-autosize';
 
 type OldValueProps = {
     messages?: Array<{ role: string, content: string }>
@@ -26,40 +27,57 @@ export const ChatInput = ({ title, oldValue = {}, onSubmit }: { title: string, o
         setMessages(newMessages);
     };
 
+    const gridContainer = {
+        display: 'grid',
+        gridTemplateColumns: '1fr',
+        gridGap: '10px',
+        padding: '20px',
+        width: '400px',
+        marginLeft: 'auto',
+        marginRight: 'auto',
+    };
+
+    const flexContainer = {
+        display: 'flex',
+        marginBottom: '10px',
+    };
+
+    const selectStyle = {
+        flex: '1',
+    };
+
     return (
         <form>
-            <div className="jp-mod-styled">
-                <label className="jp-mod-styled">Messages</label>
+            <div style={gridContainer} className="jp-mod-styled">
+                <label>Messages</label>
                 {messages.map((message, index) => (
                     <div key={index} className="jp-mod-styled">
-                        <label className="jp-mod-styled">Role</label>
-                        <select
-                            name="role"
-                            value={message.role}
-                            onChange={(e) => updateMessage(index, 'role', e.target.value)}
-                            className="jp-mod-styled"
-                        >
-                            <option value="">Select a role</option>
-                            <option value="system">system</option>
-                            <option value="user">user</option>
-                            <option value="assistant">assistant</option>
-                            <option value="function">function</option>
-                        </select>
-
-                        <label className="jp-mod-styled">Content</label>
-                        <input
+                        <div style={flexContainer}>
+                            <select
+                                name="role"
+                                value={message.role}
+                                onChange={(e) => updateMessage(index, 'role', e.target.value)}
+                                style={selectStyle} className="jp-mod-styled"
+                            >
+                                <option value="">Select a role</option>
+                                <option value="system">system</option>
+                                <option value="user">user</option>
+                                <option value="assistant">assistant</option>
+                                <option value="function">function</option>
+                            </select>
+                            <button type="button" onClick={() => removeMessage(index)} className="jp-mod-styled">Remove</button>
+                        </div>
+                        <TextareaAutosize
+                            minRows={4}
                             name="content"
-                            value={message.content}
+                            style={{ width: '100%', fontSize: 12 }}
                             onChange={(e) => updateMessage(index, 'content', e.target.value)}
-                            className="jp-mod-styled"
-                        />
-
-                        <button type="button" onClick={() => removeMessage(index)} className="jp-mod-styled">Remove</button>
+                            autoFocus />
                     </div>
                 ))}
-                <button type="button" onClick={addMessage} className="jp-mod-styled">Add Message</button>
+                <button type="button" onClick={addMessage} style={{gridColumn: 'span 1'}} className="jp-mod-styled">Add Message</button>
             </div>
-			<input type="hidden" name="messages" value={hiddenMessagesValue} />
+            <input type="hidden" name="messages" value={hiddenMessagesValue} />
         </form>
     );
 }

--- a/src/dialog/input-dialogues/ChatInput.tsx
+++ b/src/dialog/input-dialogues/ChatInput.tsx
@@ -1,21 +1,23 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 type OldValueProps = {
-    model?: string,
-    temperature?: number,
-    top_p?: number,
     messages?: Array<{ role: string, content: string }>
 }
 
-export const ChatInput = ({ title, oldValue = {} }: { title: string, oldValue?: OldValueProps }): JSX.Element => {
+export const ChatInput = ({ title, oldValue = {}, onSubmit }: { title: string, oldValue?: OldValueProps, onSubmit: (value: Array<{ role: string, content: string }>) => void }): JSX.Element => {
     const [messages, setMessages] = useState(oldValue.messages || [{ role: '', content: '' }]);
+    const [hiddenMessagesValue, setHiddenMessagesValue] = useState('');
+
+    useEffect(() => {
+    setHiddenMessagesValue(JSON.stringify(messages));
+    }, [messages]);
 
     const addMessage = () => {
         setMessages([...messages, { role: '', content: '' }]);
     };
     
     const removeMessage = (index) => {
-        setMessages(messages.filter((message, i) => i !== index));
+        setMessages(messages.filter((_, i) => i !== index));
     };
     
     const updateMessage = (index, field, value) => {
@@ -25,40 +27,39 @@ export const ChatInput = ({ title, oldValue = {} }: { title: string, oldValue?: 
     };
 
     return (
-		<form>
+        <form>
+            <div className="jp-mod-styled">
+                <label className="jp-mod-styled">Messages</label>
+                {messages.map((message, index) => (
+                    <div key={index} className="jp-mod-styled">
+                        <label className="jp-mod-styled">Role</label>
+                        <select
+                            name="role"
+                            value={message.role}
+                            onChange={(e) => updateMessage(index, 'role', e.target.value)}
+                            className="jp-mod-styled"
+                        >
+                            <option value="">Select a role</option>
+                            <option value="system">system</option>
+                            <option value="user">user</option>
+                            <option value="assistant">assistant</option>
+                            <option value="function">function</option>
+                        </select>
 
-			<div className="jp-mod-styled">
+                        <label className="jp-mod-styled">Content</label>
+                        <input
+                            name="content"
+                            value={message.content}
+                            onChange={(e) => updateMessage(index, 'content', e.target.value)}
+                            className="jp-mod-styled"
+                        />
 
-			<label className="jp-mod-styled">Messages</label>
-			{messages.map((message, index) => (
-				<div key={index} className="jp-mod-styled">
-				<label className="jp-mod-styled">Role</label>
-				<select
-					name={`role${index}`}
-					value={message.role}
-					onChange={(e) => updateMessage(index, 'role', e.target.value)}
-					className="jp-mod-styled"
-				>
-					<option value="system">system</option>
-					<option value="user">user</option>
-					<option value="assistant">assistant</option>
-					<option value="function">function</option>
-				</select>
-
-				<label className="jp-mod-styled">Content</label>
-				<input
-					name={`content${index}`}
-					value={message.content}
-					onChange={(e) => updateMessage(index, 'content', e.target.value)}
-					className="jp-mod-styled"
-				/>
-
-				<button type="button" onClick={() => removeMessage(index)} className="jp-mod-styled">Remove</button>
-				</div>
-			))}
-
-			<button type="button" onClick={addMessage} className="jp-mod-styled">Add Message</button>
-			</div>
-		</form>
+                        <button type="button" onClick={() => removeMessage(index)} className="jp-mod-styled">Remove</button>
+                    </div>
+                ))}
+                <button type="button" onClick={addMessage} className="jp-mod-styled">Add Message</button>
+            </div>
+			<input type="hidden" name="messages" value={hiddenMessagesValue} />
+        </form>
     );
 }

--- a/src/dialog/input-dialogues/ChatInput.tsx
+++ b/src/dialog/input-dialogues/ChatInput.tsx
@@ -1,26 +1,24 @@
 import React, { useState, useEffect } from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 
-type OldValueProps = {
-    messages?: Array<{ role: string, content: string }>
-}
+type OldValueProps = Array<{ role: string, content: string }>;
 
-export const ChatInput = ({ title, oldValue = {}, onSubmit }: { title: string, oldValue?: OldValueProps, onSubmit: (value: Array<{ role: string, content: string }>) => void }): JSX.Element => {
-    const [messages, setMessages] = useState(oldValue.messages || [{ role: '', content: '' }]);
+export const ChatInput = ({ title, oldValue = [], onSubmit }: { title: string, oldValue?: OldValueProps, onSubmit: (value: Array<{ role: string, content: string }>) => void }): JSX.Element => {
+    const [messages, setMessages] = useState(oldValue || [{ role: '', content: '' }]);
     const [hiddenMessagesValue, setHiddenMessagesValue] = useState('');
 
     useEffect(() => {
-    setHiddenMessagesValue(JSON.stringify(messages));
+        setHiddenMessagesValue(JSON.stringify(messages));
     }, [messages]);
 
     const addMessage = () => {
         setMessages([...messages, { role: '', content: '' }]);
     };
-    
+
     const removeMessage = (index) => {
         setMessages(messages.filter((_, i) => i !== index));
     };
-    
+
     const updateMessage = (index, field, value) => {
         let newMessages = [...messages];
         newMessages[index][field] = value;
@@ -71,6 +69,7 @@ export const ChatInput = ({ title, oldValue = {}, onSubmit }: { title: string, o
                             minRows={4}
                             name="content"
                             style={{ width: '100%', fontSize: 12 }}
+                            value={message.content}
                             onChange={(e) => updateMessage(index, 'content', e.target.value)}
                             autoFocus />
                     </div>

--- a/src/dialog/input-dialogues/ChatInput.tsx
+++ b/src/dialog/input-dialogues/ChatInput.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react';
 
-export const ChatInput = ({ title, oldValue }): JSX.Element => {
+type OldValueProps = {
+    model?: string,
+    temperature?: number,
+    top_p?: number,
+    messages?: Array<{ role: string, content: string }>
+}
+
+export const ChatInput = ({ title, oldValue = {} }: { title: string, oldValue?: OldValueProps }): JSX.Element => {
     const [messages, setMessages] = useState(oldValue.messages || [{ role: '', content: '' }]);
 
     const addMessage = () => {
@@ -18,60 +25,40 @@ export const ChatInput = ({ title, oldValue }): JSX.Element => {
     };
 
     return (
-			<div>
-			  <label>Model</label>
-			  <select name="model" defaultValue={oldValue.model}>
-				<option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
-				{/* Add other options here as needed */}
-			  </select>
-		
-			  <label>Temperature</label>
-			  <input
-				name="temperature"
-				type="number"
-				min="0"
-				max="2"
-				step="0.01"
-				defaultValue={oldValue.temperature}
-			  />
-		
-			  <label>Top_p</label>
-			  <input
-				name="top_p"
-				type="number"
-				min="0"
-				max="1"
-				step="0.01"
-				defaultValue={oldValue.top_p}
-			  />
-		
-			  <label>Messages</label>
-			  {messages.map((message, index) => (
-				<div key={index}>
-				  <label>Role</label>
-				  <select
+		<form>
+
+			<div className="jp-mod-styled">
+
+			<label className="jp-mod-styled">Messages</label>
+			{messages.map((message, index) => (
+				<div key={index} className="jp-mod-styled">
+				<label className="jp-mod-styled">Role</label>
+				<select
 					name={`role${index}`}
 					value={message.role}
 					onChange={(e) => updateMessage(index, 'role', e.target.value)}
-				  >
+					className="jp-mod-styled"
+				>
 					<option value="system">system</option>
 					<option value="user">user</option>
 					<option value="assistant">assistant</option>
 					<option value="function">function</option>
-				  </select>
-		
-				  <label>Content</label>
-				  <input
+				</select>
+
+				<label className="jp-mod-styled">Content</label>
+				<input
 					name={`content${index}`}
 					value={message.content}
 					onChange={(e) => updateMessage(index, 'content', e.target.value)}
-				  />
-		
-				  <button type="button" onClick={() => removeMessage(index)}>Remove</button>
+					className="jp-mod-styled"
+				/>
+
+				<button type="button" onClick={() => removeMessage(index)} className="jp-mod-styled">Remove</button>
 				</div>
-			  ))}
-		
-			  <button type="button" onClick={addMessage}>Add Message</button>
+			))}
+
+			<button type="button" onClick={addMessage} className="jp-mod-styled">Add Message</button>
 			</div>
-		  );
-		}
+		</form>
+    );
+}

--- a/src/dialog/input-dialogues/DictInput.tsx
+++ b/src/dialog/input-dialogues/DictInput.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export const DictInput = ({ title, oldValue }): JSX.Element => {
+    return (
+        <form>
+            <h3 style={{ marginTop: 0, marginBottom: 5 }}>
+                Enter Dict Value (Without Brackets):
+            </h3>
+            <h5 style={{ marginTop: 0, marginBottom: 5 }}>
+                For Example: "a": "apple", "b": "banana", "c": 2022
+            </h5>
+            <input
+                name={title}
+                style={{ width: 350 }}
+                defaultValue={oldValue} />
+        </form>
+    );
+}

--- a/src/dialog/input-dialogues/ListInput.tsx
+++ b/src/dialog/input-dialogues/ListInput.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export const ListInput = ({ title, oldValue }): JSX.Element => {
+    return (
+        <form>
+            <h3 style={{ marginTop: 0, marginBottom: 5 }}>
+                Enter List Value (Without Brackets):
+            </h3>
+            <h5 style={{ marginTop: 0, marginBottom: 5 }}>
+                For Example: "a", "b", "c"
+            </h5>
+            <input
+                name={title}
+                style={{ width: 350 }}
+                defaultValue={oldValue} />
+        </form>
+    );
+}

--- a/src/dialog/input-dialogues/NumberInput.tsx
+++ b/src/dialog/input-dialogues/NumberInput.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export const NumberInput = ({ title, oldValue, type }): JSX.Element => {
+	return (
+		<form>
+            <h3 style={{ marginTop: 0, marginBottom: 5 }}>
+				Enter {type == 'Float' ? "Float" : "Integer"} Value (Without Quotes):
+            </h3>
+			<input
+				name={title}
+				type="number"
+				step={type == 'Float' ? "0.01" : "1"}
+				placeholder={type == 'Float' ? "0.00" : "0"}
+				style={{ width: 350 }}
+				defaultValue={oldValue} />
+		</form>
+	);
+}

--- a/src/dialog/input-dialogues/ParameterInput.tsx
+++ b/src/dialog/input-dialogues/ParameterInput.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export const ParameterInput = ({ title, oldValue, type }): JSX.Element => {
+    return (
+        <form>
+            <h3 style={{ marginTop: 0, marginBottom: 5 }}>
+                Enter {type} Argument Name (Without Quotes):
+            </h3>
+        <input
+            name={title}
+            style={{ width: 350 }}
+            defaultValue={oldValue} />
+        </form>
+    );
+}

--- a/src/dialog/input-dialogues/SecretInput.tsx
+++ b/src/dialog/input-dialogues/SecretInput.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export const SecretInput = ({ title, oldValue }): JSX.Element => {
+    return (
+        <form>
+            <h3 style={{ marginTop: 0, marginBottom: 5 }}>
+                Enter Secret Value (Without Quotes):
+            </h3>
+            <h5 style={{ marginTop: 0, marginBottom: 5 }}>
+                    Warning: Literal Secrets are masked in the frontend only. <br />
+                    They can still be accessed in the raw .xircuits file or appear as strings in the compiled script.
+            </h5>
+            <input
+                name={title}
+                type="password"
+                style={{ width: 480 }}
+                defaultValue={oldValue} />
+        </form>
+
+    );
+}

--- a/src/dialog/input-dialogues/StringInput.tsx
+++ b/src/dialog/input-dialogues/StringInput.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export const StringInput = ({ title, oldValue }): JSX.Element => {
+	return (
+		<form>
+			<h3 style={{ marginTop: 0, marginBottom: 5 }}>
+				Enter String Value (Without Quotes):
+			</h3>
+		<input
+			name={title}
+			style={{ width: 350 }}
+			defaultValue={oldValue} />
+	</form>
+	);
+}

--- a/src/dialog/input-dialogues/TextAreaInput.tsx
+++ b/src/dialog/input-dialogues/TextAreaInput.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import TextareaAutosize from 'react-textarea-autosize';
+
+export const TextAreaInput = ({ title, oldValue }): JSX.Element => {
+	return (
+        <form>
+            <h3 style={{ marginTop: 0, marginBottom: 5 }}>
+                Enter String Value (Without Quotes):
+            </h3>
+            <div>
+            <TextareaAutosize
+                defaultValue={oldValue}
+                minRows={14}
+                name={title}
+                style={{ width: 400, height: 200, fontSize: 12 }}
+                autoFocus />
+            </div>
+    </form>
+
+	);
+}

--- a/src/dialog/input-dialogues/TupleInput.tsx
+++ b/src/dialog/input-dialogues/TupleInput.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export const TupleInput = ({ title, oldValue }): JSX.Element => {
+    return (
+        <form>
+            <h3 style={{ marginTop: 0, marginBottom: 5 }}>
+                Enter Tuple Value (Without Brackets):
+            </h3>
+            <h5 style={{ marginTop: 0, marginBottom: 5 }}>
+                For Example: "a", "b", "c"
+            </h5>
+            <input
+                name={title}
+                style={{ width: 350 }}
+                defaultValue={oldValue} />
+        </form>
+    );
+}

--- a/src/dialog/input-dialogues/VariableInput.tsx
+++ b/src/dialog/input-dialogues/VariableInput.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export const VariableInput = ({ title, oldValue }): JSX.Element => {
+	return (
+        <form>
+			<h5 style={{ marginTop: 0, marginBottom: 5 }}>
+						<p>Determine your variable type by inserting the first char as below: </p>
+						<li> " : String</li>
+						<li> # : Integer or Float</li>
+						<li> [ : List</li>
+						<li> ( : Tuple</li>
+						<li> {'{'} : Dict</li>
+						<li> !true / !True / !1 / !t : True</li>
+						<li> !false / !False / !0 / !nil : False</li>
+						<p>For Example: "Hello World or #15 or !true</p>
+					</h5>
+			<input
+				name={title}
+				style={{ width: 350 }}
+				defaultValue={oldValue} />
+		</form>
+	);
+}

--- a/src/helpers/InputSanitizer.tsx
+++ b/src/helpers/InputSanitizer.tsx
@@ -21,6 +21,7 @@ function checkInput(input: any, dataType: string): boolean {
             break;
         case "string":
         case "secret":
+        case "chat":
             processedInput = JSON.stringify(input);
             break;
         case "list":
@@ -28,7 +29,6 @@ function checkInput(input: any, dataType: string): boolean {
             processedInput = `[${input}]`;
             break;
         case "dict":
-        case "chat":
             processedInput = `{${input}}`;
             break;
         case "undefined_any":

--- a/src/helpers/InputSanitizer.tsx
+++ b/src/helpers/InputSanitizer.tsx
@@ -30,6 +30,7 @@ function checkInput(input: any, dataType: string): boolean {
             processedInput = `[${input}]`;
             break;
         case "dict":
+        case "chat":
             processedInput = `{${input}}`;
             break;
         case "undefined_any":

--- a/src/helpers/InputSanitizer.tsx
+++ b/src/helpers/InputSanitizer.tsx
@@ -23,10 +23,8 @@ function checkInput(input: any, dataType: string): boolean {
         case "secret":
             processedInput = JSON.stringify(input);
             break;
-        case "tuple":
-            processedInput = `(${input})`;
-            break;
         case "list":
+        case "tuple": // validate tuple as list,as JS doesn't have native tuples
             processedInput = `[${input}]`;
             break;
         case "dict":
@@ -60,8 +58,6 @@ function checkInput(input: any, dataType: string): boolean {
                 exampleInput = '"example_string"';
                 break;
             case "tuple":
-                exampleInput = '"item1", "item2", "item3"';
-                break;
             case "list":
                 exampleInput = '"item1", "item2", 123';
                 break;

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -88,7 +88,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
             node.addOutPortEnhance(inputValue, 'out-0');
         }
         else {
-            const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'String'});
+            const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'Argument', inputType:'String'});
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
             inputValue = dialogResult["value"][argumentTitle];
@@ -109,7 +109,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
             node.addOutPortEnhance(inputValue, 'out-0');
 
         } else {
-            const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'String'});
+            const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'Argument', inputType:'Integer'});
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
             inputValue = dialogResult["value"][argumentTitle];
@@ -132,7 +132,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         } else {
 
-            const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'String'});
+            const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'Argument', inputType:'Float'});
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
             inputValue = dialogResult["value"][argumentTitle];
@@ -155,7 +155,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         } else {
 
-            const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'String'});
+            const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'Argument', inputType:'Boolean'});
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
             inputValue = dialogResult["value"][argumentTitle];
@@ -272,8 +272,6 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
                 if (cancelDialog(dialogResult)) return;
                 inputValue = dialogResult["value"];
                 inputValue = convertToOpenAI(inputValue)
-                // inputValue = JSON.stringify(inputValue);
-                // inputValue = inputValue.slice(1, -1); // Remove the first and last character
             }
 
             node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -16,44 +16,6 @@ export function cancelDialog(dialogResult) {
     return false
 }
 
-function convertToOpenAI(inputObject) {
-    // Initialize the new format object
-    let newObject = {
-        "model": inputObject.model,
-        "messages": []
-    };
-
-    // Loop over the input object properties
-    for (let key in inputObject) {
-        if (inputObject.hasOwnProperty(key)) {
-            // If key starts with 'content' or 'role', add it to the 'messages' array
-            let matchContent = key.match(/^content(\d+)/);
-            let matchRole = key.match(/^role(\d+)/);
-            if (matchContent) {
-                let index = parseInt(matchContent[1]);
-                if (!newObject.messages[index]) {
-                    newObject.messages[index] = {};
-                }
-                newObject.messages[index].content = inputObject[key];
-            } else if (matchRole) {
-                let index = parseInt(matchRole[1]);
-                if (!newObject.messages[index]) {
-                    newObject.messages[index] = {};
-                }
-                newObject.messages[index].role = inputObject[key];
-            } else if (key !== 'model') { // Ignore 'model', add other properties directly
-                if (inputObject[key]) { // Ignore empty properties
-                    newObject[key] = inputObject[key];
-                }
-            }
-        }
-    }
-
-    // Convert to string and return
-    return JSON.stringify(newObject, null, 2);
-}
-
-
 export async function GeneralComponentLibrary(props: GeneralComponentLibraryProps){
     let node = null;
     const nodeData = props.model;
@@ -271,12 +233,19 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
                 const dialogResult = await showFormDialog(dialogOptions);
                 if (cancelDialog(dialogResult)) return;
                 inputValue = dialogResult["value"];
+
+                while (!checkInput(inputValue, 'chat')){
+                    const dialogOptions = inputDialog({ title:'Chat', oldValue:inputValue, type:'Chat'});
+                    const dialogResult = await showFormDialog(dialogOptions);
+    
+                    if (cancelDialog(dialogResult)) return;
+                    inputValue = dialogResult["value"];
+                }
                 inputValue = JSON.stringify(inputValue)
             }
 
             node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance(inputValue, 'out-0');
-
         } 
     } 
 

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -272,7 +272,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
         } else {
 
-            const dialogOptions = inputDialog(hyperparameterTitle, "", 'String');
+            const dialogOptions = inputDialog(hyperparameterTitle, "", 'Secret');
             const dialogResult = await showFormDialog(dialogOptions);
             if (cancelDialog(dialogResult)) return;
             inputValue = dialogResult["value"][hyperparameterTitle];
@@ -280,30 +280,39 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
             node.addOutPortEnhance('▶', 'parameter-out-0');
 
         }
+    } else if (nodeData.type === 'chat') {
 
-    // } else if (props.type === 'debug') {
-    //     node = new CustomNodeModel({ name: props.name, color: props.color, extras: { "type": props.type } });
-    //     node.addInPortEnhance('▶', 'in-0');
-    //     node.addInPortEnhance('props Set', 'parameter-in-1');
-    //     node.addOutPortEnhance('▶', 'out-0');
+    if ((nodeName).startsWith("Literal")) {
 
-    // } else if (props.type === 'enough') {
+        if (variableValue == '' || variableValue == undefined) {
+            const dialogOptions = inputDialog('Chat', "", 'Chat', false);
+            const dialogResult = await showFormDialog(dialogOptions);
+            if (cancelDialog(dialogResult)) return;
+            inputValue = dialogResult["value"]['Chat'];
+        }
 
-    //     node = new CustomNodeModel({ name: props.name, color: props.color, extras: { "type": props.type } });
+        while (!checkInput(inputValue, 'chat')){
+            const dialogOptions = inputDialog('Chat', "", 'Chat', false);
+            const dialogResult = await showFormDialog(dialogOptions);
 
-    //     node.addInPortEnhance('▶', 'in-0');
-    //     node.addInPortEnhance('Target Accuracy', 'parameter-float-in-1');
-    //     node.addInPortEnhance('Max Retries', 'parameter-int-in-2');
-    //     node.addInPortEnhance('Metrics', 'parameter-string-in-3');
+            if (cancelDialog(dialogResult)) return;
+            inputValue = dialogResult["value"]['Chat'];
+        }
+        
+        node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
+        node.addOutPortEnhance(inputValue, 'out-0');
 
-    //     node.addOutPortEnhance('▶', 'out-0');
-    //     node.addOutPortEnhance('Should Retrain', 'out-1');
+    } else {
 
-    } 
-    // else if (nodeData.type === 'literal') {
+        const dialogOptions = inputDialog(hyperparameterTitle, "", 'Chat');
+        const dialogResult = await showFormDialog(dialogOptions);
+        if (cancelDialog(dialogResult)) return;
+        inputValue = dialogResult["value"][hyperparameterTitle];
+        node = new CustomNodeModel({ name: "Argument (Chat): " + inputValue, color: nodeData.color, extras: { "type": nodeData.type } });
+        node.addOutPortEnhance('▶', 'parameter-out-0');
 
-    //     node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-    //     node.addOutPortEnhance('Value', 'out-0');
-    // }
+    }
+} 
+
     return node;
 }

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -271,7 +271,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
                 const dialogResult = await showFormDialog(dialogOptions);
                 if (cancelDialog(dialogResult)) return;
                 inputValue = dialogResult["value"];
-                inputValue = convertToOpenAI(inputValue)
+                inputValue = JSON.stringify(inputValue)
             }
 
             node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });

--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -134,6 +134,8 @@ def main(args):
                         value = json.loads("{" + port.sourceLabel + "}")
                     elif port.source.name == "Literal Secret":
                         value = port.sourceLabel
+                    elif port.source.name == "Literal Chat":
+                        value = json.loads("{" + port.sourceLabel + "}")
                     else:
                         value = eval(port.sourceLabel)
                     tpl.body[0].value.value = value

--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -136,6 +136,11 @@ def main(args):
                         value = port.sourceLabel
                     elif port.source.name == "Literal Chat":
                         value = json.loads("{" + port.sourceLabel + "}")
+                    elif port.source.name == "Literal Tuple":
+                        value = eval(port.sourceLabel)
+                        if not isinstance(value, tuple):
+                            # handler for single entry tuple
+                            value = (value,)
                     else:
                         value = eval(port.sourceLabel)
                     tpl.body[0].value.value = value

--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -135,7 +135,7 @@ def main(args):
                     elif port.source.name == "Literal Secret":
                         value = port.sourceLabel
                     elif port.source.name == "Literal Chat":
-                        value = json.loads("{" + port.sourceLabel + "}")
+                        value = json.loads(port.sourceLabel)
                     elif port.source.name == "Literal Tuple":
                         value = eval(port.sourceLabel)
                         if not isinstance(value, tuple):

--- a/xircuits/handlers/components.py
+++ b/xircuits/handlers/components.py
@@ -37,6 +37,7 @@ DEFAULT_COMPONENTS = {
     11:{ "name": "Literal Tuple", "returnType": "tuple","color":"purple"},
     12:{ "name": "Literal Dict", "returnType": "dict","color":"orange"},
     13:{ "name": "Literal Secret", "returnType": "secret","color":"black"},
+    14:{ "name": "Literal Chat", "returnType": "chat","color":"green"},
 
     # Comment this first since we don't use it
     # 1: { "name": "Math Operation", "returnType": "math"},


### PR DESCRIPTION
# Description

This PR implements a `Literal Chat` interface for Chat-like messages. Specifically, it allows users to specify [messages](https://platform.openai.com/docs/api-reference/chat/create) in an list of dicts. 
This PR also refactors form interfaces so that each Literal has its own customizable display, as well as fixes a Literal Tuple bug. 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [x] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Tests

**1. Try Literal Chat**

    1. Drag a Literal Chat from the tray. 
    2. Confirm that it you can correctly render the role and content.
    3. Confirm that you can edit it and it preserves the previous state.
    4. Confirm that it prints out a list of dicts as expected.

**2. Try Literal Tuple**

    1. Drag a Literal Tuple. Confirm that you can edit and compile it.

**3. Try Literals and Arguments**

    1. The literals and tuples have been refactored. Try dragging them, editing them, and compiling them and ensure that they're  functional. 

## Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

I've noted the first instance of `role` and `content` message has a different appearance. This is due to a jupyter css wrapper applied on runtime. 