### PR TITLE
✨/♻️ Enable Literal Bool Toggle + Refactor General Component Handling

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -681,14 +681,14 @@ export function addNodeActionCommands(
             let node = null;
             const links = widget.xircuitsApp.getDiagramEngine().getModel()["layers"][0]["models"];
             var oldValue = selected_node.getPorts()["out-0"].getOptions()["label"];
-            const literalType = selected_node["name"].split(" ")[1];
+            const literalType = selected_node["extras"]["type"];
             let inputType: string = "";
             
             switch(literalType){
-                case "String":
+                case "string":
                     inputType = 'textarea';
                     break;
-                case "Chat":
+                case "chat":
                     oldValue = JSON.parse(oldValue);
                     break;
                 default:
@@ -711,7 +711,7 @@ export function addNodeActionCommands(
                 updatedContent = dialogResult["value"][updateTitle] || dialogResult["value"];
             }
 
-            let strContent: string = (literalType == 'Chat') ? JSON.stringify(updatedContent) : updatedContent;
+            let strContent: string = (literalType == 'chat') ? JSON.stringify(updatedContent) : updatedContent;
 
             node = new CustomNodeModel({ name: selected_node["name"], color: selected_node["color"], extras: { "type": selected_node["extras"]["type"] } });
             node.addOutPortEnhance(strContent, 'out-0');

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -691,9 +691,6 @@ export function addNodeActionCommands(
                 case "Chat":
                     oldValue = JSON.parse(oldValue);
                     break;
-                case "True":
-                case "False":
-                    return;
                 default:
                     break;
             }

--- a/src/components/xircuitBodyWidget.tsx
+++ b/src/components/xircuitBodyWidget.tsx
@@ -678,10 +678,10 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 
 		context.ready.then(() => {
 			const setterByType = {
-				'String': setStringNodes,
-				'Int': setIntNodes,
-				'Float': setFloatNodes,
-				'Boolean': setBoolNodes
+				'string': setStringNodes,
+				'int': setIntNodes,
+				'float': setFloatNodes,
+				'boolean': setBoolNodes
 			}
 
 
@@ -817,7 +817,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 				break;
 			case 'boolean':
 				let boolTitle = 'Enter boolean value: ';
-				const dialogOptions = inputDialog({ title:boolTitle, oldValue:"", type:'Boolean'});
+				const dialogOptions = inputDialog({ title:boolTitle, oldValue:"", type:'boolean'});
 				const dialogResult = await showFormDialog(dialogOptions);
 				if (cancelDialog(dialogResult)) return;
 				let boolValue = dialogResult["value"][boolTitle];

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -56,7 +56,7 @@ export const LiteralInputDialog = ({ title, oldValue, type, inputType }): JSX.El
 	};
 
 	const InputValueDialog = () => {
-		const InputComponent = inputComponents[inputType === 'textarea' ? inputType : type];
+		const InputComponent = inputComponents[inputType === 'textarea' ? inputType.toLowerCase() : type.toLowerCase()];
 		
 		// The `type` prop is now passed to all components
 		const extraProps = { type, inputType };

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -41,17 +41,18 @@ export const LiteralInputDialog = ({ title, oldValue, type, inputType }): JSX.El
 
 	const inputComponents = {
 		textarea: TextAreaInput,
-		Integer: NumberInput,
-		Float: NumberInput,
-		Boolean: BooleanInput,
-		String: StringInput,
-		Dict: DictInput,
-		List: ListInput,
-		Tuple: TupleInput,
-		Variable: VariableInput,
-		Secret: SecretInput,
-		Chat: ChatInput,
-		Argument: ArgumentInput,
+		int: NumberInput,
+		integer: NumberInput,
+		float: NumberInput,
+		boolean: BooleanInput,
+		string: TextAreaInput,
+		dict: DictInput,
+		list: ListInput,
+		tuple: TupleInput,
+		variable: VariableInput,
+		secret: SecretInput,
+		chat: ChatInput,
+		argument: ArgumentInput,
 	};
 
 	const InputValueDialog = () => {

--- a/src/dialog/input-dialogues/BooleanInput.tsx
+++ b/src/dialog/input-dialogues/BooleanInput.tsx
@@ -2,23 +2,30 @@ import React, { useState } from 'react';
 import Switch from "react-switch";
 
 export const BooleanInput = ({ title, oldValue }): JSX.Element => {
-	const [checked, setChecked] = useState<boolean>(true);
+	const [checked, setChecked] = useState<boolean>(oldValue.toLowerCase() === 'true');
 
 	const handleChecked = () => {
 		setChecked(!checked);
 	};
 
 	return (
-		<div style={{ paddingLeft: 5, paddingTop: 5 }}>
-			<Switch
-				checked={checked}
-				name={title}
-				onChange={() => handleChecked()}
-				boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
-				handleDiameter={25}
-				height={20}
-				width={48}
-			/>
-		</div>
+		<form>
+			<div style={{ paddingLeft: 5, paddingTop: 5 }}>
+				<Switch
+					checked={checked}
+					name={title}
+					onChange={handleChecked}
+					boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
+					handleDiameter={25}
+					height={20}
+					width={48}
+				/>
+                <input 
+                    type="hidden" 
+                    name={title} 
+                    value={checked ? 'True' : 'False'}
+                />
+			</div>
+		</form>
 	);
 }

--- a/src/dialog/input-dialogues/BooleanInput.tsx
+++ b/src/dialog/input-dialogues/BooleanInput.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import Switch from "react-switch";
 
 export const BooleanInput = ({ title, oldValue }): JSX.Element => {
-	const [checked, setChecked] = useState<boolean>(oldValue.toLowerCase() === 'true');
+	const [checked, setChecked] = useState<boolean>(oldValue[0].toLowerCase() === 'true');
 
 	const handleChecked = () => {
 		setChecked(!checked);

--- a/src/dialog/input-dialogues/BooleanInput.tsx
+++ b/src/dialog/input-dialogues/BooleanInput.tsx
@@ -2,7 +2,10 @@ import React, { useState } from 'react';
 import Switch from "react-switch";
 
 export const BooleanInput = ({ title, oldValue }): JSX.Element => {
-	const [checked, setChecked] = useState<boolean>(oldValue[0].toLowerCase() === 'true');
+	
+	// Initialize based on the oldValue (or its first element if an array).
+	// Explicitly compare to 'true' as JS treats non-empty strings as truthy.
+	const [checked, setChecked] = useState<boolean>((Array.isArray(oldValue) ? oldValue[0] : oldValue).toLowerCase() === 'true');
 
 	const handleChecked = () => {
 		setChecked(!checked);

--- a/src/dialog/input-dialogues/BooleanInput.tsx
+++ b/src/dialog/input-dialogues/BooleanInput.tsx
@@ -3,9 +3,8 @@ import Switch from "react-switch";
 
 export const BooleanInput = ({ title, oldValue }): JSX.Element => {
 	
-	// Initialize based on the oldValue (or its first element if an array).
 	// Explicitly compare to 'true' as JS treats non-empty strings as truthy.
-	const [checked, setChecked] = useState<boolean>((Array.isArray(oldValue) ? oldValue[0] : oldValue).toLowerCase() === 'true');
+	const [checked, setChecked] = useState<boolean>(oldValue.toLowerCase() === 'true');
 
 	const handleChecked = () => {
 		setChecked(!checked);

--- a/src/dialog/input-dialogues/NumberInput.tsx
+++ b/src/dialog/input-dialogues/NumberInput.tsx
@@ -4,13 +4,13 @@ export const NumberInput = ({ title, oldValue, type }): JSX.Element => {
 	return (
 		<form>
             <h3 style={{ marginTop: 0, marginBottom: 5 }}>
-				Enter {type == 'Float' ? "Float" : "Integer"} Value:
+				Enter {type == 'float' ? "Float" : "Integer"} Value:
             </h3>
 			<input
 				name={title}
 				type="number"
-				step={type == 'Float' ? "0.01" : "1"}
-				placeholder={type == 'Float' ? "0.00" : "0"}
+				step={type == 'float' ? "0.01" : "1"}
+				placeholder={type == 'float' ? "0.00" : "0"}
 				style={{ width: 350 }}
 				defaultValue={oldValue} />
 		</form>

--- a/src/dialog/input-dialogues/NumberInput.tsx
+++ b/src/dialog/input-dialogues/NumberInput.tsx
@@ -4,7 +4,7 @@ export const NumberInput = ({ title, oldValue, type }): JSX.Element => {
 	return (
 		<form>
             <h3 style={{ marginTop: 0, marginBottom: 5 }}>
-				Enter {type == 'Float' ? "Float" : "Integer"} Value (Without Quotes):
+				Enter {type == 'Float' ? "Float" : "Integer"} Value:
             </h3>
 			<input
 				name={title}

--- a/src/dialog/input-dialogues/VariableInput.tsx
+++ b/src/dialog/input-dialogues/VariableInput.tsx
@@ -30,7 +30,7 @@ export const VariableInput = ({ title, oldValue }): JSX.Element => {
 export async function getItsLiteralType(){
 	// When inPort is 'any' type, get the correct literal type based on the first character inputed
 	let varOfAnyTypeTitle = 'Enter your variable value';
-	let dialogOptions = inputDialog({ title: varOfAnyTypeTitle, oldValue: "", type: 'Variable' });
+	let dialogOptions = inputDialog({ title: varOfAnyTypeTitle, oldValue: "", type: 'variable' });
 	const dialogResult = await showFormDialog(dialogOptions);
 	if (cancelDialog(dialogResult)) return;
 	let varValue = dialogResult["value"][varOfAnyTypeTitle];

--- a/src/dialog/input-dialogues/VariableInput.tsx
+++ b/src/dialog/input-dialogues/VariableInput.tsx
@@ -47,7 +47,7 @@ export async function getItsLiteralType(){
 		varValue = dialogResult["value"][varOfAnyTypeTitle];
 		varType = varValue.charAt(0);
 		varInput = varValue.slice(1);
-		 nodeType = varTypeChecker(varType, varInput, varValue);
+		nodeType = varTypeChecker(varType, varInput, varValue);
 
 	}
 

--- a/src/helpers/InputSanitizer.tsx
+++ b/src/helpers/InputSanitizer.tsx
@@ -31,6 +31,8 @@ function checkInput(input: any, dataType: string): boolean {
         case "dict":
             processedInput = `{${input}}`;
             break;
+        case "boolean":
+            return true;
         case "undefined_any":
             //handler if called from any inputDialogue
             alert(`Type is undefined or not provided. Please insert the first character as shown in example.`);

--- a/src/helpers/InputSanitizer.tsx
+++ b/src/helpers/InputSanitizer.tsx
@@ -31,6 +31,8 @@ function checkInput(input: any, dataType: string): boolean {
         case "dict":
             processedInput = `{${input}}`;
             break;
+        case "true":
+        case "false":
         case "boolean":
             return true;
         case "undefined_any":

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -38,7 +38,8 @@ export async function handleLiteralInput(nodeName, nodeData, inputValue = "", ty
     }
 
     if (SPECIAL_LITERALS.includes(type)) inputValue = JSON.stringify(inputValue);
-
+    if (nodeName === 'Literal True' || nodeName === 'Literal False') nodeName = 'Literal Boolean';
+    
     const node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
     node.addOutPortEnhance(inputValue, 'out-0');
     return node;

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -112,7 +112,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
             let portLabel = nodeName.split(' ');
             portLabel = portLabel[portLabel.length - 1];
 
-            node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
+            node = new CustomNodeModel({ name: "Literal Boolean", color: nodeData.color, extras: { "type": nodeData.type } });
             node.addOutPortEnhance(portLabel, 'out-0');
 
         } else {

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -18,11 +18,10 @@ export function cancelDialog(dialogResult) {
 
 const TYPE_LITERALS = ['string', 'int', 'float', 'boolean', 'list', 'tuple', 'dict', 'secret', 'chat'];
 const TYPE_ARGUMENTS = ['string', 'int', 'float', 'boolean'];
-const SPECIAL_LITERALS = ['chat']
+const SPECIAL_LITERALS = ['chat'];
 
-async function handleLiteralInput(nodeName, nodeData, variableValue, type) {
+export async function handleLiteralInput(nodeName, nodeData, variableValue, type, title = "New Literal Input") {
     let inputValue = variableValue;
-    let title = "New Literal Input"
     if (variableValue == '' || variableValue == undefined) {
         let dialogOptions = inputDialog({ title, oldValue: "", type });
         let dialogResult = await showFormDialog(dialogOptions);
@@ -47,7 +46,7 @@ async function handleLiteralInput(nodeName, nodeData, variableValue, type) {
 }
 
 async function handleArgumentInput(nodeData, argumentTitle) {
-    const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'Argument', inputType: nodeData.type });
+    const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'argument', inputType: nodeData.type });
     const dialogResult = await showFormDialog(dialogOptions);
     if (cancelDialog(dialogResult)) return;
     const inputValue = dialogResult["value"][argumentTitle];

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -16,238 +16,70 @@ export function cancelDialog(dialogResult) {
     return false
 }
 
+const TYPE_LITERALS = ['string', 'int', 'float', 'boolean', 'list', 'tuple', 'dict', 'secret', 'chat'];
+const TYPE_ARGUMENTS = ['string', 'int', 'float', 'boolean'];
+const SPECIAL_LITERALS = ['chat']
+
+async function handleLiteralInput(nodeName, nodeData, variableValue, type) {
+    let inputValue = variableValue;
+    let title = "New Literal Input"
+    if (variableValue == '' || variableValue == undefined) {
+        let dialogOptions = inputDialog({ title, oldValue: "", type });
+        let dialogResult = await showFormDialog(dialogOptions);
+        if (cancelDialog(dialogResult)) return;
+
+        inputValue = dialogResult["value"][title] || dialogResult["value"];;
+
+        while (!checkInput(inputValue, type)){
+            dialogOptions = inputDialog({ title: type, oldValue: inputValue, type });
+            dialogResult = await showFormDialog(dialogOptions);
+
+            if (cancelDialog(dialogResult)) return;
+            inputValue = dialogResult["value"][title] || dialogResult["value"];
+        }
+    }
+    
+    if (SPECIAL_LITERALS.includes(type)) inputValue = JSON.stringify(inputValue);
+
+    const node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
+    node.addOutPortEnhance(inputValue, 'out-0');
+    return node;
+}
+
+async function handleArgumentInput(nodeData, argumentTitle) {
+    const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'Argument', inputType: nodeData.type });
+    const dialogResult = await showFormDialog(dialogOptions);
+    if (cancelDialog(dialogResult)) return;
+    const inputValue = dialogResult["value"][argumentTitle];
+
+    const node = new CustomNodeModel({ name: `Argument (${nodeData.type}): ${inputValue}`, color: nodeData.color, extras: { "type": nodeData.type } });
+    node.addOutPortEnhance('▶', 'parameter-out-0');
+    return node;
+}
+
 export async function GeneralComponentLibrary(props: GeneralComponentLibraryProps){
+    
     let node = null;
     const nodeData = props.model;
-    const variableValue = props.variableValue;
+    const variableValue = props.variableValue || '';
     const nodeName = nodeData.task;
     const argumentTitle = 'Please define parameter';
-    let inputValue;
-    if (variableValue != ''){
-        inputValue = variableValue;
+
+    // handler for Boolean
+    if (nodeData.type === 'boolean' && nodeName.startsWith("Literal")) {
+        const portLabel = nodeName.split(' ').slice(-1);
+        node = new CustomNodeModel({ name: "Literal Boolean", color: nodeData.color, extras: { "type": nodeData.type } });
+        node.addOutPortEnhance(portLabel, 'out-0');
+        return node;
+    }
+    
+    if (TYPE_LITERALS.includes(nodeData.type) && nodeName.startsWith("Literal")) {
+        return handleLiteralInput(nodeName, nodeData, variableValue, nodeData.type);
     }
 
-    if (nodeData.type === 'string') {
+    if (TYPE_ARGUMENTS.includes(nodeData.type)) {
+        return handleArgumentInput(nodeData, argumentTitle);
+    }
 
-        if ((nodeName).startsWith("Literal")) {
-            if (variableValue == '' || variableValue == undefined) {
-                const dialogOptions = inputDialog({ title: 'String', oldValue: "", type: 'String', inputType: 'textarea' });
-                const dialogResult = await showFormDialog(dialogOptions);
-                if (cancelDialog(dialogResult)) return;
-                
-                inputValue = dialogResult["value"]['String'];
-
-                while (!checkInput(inputValue, 'string')){
-                    const dialogOptions = inputDialog({ title: 'String', oldValue: inputValue, type: 'String', inputType: 'textarea' });
-                    const dialogResult = await showFormDialog(dialogOptions);
-                    if (cancelDialog(dialogResult)) return;
-
-                    inputValue = dialogResult["value"]['String'];
-                }
-            }
-
-            node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(inputValue, 'out-0');
-        }
-        else {
-            const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'Argument', inputType:'String'});
-            const dialogResult = await showFormDialog(dialogOptions);
-            if (cancelDialog(dialogResult)) return;
-            inputValue = dialogResult["value"][argumentTitle];
-            node = new CustomNodeModel({ name: "Argument (String): " + inputValue, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance('▶', 'parameter-out-0');
-        }
-
-    } else if (nodeData.type === 'int') {
-
-        if ((nodeName).startsWith("Literal")) {
-            if (variableValue == '' || variableValue == undefined) {
-                const dialogOptions = inputDialog({title: 'Integer', oldValue: "", type: 'Integer' });
-                const dialogResult = await showFormDialog(dialogOptions);
-                if (cancelDialog(dialogResult)) return;
-                inputValue = dialogResult["value"]['Integer'];
-            }
-            node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(inputValue, 'out-0');
-
-        } else {
-            const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'Argument', inputType:'Integer'});
-            const dialogResult = await showFormDialog(dialogOptions);
-            if (cancelDialog(dialogResult)) return;
-            inputValue = dialogResult["value"][argumentTitle];
-            node = new CustomNodeModel({ name: "Argument (Int): " + inputValue, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance('▶', 'parameter-out-0');
-
-        }
-
-    } else if (nodeData.type === 'float') {
-
-        if ((nodeName).startsWith("Literal")) {
-            if (variableValue == '' || variableValue == undefined) {
-                const dialogOptions = inputDialog({ title:'Float', oldValue:"", type:'Float' });
-                const dialogResult = await showFormDialog(dialogOptions);
-                if (cancelDialog(dialogResult)) return;
-                inputValue = dialogResult["value"]['Float'];
-            }
-            node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(inputValue, 'out-0');
-
-        } else {
-
-            const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'Argument', inputType:'Float'});
-            const dialogResult = await showFormDialog(dialogOptions);
-            if (cancelDialog(dialogResult)) return;
-            inputValue = dialogResult["value"][argumentTitle];
-            console.log(dialogResult);
-            
-            node = new CustomNodeModel({ name: "Argument (Float): " + inputValue, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance('▶', 'parameter-out-0');
-
-        }
-
-    } else if (nodeData.type === 'boolean') {
-
-        if ((nodeName).startsWith("Literal")) {
-
-            let portLabel = nodeName.split(' ');
-            portLabel = portLabel[portLabel.length - 1];
-
-            node = new CustomNodeModel({ name: "Literal Boolean", color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(portLabel, 'out-0');
-
-        } else {
-
-            const dialogOptions = inputDialog({ title: argumentTitle, oldValue: "", type:'Argument', inputType:'Boolean'});
-            const dialogResult = await showFormDialog(dialogOptions);
-            if (cancelDialog(dialogResult)) return;
-            inputValue = dialogResult["value"][argumentTitle];
-            node = new CustomNodeModel({ name: "Argument (Boolean): " + inputValue, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance('▶', 'parameter-out-0');
-
-        }
-
-    } else if (nodeData.type === 'list') {
-
-        if ((nodeName).startsWith("Literal")) {
-
-            if (variableValue == '' || variableValue == undefined) {
-                const dialogOptions = inputDialog({ title: 'List', oldValue: "", type: 'List'});
-                const dialogResult = await showFormDialog(dialogOptions);
-                if (cancelDialog(dialogResult)) return;
-
-                inputValue = dialogResult["value"]['List'];
-                
-                while (!checkInput(inputValue, 'list')){
-                    const dialogOptions = inputDialog({ title: 'List', oldValue: inputValue, type: 'List'});
-                    const dialogResult = await showFormDialog(dialogOptions);
-
-                    if (cancelDialog(dialogResult)) return;
-                    inputValue = dialogResult["value"]['List'];
-                }
-                
-            }
-            node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(inputValue, 'out-0');
-
-        } 
-
-    } else if (nodeData.type === 'tuple') {
-
-        if ((nodeName).startsWith("Literal")) {
-
-            if (variableValue == '' || variableValue == undefined) {
-                const dialogOptions = inputDialog({ title:'Tuple', oldValue:"", type:'Tuple'} );
-                const dialogResult = await showFormDialog(dialogOptions);
-                if (cancelDialog(dialogResult)) return;
-
-                inputValue = dialogResult["value"]['Tuple'];
-                
-                while (!checkInput(inputValue, 'tuple')){
-                    const dialogOptions = inputDialog({ title:'Tuple', oldValue:inputValue, type:'Tuple'} );
-                    const dialogResult = await showFormDialog(dialogOptions);
-
-                    if (cancelDialog(dialogResult)) return;
-                    inputValue = dialogResult["value"]['Tuple'];
-                }
-
-            }
-            node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(inputValue, 'out-0');
-
-        } 
-
-    } else if (nodeData.type === 'dict') {
-
-        if ((nodeName).startsWith("Literal")) {
-
-            if (variableValue == '' || variableValue == undefined) {
-                const dialogOptions = inputDialog({ title:'Dict', oldValue:"", type:'Dict' });
-                const dialogResult = await showFormDialog(dialogOptions);
-                if (cancelDialog(dialogResult)) return;
-                inputValue = dialogResult["value"]['Dict'];
-
-                while (!checkInput(inputValue, 'dict')){
-                    const dialogOptions = inputDialog({ title:'Dict', oldValue: inputValue, type:'Dict' });
-                    const dialogResult = await showFormDialog(dialogOptions);
-
-                    if (cancelDialog(dialogResult)) return;
-                    inputValue = dialogResult["value"]['Dict'];
-                }
-
-            }
-            node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(inputValue, 'out-0');
-
-        } 
-
-    } else if (nodeData.type === 'secret') {
-
-        if ((nodeName).startsWith("Literal")) {
-
-            if (variableValue == '' || variableValue == undefined) {
-                const dialogOptions = inputDialog({ title:'Secret', oldValue:"", type:'Secret'});
-                const dialogResult = await showFormDialog(dialogOptions);
-                if (cancelDialog(dialogResult)) return;
-                inputValue = dialogResult["value"]['Secret'];
-            }
-
-            while (!checkInput(inputValue, 'secret')){
-                const dialogOptions = inputDialog({ title:'Secret', oldValue:inputValue, type:'Secret'});
-                const dialogResult = await showFormDialog(dialogOptions);
-
-                if (cancelDialog(dialogResult)) return;
-                inputValue = dialogResult["value"]['Secret'];
-            }
-            
-            node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(inputValue, 'out-0');
-
-        } 
-
-    } else if (nodeData.type === 'chat') {
-
-        if ((nodeName).startsWith("Literal")) {
-
-            if (variableValue == '' || variableValue == undefined) {
-                const dialogOptions = inputDialog({ title: 'Chat', oldValue:"", type:'Chat' });
-                const dialogResult = await showFormDialog(dialogOptions);
-                if (cancelDialog(dialogResult)) return;
-                inputValue = dialogResult["value"];
-
-                while (!checkInput(inputValue, 'chat')){
-                    const dialogOptions = inputDialog({ title:'Chat', oldValue:inputValue, type:'Chat'});
-                    const dialogResult = await showFormDialog(dialogOptions);
-    
-                    if (cancelDialog(dialogResult)) return;
-                    inputValue = dialogResult["value"];
-                }
-                inputValue = JSON.stringify(inputValue)
-            }
-
-            node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
-            node.addOutPortEnhance(inputValue, 'out-0');
-        } 
-    } 
-
-    return node;
+    return null;
 }

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -20,24 +20,23 @@ const TYPE_LITERALS = ['string', 'int', 'float', 'boolean', 'list', 'tuple', 'di
 const TYPE_ARGUMENTS = ['string', 'int', 'float', 'boolean'];
 const SPECIAL_LITERALS = ['chat'];
 
-export async function handleLiteralInput(nodeName, nodeData, variableValue, type, title = "New Literal Input") {
-    let inputValue = variableValue;
-    if (variableValue == '' || variableValue == undefined) {
-        let dialogOptions = inputDialog({ title, oldValue: "", type });
-        let dialogResult = await showFormDialog(dialogOptions);
-        if (cancelDialog(dialogResult)) return;
-
-        inputValue = dialogResult["value"][title] || dialogResult["value"];;
-
-        while (!checkInput(inputValue, type)){
-            dialogOptions = inputDialog({ title: type, oldValue: inputValue, type });
-            dialogResult = await showFormDialog(dialogOptions);
-
-            if (cancelDialog(dialogResult)) return;
-            inputValue = dialogResult["value"][title] || dialogResult["value"];
-        }
-    }
+export async function handleLiteralInput(nodeName, nodeData, inputValue = "", type, title = "New Literal Input") {
     
+    let dialogOptions = inputDialog({ title, oldValue:inputValue, type });
+    let dialogResult = await showFormDialog(dialogOptions);
+    if (cancelDialog(dialogResult)) return;
+
+    inputValue = dialogResult["value"][title] || dialogResult["value"];;
+
+    while (!checkInput(inputValue, type)){
+        dialogOptions = inputDialog({ title: type, oldValue: inputValue, type });
+        dialogResult = await showFormDialog(dialogOptions);
+
+        if (cancelDialog(dialogResult)) return;
+        inputValue = dialogResult["value"][title] || dialogResult["value"];
+        
+    }
+
     if (SPECIAL_LITERALS.includes(type)) inputValue = JSON.stringify(inputValue);
 
     const node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
@@ -62,7 +61,6 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
     const nodeData = props.model;
     const variableValue = props.variableValue || '';
     const nodeName = nodeData.task;
-    const argumentTitle = 'Please define parameter';
 
     // handler for Boolean
     if (nodeData.type === 'boolean' && nodeName.startsWith("Literal")) {
@@ -72,12 +70,19 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
         return node;
     }
     
+    // handler for Any
+    if (variableValue) {
+        const node = new CustomNodeModel({ name: nodeName, color: nodeData.color, extras: { "type": nodeData.type } });
+        node.addOutPortEnhance(variableValue, 'out-0');
+        return node;
+    }
+
     if (TYPE_LITERALS.includes(nodeData.type) && nodeName.startsWith("Literal")) {
         return handleLiteralInput(nodeName, nodeData, variableValue, nodeData.type);
     }
 
     if (TYPE_ARGUMENTS.includes(nodeData.type)) {
-        return handleArgumentInput(nodeData, argumentTitle);
+        return handleArgumentInput(nodeData, 'Please define parameter');
     }
 
     return null;

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -65,7 +65,7 @@ export async function GeneralComponentLibrary(props: GeneralComponentLibraryProp
 
     // handler for Boolean
     if (nodeData.type === 'boolean' && nodeName.startsWith("Literal")) {
-        const portLabel = nodeName.split(' ').slice(-1);
+        const portLabel = nodeData.task.split(' ').slice(-1)[0];
         node = new CustomNodeModel({ name: "Literal Boolean", color: nodeData.color, extras: { "type": nodeData.type } });
         node.addOutPortEnhance(portLabel, 'out-0');
         return node;

--- a/xai_components/base.py
+++ b/xai_components/base.py
@@ -1,5 +1,5 @@
 from argparse import Namespace
-from typing import TypeVar, Generic, Tuple
+from typing import TypeVar, Generic, Tuple, NamedTuple, List
 
 T = TypeVar('T')
 
@@ -131,3 +131,11 @@ class secret:
 
     def get_value(self):
         return self.__value
+    
+    
+class message(NamedTuple):
+    role: str
+    content: str
+
+class chat(NamedTuple):
+    messages: List[message]

--- a/xai_components/xai_template/example_components.py
+++ b/xai_components/xai_template/example_components.py
@@ -12,7 +12,6 @@ class HelloComponent(Component):
         creator_name = os.getlogin()
         print("Hello, " + creator_name)
 
-
 @xai_component
 class HelloHyperparameter(Component):
     """A component that changes the print message depending on the supplied parameter.
@@ -25,6 +24,7 @@ class HelloHyperparameter(Component):
     def execute(self, ctx) -> None:
         input_str = self.input_str.value
         print("Hello " + str(input_str))
+        
 @xai_component
 class CompulsoryHyperparameter(Component):
     """A component that uses Compulsory inPorts. 


### PR DESCRIPTION
# Description

This PR enables users to toggle Literal Booleans. Internally `Literal True` and `Literal False` are consolidated into `Literal Boolean`. The Boolean update is fully backwards compatible with older canvases.
Aside from that, this PR also:
- Refactored general components.
- Standardized literal type caps.
- Fixed Literal True / False from not rendering from an `any` port.
- Added the `chat` data type into base.py.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
# Tests

**1. Test Boolean Toggle**
    - Drag in a `Literal True` or `Literal False`. Verify that a `Literal Boolean` with the respective `True` or `False` value is spawned.  
    - Double click on it to spawn the edit menu form. Verify that the form spawns and it saved the old state (ie if it was a `Literal True` the form will show the `on` toggle.)
    - Change the value. Verify that the new value is updated.
    - Connect to the `Print` component. Verify that it compiles and correctly displays the value.
    
**2. Test Boolean Backward Compatibility**
    - Open a Xircuits canvas that has an old `Literal True` or `Literal False`, for example `ControlflowBranch.xircuits` in the examples directory. Verify that it can be compiled and runs correctly. 
    - Double click on the `Literal True` or `Literal False`. Verify that the toggle menu forms spawns.
    - Verify on updating the value, the Literal node will update with a `Literal Boolean`  node header.
    
**3. Test General Components**
    - Try out each general components. Verify that their inputs are correct and can be rendered correctly.
    - Try out rendering the Literals by dragging from the ports. Try out the Arguments as well. 
    - Try out each Literals from the `any` port interface.
    To help you, I've made this [component](https://gist.github.com/MFA-X-AI/9d344e3069e11d3061d1fbc877fe768d) that has all the current available port types.


- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
