### PR TITLE
🤖 Datatype Automation Tests + Xircuits - Playwright Interface Library

### DIFF
--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -69,5 +69,6 @@ jobs:
 
     - name: Test E2E
       run: |
-        ( ls && jupyter lab --NotebookApp.token='' ) & npm install -D @playwright/test && npx playwright test
+        ( ls && jupyter lab --ServerApp.token= --ServerApp.password= --LabApp.default_url=/lab\?reset
+) & npm install -D @playwright/test && npx playwright test
     

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -72,5 +72,5 @@ jobs:
       if: always()
       with:
         name: playwright-report
-        path: playwright-report/
+        path: ui-tests/playwright-report/
         retention-days: 30

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -64,6 +64,10 @@ jobs:
       run: |
         npx playwright install --with-deps
 
+    - name: Install xvfb
+      run: |
+        sudo apt-get install xvfb
+
     - name: Test E2E
       uses: coactions/setup-xvfb@v1
       with:

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -1,4 +1,4 @@
-name: Combined UI E2E Test and Playwright Tests
+name: Frontend Playwright Tests
 
 on:
   push:
@@ -48,16 +48,11 @@ jobs:
       run: |
         pip install -e .
 
-    - name: Build Wheel
-      run: |
-        python -m pip install --upgrade pip      
-        python -m pip install --upgrade build &&
-        python -m build
-
     - name: Install Xircuits
       run: |
-        whl_name=$(echo dist/*whl)[tensorflow_keras]
-        pip install $whl_name
+        xircuits-submodules tensorflow_keras
+        xircuits-submodules test
+
 
     - uses: actions/setup-node@v3
       with:
@@ -72,10 +67,7 @@ jobs:
 
     - name: Test E2E
       run: |
-        ( ls && jupyter lab --ServerApp.token= --ServerApp.password= --LabApp.default_url=/lab\?reset ) & npm install -D @playwright/test && npx playwright test
-
-    - name: Run Playwright tests
-      run: npx playwright test
+        ( ls && jupyter lab --ServerApp.token= --ServerApp.password= --LabApp.default_url=/lab\?reset ) & npm install -D @playwright/test && cd ui-tests && npx playwright test e2e/
 
     - uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -65,8 +65,10 @@ jobs:
         npx playwright install --with-deps
 
     - name: Test E2E
-      run: |
-        ( ls && jupyter lab --ServerApp.token= --ServerApp.password= --LabApp.default_url=/lab\?reset ) & npm install -D @playwright/test && cd ui-tests && npx playwright test e2e/datatype-test.spec.ts
+      uses: coactions/setup-xvfb@v1
+      with:
+        run: |
+          ( ls && jupyter lab --ServerApp.token= --ServerApp.password= --LabApp.default_url=/lab\?reset ) & npm install -D @playwright/test && cd ui-tests && xvfb-run npx playwright test e2e/datatype-test.spec.ts
 
     - uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -48,7 +48,18 @@ jobs:
       run: |
         pip install -e .
 
-    - name: Install Xircuits
+    - name: Build Wheel
+      run: |
+        python -m pip install --upgrade pip      
+        python -m pip install --upgrade build &&
+        python -m build
+
+    - name: Install Xircuits from wheel
+      run: |
+        whl_name=$(echo dist/*whl)
+        pip install $whl_name
+
+    - name: Install Xircuits Test Component Library
       run: |
         xircuits-submodules tests
 

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -77,4 +77,4 @@ jobs:
       with:
         name: playwright-report
         path: ui-tests/playwright-report/
-        retention-days: 30
+        retention-days: 1

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -69,10 +69,8 @@ jobs:
         sudo apt-get install xvfb
 
     - name: Test E2E
-      uses: coactions/setup-xvfb@v1
-      with:
-        run: |
-          ( ls && jupyter lab --ServerApp.token= --ServerApp.password= --LabApp.default_url=/lab\?reset ) & npm install -D @playwright/test && cd ui-tests && xvfb-run npx playwright test e2e/datatype-test.spec.ts
+      run: |
+        ( ls && jupyter lab --ServerApp.token= --ServerApp.password= --LabApp.default_url=/lab\?reset ) & npm install -D @playwright/test && cd ui-tests && xvfb-run npx playwright test e2e/datatype-test.spec.ts
 
     - uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -50,8 +50,7 @@ jobs:
 
     - name: Install Xircuits
       run: |
-        xircuits-submodules tensorflow_keras
-        xircuits-submodules test
+        xircuits-submodules tests
 
 
     - uses: actions/setup-node@v3
@@ -67,7 +66,7 @@ jobs:
 
     - name: Test E2E
       run: |
-        ( ls && jupyter lab --ServerApp.token= --ServerApp.password= --LabApp.default_url=/lab\?reset ) & npm install -D @playwright/test && cd ui-tests && npx playwright test e2e/
+        ( ls && jupyter lab --ServerApp.token= --ServerApp.password= --LabApp.default_url=/lab\?reset ) & npm install -D @playwright/test && cd ui-tests && npx playwright test e2e/datatype-test.spec.ts
 
     - uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -84,8 +84,8 @@ jobs:
         ( ls && jupyter lab --ServerApp.token= --ServerApp.password= --LabApp.default_url=/lab\?reset ) & npm install -D @playwright/test && cd ui-tests && xvfb-run npx playwright test e2e/datatype-test.spec.ts
 
     - uses: actions/upload-artifact@v3
-      if: always()
+      if: failure()
       with:
-        name: playwright-report
+        name: playwright-report-${{ matrix.python-version }}
         path: ui-tests/playwright-report/
         retention-days: 1

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,8 @@ tsconfig.tsbuildinfo
 
 # .py files compiled by Xircuits
 examples/*.py
+
+# playwright files
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "xai_components/xai_discord"]
 	path = xai_components/xai_discord
 	url = https://github.com/XpressAI/xai-discord
+[submodule "xai_components/xai_tests"]
+	path = xai_components/xai_tests
+	url = https://github.com/XpressAI/xai-tests

--- a/ui-tests/README.md
+++ b/ui-tests/README.md
@@ -104,7 +104,7 @@ docker-compose -f ../end-to-end-tests/docker-compose.yml --env-file ./ui-tests/.
 **Using local installation**
 
 ```
-jupyter lab --ServerApp.token= --ServerApp.password=
+jupyter lab --ServerApp.token= --ServerApp.password= --LabApp.default_url=/lab\?reset
 ```
 
 3. Launch the debug tool:
@@ -115,3 +115,7 @@ jlpm install
 npx playwright install
 PWDEBUG=1 npx playwright test
 ```
+Alternatively, if you would like to debug in the browser console:
+```
+PWDEBUG=console npx playwright test testname.spec.ts
+``

--- a/ui-tests/e2e/datatype-test.spec.ts
+++ b/ui-tests/e2e/datatype-test.spec.ts
@@ -7,12 +7,11 @@ test('test', async ({ page, browserName }) => {
   await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=xai_components').dblclick();
   await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=xai_tests').dblclick();
   await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=DataTypes.xircuits').click();
-  await page.keyboard.press('Control+D', { delay: 100 }); // duplicate
-  await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=DataTypes-Copy').click();
-  await page.keyboard.press('F2', { delay: 100 }); // rename
-  await page.keyboard.type(browserName, { delay: 100 });
-  await page.keyboard.press('Enter', { delay: 100 });
-  await page.keyboard.press('Enter');
+  await page.keyboard.press('Control+C'); // duplicate
+  await page.locator(`[aria-label="File\\ Browser\\ Section"] >> text=${browserName}`).dblclick();
+  await page.locator('.jp-DirListing-content').click({ button: 'right' });
+  await page.getByText("Ctrl+V").click();
+  await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=DataTypes.xircuits').dblclick();
   
   const nodeConnections: NodeConnection[] = [
     { sourceNode: "Literal String",   sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-string-string_port" },
@@ -60,7 +59,21 @@ test('test', async ({ page, browserName }) => {
   await page.locator('.react-switch-handle').click();
   await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
   await expect(page.getByText('False')).toBeVisible();
-  
+
+  await page.getByText('Literal Chat').dblclick();
+  await page.locator('div').filter({ hasText: /^Select a rolesystemuserassistantfunctionRemovedef$/ }).getByRole('button').click();
+  await page.locator('select[name="role"]').selectOption('user');
+  await page.locator('select[name="role"]').click();
+  await page.getByText('abc', { exact: true }).fill('updated user message');
+  await page.getByRole('button', { name: 'Add Message' }).click();
+  await page.getByRole('combobox').nth(2).selectOption('assistant');
+  await page.getByRole('textbox').nth(2).click();
+  await page.getByRole('textbox').nth(2).fill('new assistant message');
+  await page.getByRole('button', { name: 'Submit' }).click();
+  await expect(page.getByText('False')).toBeVisible();
+
+  [{"role":"user","content":"updated user message"},{"role":"assistant","content":"new assistant message"}]
+
   await compileAndRunXircuits(page);
 
   const updated_content = await page.locator('.jp-OutputArea-output').innerText();

--- a/ui-tests/e2e/datatype-test.spec.ts
+++ b/ui-tests/e2e/datatype-test.spec.ts
@@ -1,19 +1,7 @@
-import { Page, test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test';
+import { compileAndRunXircuits, NodeConnection, connectNodes, UpdateLiteralNode, updateLiteral } from '../xircuits_test_utils'
 import { datatype_test_1, datatype_test_2 } from './expected_outputs/01_datatypes'
 
-interface NodeConnection {
-  sourceNode: string;
-  sourcePort: string;
-  targetNode: string;
-  targetPort: string;
-}
-
-const connectNodes = async (page: Page, connection: NodeConnection) => {
-  await page.locator(`div[data-default-node-name="${connection.sourceNode}"] >> div[data-name="${connection.sourcePort}"]`).hover();
-  await page.mouse.down();
-  await page.locator(`div[data-default-node-name="${connection.targetNode}"] >> div[data-name="${connection.targetPort}"]`).hover();
-  await page.mouse.up();
-};
 test('test', async ({ page, browserName }) => {
   await page.goto('http://localhost:8888');
   await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=xai_components').dblclick();
@@ -26,84 +14,55 @@ test('test', async ({ page, browserName }) => {
   await page.keyboard.press('Enter', { delay: 100 });
   await page.keyboard.press('Enter');
   
-  await connectNodes(page, { sourceNode: "Literal String", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-string-string_port" });
-  await connectNodes(page, { sourceNode: "Literal Integer", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-int-int_port" });
-  await connectNodes(page, { sourceNode: "Literal Float", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-float-float_port" });
-  await connectNodes(page, { sourceNode: "Literal Boolean", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-boolean-boolean_port" });
-  await connectNodes(page, { sourceNode: "Literal List", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-list-list_port" });
-  await connectNodes(page, { sourceNode: "Literal Tuple", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-tuple-tuple_port" });
-  await connectNodes(page, { sourceNode: "Literal Dict", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-dict-dict_port" });
-  await connectNodes(page, { sourceNode: "Literal Secret", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-secret-secret_port" });
-  await connectNodes(page, { sourceNode: "Literal Chat", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-chat-chat_port" });
+  const nodeConnections: NodeConnection[] = [
+    { sourceNode: "Literal String",   sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-string-string_port" },
+    { sourceNode: "Literal Integer",  sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-int-int_port" },
+    { sourceNode: "Literal Float",    sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-float-float_port" },
+    { sourceNode: "Literal Boolean",  sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-boolean-boolean_port" },
+    { sourceNode: "Literal List",     sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-list-list_port" },
+    { sourceNode: "Literal Tuple",    sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-tuple-tuple_port" },
+    { sourceNode: "Literal Dict",     sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-dict-dict_port" },
+    { sourceNode: "Literal Secret",   sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-secret-secret_port" },
+    { sourceNode: "Literal Chat",     sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-chat-chat_port" },
+    { sourceNode: "Start",            sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "in-0" },
+    { sourceNode: "AllLiteralTypes",  sourcePort: "out-0", targetNode: "Finish",          targetPort: "in-0" }
+  ];
+  
+  for (const connection of nodeConnections) {
+    await connectNodes(page, connection);
+  }
 
-  await connectNodes(page, { sourceNode: "Start", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "in-0" });
-  await connectNodes(page, { sourceNode: "AllLiteralTypes", sourcePort: "out-0", targetNode: "Finish", targetPort: "in-0" });
-
-  // Save and compile the Xircuits file, wait for the element to be visible before interacting
-  await page.locator("xpath=//*[contains(@title, 'Save (Ctrl+S)')]").first().click();
-  await page.locator("xpath=//*[contains(@title, 'Compile Xircuits')]").first().click();
-  await page.locator("xpath=//*[contains(@title, 'Compile and Run Xircuits')]").first().click();
-
-  // Start and select the kernel for Xircuits
-  await page.locator('button:has-text("Start")').click();
-  await page.locator('button:has-text("Select")').click();
+  await compileAndRunXircuits(page);
 
   const content = await page.locator('.jp-OutputArea-output').innerText();
-
   expect(content).toContain(datatype_test_1);
   await page.locator('li[data-id="xircuit-output-panel"] >> svg[data-icon="ui-components:close"]').click();
   
-  await page.locator(`div[data-default-node-name="Literal String"]`).dblclick();
-  await page.locator('textarea[name="Update string"]').fill("Updated String")
-  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
-  await expect(page.getByText('Updated String')).toBeVisible();
-
-  await page.locator(`div[data-default-node-name="Literal Integer"]`).dblclick();
-  await page.locator('input[name="Update int"]').fill("456")
-  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
-  await expect(page.getByText('456')).toBeVisible();
-
-  await page.locator(`div[data-default-node-name="Literal Float"]`).dblclick();
-  await page.locator('input[name="Update float"]').fill("4.56")
-  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
-  await expect(page.getByText('4.56')).toBeVisible();
-
+  const updateParamsList = [
+    { type: "Literal String",   titleName: "Update string", updateValue: "Updated String", inputType: 'textarea' },
+    { type: "Literal Integer",  titleName: "Update int",    updateValue: "456" },
+    { type: "Literal Float",    titleName: "Update float",  updateValue: "4.56" },
+    { type: "Literal List",     titleName: "Update list",   updateValue: '"d", "e", "f"' },
+    { type: "Literal Tuple",    titleName: "Update tuple",  updateValue: '"g", "h", "i"' },
+    { type: "Literal Dict",     titleName: "Update dict",   updateValue: '"x": "xenon", "y": "yellow", "z": 2023' },
+    { type: "Literal Secret",   titleName: "Update secret", updateValue: "def", expectedText: '*****' },
+  ];
+  
+  for (const params of updateParamsList) {
+    const { type, titleName, updateValue, expectedText, inputType } = params;
+    await updateLiteral(page, { type, titleName, updateValue, inputType });
+    const visibleText = expectedText ? expectedText : updateValue;
+    await expect(page.getByText(visibleText)).toBeVisible();
+}
+  
+  // Handling Boolean separately
   await page.locator(`div[data-default-node-name="Literal Boolean"]`).dblclick();
   await page.locator('.react-switch-handle').click();
   await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
   await expect(page.getByText('False')).toBeVisible();
-
-  await page.locator(`div[data-default-node-name="Literal List"]`).dblclick();
-  await page.locator('input[name="Update list"]').fill('"d", "e", "f"')
-  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
-  await expect(page.getByText('"d", "e", "f"')).toBeVisible();
-
-  await page.locator(`div[data-default-node-name="Literal Tuple"]`).dblclick();
-  await page.locator('input[name="Update tuple"]').fill('"g", "h", "i"')
-  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
-  await expect(page.getByText('"g", "h", "i"')).toBeVisible();
-
-  await page.locator(`div[data-default-node-name="Literal Dict"]`).dblclick();
-  await page.locator('input[name="Update dict"]').fill('"x": "xenon", "y": "yellow", "z": 2023')
-  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
-  await expect(page.getByText('"x": "xenon", "y": "yellow", "z": 2023')).toBeVisible();
-
-  await page.locator(`div[data-default-node-name="Literal Secret"]`).dblclick();
-  await page.locator('input[name="Update secret"]').fill("Whose eyes are those eyes?")
-  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
-  await expect(page.getByText('*****')).toBeVisible();
-
-
-  // Save and compile the Xircuits file, wait for the element to be visible before interacting
-  await page.locator("xpath=//*[contains(@title, 'Save (Ctrl+S)')]").first().click();
-  await page.locator("xpath=//*[contains(@title, 'Compile Xircuits')]").first().click();
-  await page.locator("xpath=//*[contains(@title, 'Compile and Run Xircuits')]").first().click();
-
-  // Start and select the kernel for Xircuits
-  await page.locator('button:has-text("Start")').click();
-  await page.locator('button:has-text("Select")').click();
+  
+  await compileAndRunXircuits(page);
 
   const updated_content = await page.locator('.jp-OutputArea-output').innerText();
-
   expect(updated_content).toContain(datatype_test_2);
 });

--- a/ui-tests/e2e/datatype-test.spec.ts
+++ b/ui-tests/e2e/datatype-test.spec.ts
@@ -7,7 +7,7 @@ test('test', async ({ page, browserName }) => {
   await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=xai_components').dblclick();
   await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=xai_tests').dblclick();
   await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=DataTypes.xircuits').click();
-  await page.keyboard.press('Control+C'); // duplicate
+  await page.keyboard.press('Control+C');
   await page.locator(`[aria-label="File\\ Browser\\ Section"] >> text=${browserName}`).dblclick();
   await page.locator('.jp-DirListing-content').click({ button: 'right' });
   await page.getByText("Ctrl+V").click();
@@ -38,27 +38,22 @@ test('test', async ({ page, browserName }) => {
   await page.locator('li[data-id="xircuit-output-panel"] >> svg[data-icon="ui-components:close"]').click();
   
   const updateParamsList = [
-    { type: "Literal String",   titleName: "Update string", updateValue: "Updated String", inputType: 'textarea' },
-    { type: "Literal Integer",  titleName: "Update int",    updateValue: "456" },
-    { type: "Literal Float",    titleName: "Update float",  updateValue: "4.56" },
-    { type: "Literal List",     titleName: "Update list",   updateValue: '"d", "e", "f"' },
-    { type: "Literal Tuple",    titleName: "Update tuple",  updateValue: '"g", "h", "i"' },
-    { type: "Literal Dict",     titleName: "Update dict",   updateValue: '"x": "xenon", "y": "yellow", "z": 2023' },
-    { type: "Literal Secret",   titleName: "Update secret", updateValue: "def", expectedText: '*****' },
+    { type: "Literal String",   updateValue: "Updated String" },
+    { type: "Literal Integer",  updateValue: "456" },
+    { type: "Literal Float",    updateValue: "4.56" },
+    { type: "Literal Boolean",  updateValue: false },
+    { type: "Literal List",     updateValue: '"d", "e", "f"' },
+    { type: "Literal Tuple",    updateValue: '"g", "h", "i"' },
+    { type: "Literal Dict",     updateValue: '"x": "xenon", "y": "yellow", "z": 2023' },
+    { type: "Literal Secret",   updateValue: "def", expectedText: '*****' },
   ];
   
   for (const params of updateParamsList) {
-    const { type, titleName, updateValue, expectedText, inputType } = params;
-    await updateLiteral(page, { type, titleName, updateValue, inputType });
-    const visibleText = expectedText ? expectedText : updateValue;
+    const { type, updateValue, expectedText } = params;
+    await updateLiteral(page, { type, updateValue });
+    const visibleText = expectedText ? expectedText : (typeof updateValue === "boolean" ? (updateValue ? "True" : "False") : String(updateValue));
     await expect(page.getByText(visibleText)).toBeVisible();
-}
-  
-  // Handling Boolean separately
-  await page.locator(`div[data-default-node-name="Literal Boolean"]`).dblclick();
-  await page.locator('.react-switch-handle').click();
-  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
-  await expect(page.getByText('False')).toBeVisible();
+  }
 
   await page.getByText('Literal Chat').dblclick();
   await page.locator('div').filter({ hasText: /^Select a rolesystemuserassistantfunctionRemovedef$/ }).getByRole('button').click();
@@ -71,8 +66,6 @@ test('test', async ({ page, browserName }) => {
   await page.getByRole('textbox').nth(2).fill('new assistant message');
   await page.getByRole('button', { name: 'Submit' }).click();
   await expect(page.getByText('False')).toBeVisible();
-
-  [{"role":"user","content":"updated user message"},{"role":"assistant","content":"new assistant message"}]
 
   await compileAndRunXircuits(page);
 

--- a/ui-tests/e2e/datatype-test.spec.ts
+++ b/ui-tests/e2e/datatype-test.spec.ts
@@ -14,12 +14,18 @@ const connectNodes = async (page: Page, connection: NodeConnection) => {
   await page.locator(`div[data-default-node-name="${connection.targetNode}"] >> div[data-name="${connection.targetPort}"]`).hover();
   await page.mouse.up();
 };
-test('test', async ({ page }) => {
+test('test', async ({ page, browserName }) => {
   await page.goto('http://localhost:8888');
   await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=xai_components').dblclick();
   await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=xai_tests').dblclick();
-  await page.locator('text=DataTypes.xircuits').dblclick()
-
+  await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=DataTypes.xircuits').click();
+  await page.keyboard.press('Control+D', { delay: 100 }); // duplicate
+  await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=DataTypes-Copy').click();
+  await page.keyboard.press('F2', { delay: 100 }); // rename
+  await page.keyboard.type(browserName, { delay: 100 });
+  await page.keyboard.press('Enter', { delay: 100 });
+  await page.keyboard.press('Enter');
+  
   await connectNodes(page, { sourceNode: "Literal String", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-string-string_port" });
   await connectNodes(page, { sourceNode: "Literal Integer", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-int-int_port" });
   await connectNodes(page, { sourceNode: "Literal Float", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-float-float_port" });
@@ -46,6 +52,5 @@ test('test', async ({ page }) => {
   const content = await page.locator('.jp-OutputArea-output').innerText();
 
   expect(content).toContain(datatype_test_1);
-
 
 });

--- a/ui-tests/e2e/datatype-test.spec.ts
+++ b/ui-tests/e2e/datatype-test.spec.ts
@@ -1,8 +1,23 @@
-import { test, expect } from '@playwright/test';
-import { compileAndRunXircuits, NodeConnection, connectNodes, UpdateLiteralNode, updateLiteral } from '../xircuits_test_utils'
+import { test, type Page, expect } from '@playwright/test';
+import { navigateThroughJupyterDirectories, compileAndRunXircuits, NodeConnection, connectNodes, UpdateLiteralNode, updateLiteral } from '../xircuits_test_utils'
 import { datatype_test_1, datatype_test_2 } from './expected_outputs/01_datatypes'
 
-test('test', async ({ page, browserName }) => {
+
+test.describe.configure({ mode: 'serial' });
+
+let page: Page;
+
+test.beforeAll(async ({ browser }) => {
+  page = await browser.newPage();
+});
+
+test.afterAll(async () => {
+  await page.close();
+});
+
+
+test('Init data type test', async ({ page, browserName }) => {
+
   await page.goto('http://localhost:8888');
   await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=xai_components').dblclick();
   await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=xai_tests').dblclick();
@@ -11,8 +26,14 @@ test('test', async ({ page, browserName }) => {
   await page.locator(`[aria-label="File\\ Browser\\ Section"] >> text=${browserName}`).dblclick();
   await page.locator('.jp-DirListing-content').click({ button: 'right' });
   await page.getByText("Ctrl+V").click();
-  await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=DataTypes.xircuits').dblclick();
-  
+});
+
+
+test('Test connecting nodes', async ({ page, browserName }) => {
+
+  await page.goto(`http://localhost:8888/`);
+  await navigateThroughJupyterDirectories(page, `http://localhost:8888/lab/tree/xai_components/xai_tests/${browserName}/DataTypes.xircuits`);
+
   const nodeConnections: NodeConnection[] = [
     { sourceNode: "Literal String",   sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-string-string_port" },
     { sourceNode: "Literal Integer",  sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-int-int_port" },
@@ -36,7 +57,14 @@ test('test', async ({ page, browserName }) => {
   const content = await page.locator('.jp-OutputArea-output').innerText();
   expect(content).toContain(datatype_test_1);
   await page.locator('li[data-id="xircuit-output-panel"] >> svg[data-icon="ui-components:close"]').click();
-  
+});
+
+
+test('Test editing literal nodes', async ({ page, browserName }) => {
+
+  await page.goto(`http://localhost:8888/`);
+  await navigateThroughJupyterDirectories(page, `http://localhost:8888/lab/tree/xai_components/xai_tests/${browserName}/DataTypes.xircuits`);
+
   const updateParamsList = [
     { type: "Literal String",   updateValue: "Updated String" },
     { type: "Literal Integer",  updateValue: "456" },

--- a/ui-tests/e2e/datatype-test.spec.ts
+++ b/ui-tests/e2e/datatype-test.spec.ts
@@ -1,5 +1,5 @@
 import { Page, test, expect } from '@playwright/test';
-import { datatype_test_1 } from './expected_outputs/01_datatypes'
+import { datatype_test_1, datatype_test_2 } from './expected_outputs/01_datatypes'
 
 interface NodeConnection {
   sourceNode: string;
@@ -29,7 +29,7 @@ test('test', async ({ page, browserName }) => {
   await connectNodes(page, { sourceNode: "Literal String", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-string-string_port" });
   await connectNodes(page, { sourceNode: "Literal Integer", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-int-int_port" });
   await connectNodes(page, { sourceNode: "Literal Float", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-float-float_port" });
-  await connectNodes(page, { sourceNode: "Literal True", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-boolean-boolean_port" });
+  await connectNodes(page, { sourceNode: "Literal Boolean", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-boolean-boolean_port" });
   await connectNodes(page, { sourceNode: "Literal List", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-list-list_port" });
   await connectNodes(page, { sourceNode: "Literal Tuple", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-tuple-tuple_port" });
   await connectNodes(page, { sourceNode: "Literal Dict", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-dict-dict_port" });
@@ -38,7 +38,6 @@ test('test', async ({ page, browserName }) => {
 
   await connectNodes(page, { sourceNode: "Start", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "in-0" });
   await connectNodes(page, { sourceNode: "AllLiteralTypes", sourcePort: "out-0", targetNode: "Finish", targetPort: "in-0" });
-
 
   // Save and compile the Xircuits file, wait for the element to be visible before interacting
   await page.locator("xpath=//*[contains(@title, 'Save (Ctrl+S)')]").first().click();
@@ -52,5 +51,59 @@ test('test', async ({ page, browserName }) => {
   const content = await page.locator('.jp-OutputArea-output').innerText();
 
   expect(content).toContain(datatype_test_1);
+  await page.locator('li[data-id="xircuit-output-panel"] >> svg[data-icon="ui-components:close"]').click();
+  
+  await page.locator(`div[data-default-node-name="Literal String"]`).dblclick();
+  await page.locator('textarea[name="Update string"]').fill("Updated String")
+  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
+  await expect(page.getByText('Updated String')).toBeVisible();
 
+  await page.locator(`div[data-default-node-name="Literal Integer"]`).dblclick();
+  await page.locator('input[name="Update int"]').fill("456")
+  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
+  await expect(page.getByText('456')).toBeVisible();
+
+  await page.locator(`div[data-default-node-name="Literal Float"]`).dblclick();
+  await page.locator('input[name="Update float"]').fill("4.56")
+  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
+  await expect(page.getByText('4.56')).toBeVisible();
+
+  await page.locator(`div[data-default-node-name="Literal Boolean"]`).dblclick();
+  await page.locator('.react-switch-handle').click();
+  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
+  await expect(page.getByText('False')).toBeVisible();
+
+  await page.locator(`div[data-default-node-name="Literal List"]`).dblclick();
+  await page.locator('input[name="Update list"]').fill('"d", "e", "f"')
+  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
+  await expect(page.getByText('"d", "e", "f"')).toBeVisible();
+
+  await page.locator(`div[data-default-node-name="Literal Tuple"]`).dblclick();
+  await page.locator('input[name="Update tuple"]').fill('"g", "h", "i"')
+  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
+  await expect(page.getByText('"g", "h", "i"')).toBeVisible();
+
+  await page.locator(`div[data-default-node-name="Literal Dict"]`).dblclick();
+  await page.locator('input[name="Update dict"]').fill('"x": "xenon", "y": "yellow", "z": 2023')
+  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
+  await expect(page.getByText('"x": "xenon", "y": "yellow", "z": 2023')).toBeVisible();
+
+  await page.locator(`div[data-default-node-name="Literal Secret"]`).dblclick();
+  await page.locator('input[name="Update secret"]').fill("Whose eyes are those eyes?")
+  await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
+  await expect(page.getByText('*****')).toBeVisible();
+
+
+  // Save and compile the Xircuits file, wait for the element to be visible before interacting
+  await page.locator("xpath=//*[contains(@title, 'Save (Ctrl+S)')]").first().click();
+  await page.locator("xpath=//*[contains(@title, 'Compile Xircuits')]").first().click();
+  await page.locator("xpath=//*[contains(@title, 'Compile and Run Xircuits')]").first().click();
+
+  // Start and select the kernel for Xircuits
+  await page.locator('button:has-text("Start")').click();
+  await page.locator('button:has-text("Select")').click();
+
+  const updated_content = await page.locator('.jp-OutputArea-output').innerText();
+
+  expect(updated_content).toContain(datatype_test_2);
 });

--- a/ui-tests/e2e/datatype-test.spec.ts
+++ b/ui-tests/e2e/datatype-test.spec.ts
@@ -1,4 +1,5 @@
 import { Page, test, expect } from '@playwright/test';
+import { datatype_test_1 } from './expected_outputs/01_datatypes'
 
 interface NodeConnection {
   sourceNode: string;
@@ -42,8 +43,9 @@ test('test', async ({ page }) => {
   await page.locator('button:has-text("Start")').click();
   await page.locator('button:has-text("Select")').click();
 
-  // Check if the Xircuits execution completed successfully
-  const content = await page.locator("text=Finished Executing").innerHTML()
+  const content = await page.locator('.jp-OutputArea-output').innerText();
 
-  expect(content).toContain('Finished Executing')
+  expect(content).toContain(datatype_test_1);
+
+
 });

--- a/ui-tests/e2e/datatype-test.spec.ts
+++ b/ui-tests/e2e/datatype-test.spec.ts
@@ -1,5 +1,5 @@
 import { test, type Page, expect } from '@playwright/test';
-import { navigateThroughJupyterDirectories, cleanDirectory, compileAndRunXircuits, NodeConnection, connectNodes, UpdateLiteralNode, updateLiteral } from '../xircuits_test_utils'
+import { cleanDirectory, copyFile, deleteFile, compileAndRunXircuits, NodeConnection, connectNodes, updateLiteral } from '../xircuits_test_utils'
 import { datatype_test_1, datatype_test_2 } from './expected_outputs/01_datatypes'
 
 
@@ -33,9 +33,16 @@ test('Init data type test', async ({ page, browserName }, testInfo) => {
 
 
 test('Test connecting nodes', async ({ page, browserName }) => {
-  
+
+  let testFileName = "DataTypes-TestNodeConnect.xircuits"
+
   await page.goto(`http://localhost:8888/`);
-  await navigateThroughJupyterDirectories(page, `http://localhost:8888/lab/tree/xai_components/xai_tests/${browserName}/DataTypes.xircuits`);
+
+  await copyFile(page, 
+        `xai_components/xai_tests/${browserName}/DataTypes.xircuits`, 
+        `xai_components/xai_tests/${browserName}/${testFileName}`);
+
+  await page.goto(`http://localhost:8888/lab/tree/xai_components/xai_tests/${browserName}/${testFileName}`);
 
   const nodeConnections: NodeConnection[] = [
     { sourceNode: "Literal String",   sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-string-string_port" },
@@ -63,10 +70,20 @@ test('Test connecting nodes', async ({ page, browserName }) => {
 });
 
 
-test('Test editing literal nodes', async ({ page, browserName }) => {
+test('Test editing literal nodes', async ({ page, browserName }, testInfo) => {
+
+  let testFileName = "DataTypes-TestNodeEdit.xircuits"
+
+  if (testInfo.retry)
+    await deleteFile(page, `xai_components/xai_tests/${browserName}/${testFileName}`);
 
   await page.goto(`http://localhost:8888/`);
-  await navigateThroughJupyterDirectories(page, `http://localhost:8888/lab/tree/xai_components/xai_tests/${browserName}/DataTypes.xircuits`);
+
+  await copyFile(page, 
+        `xai_components/xai_tests/${browserName}/DataTypes-TestNodeConnect.xircuits`, 
+        `xai_components/xai_tests/${browserName}/${testFileName}`);
+
+    await page.goto(`http://localhost:8888/lab/tree/xai_components/xai_tests/${browserName}/${testFileName}`);
 
   const updateParamsList = [
     { type: "Literal String",   updateValue: "Updated String" },

--- a/ui-tests/e2e/datatype-test.spec.ts
+++ b/ui-tests/e2e/datatype-test.spec.ts
@@ -1,0 +1,49 @@
+import { Page, test, expect } from '@playwright/test';
+
+interface NodeConnection {
+  sourceNode: string;
+  sourcePort: string;
+  targetNode: string;
+  targetPort: string;
+}
+
+const connectNodes = async (page: Page, connection: NodeConnection) => {
+  await page.locator(`div[data-default-node-name="${connection.sourceNode}"] >> div[data-name="${connection.sourcePort}"]`).hover();
+  await page.mouse.down();
+  await page.locator(`div[data-default-node-name="${connection.targetNode}"] >> div[data-name="${connection.targetPort}"]`).hover();
+  await page.mouse.up();
+};
+test('test', async ({ page }) => {
+  await page.goto('http://localhost:8888');
+  await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=xai_components').dblclick();
+  await page.locator('[aria-label="File\\ Browser\\ Section"] >> text=xai_tests').dblclick();
+  await page.locator('text=DataTypes.xircuits').dblclick()
+
+  await connectNodes(page, { sourceNode: "Literal String", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-string-string_port" });
+  await connectNodes(page, { sourceNode: "Literal Integer", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-int-int_port" });
+  await connectNodes(page, { sourceNode: "Literal Float", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-float-float_port" });
+  await connectNodes(page, { sourceNode: "Literal True", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-boolean-boolean_port" });
+  await connectNodes(page, { sourceNode: "Literal List", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-list-list_port" });
+  await connectNodes(page, { sourceNode: "Literal Tuple", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-tuple-tuple_port" });
+  await connectNodes(page, { sourceNode: "Literal Dict", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-dict-dict_port" });
+  await connectNodes(page, { sourceNode: "Literal Secret", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-secret-secret_port" });
+  await connectNodes(page, { sourceNode: "Literal Chat", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "parameter-chat-chat_port" });
+
+  await connectNodes(page, { sourceNode: "Start", sourcePort: "out-0", targetNode: "AllLiteralTypes", targetPort: "in-0" });
+  await connectNodes(page, { sourceNode: "AllLiteralTypes", sourcePort: "out-0", targetNode: "Finish", targetPort: "in-0" });
+
+
+  // Save and compile the Xircuits file, wait for the element to be visible before interacting
+  await page.locator("xpath=//*[contains(@title, 'Save (Ctrl+S)')]").first().click();
+  await page.locator("xpath=//*[contains(@title, 'Compile Xircuits')]").first().click();
+  await page.locator("xpath=//*[contains(@title, 'Compile and Run Xircuits')]").first().click();
+
+  // Start and select the kernel for Xircuits
+  await page.locator('button:has-text("Start")').click();
+  await page.locator('button:has-text("Select")').click();
+
+  // Check if the Xircuits execution completed successfully
+  const content = await page.locator("text=Finished Executing").innerHTML()
+
+  expect(content).toContain('Finished Executing')
+});

--- a/ui-tests/e2e/expected_outputs/01_datatypes.ts
+++ b/ui-tests/e2e/expected_outputs/01_datatypes.ts
@@ -17,3 +17,23 @@ Secret inPort:
 554
 Chat inPort:
 [{'role': 'system', 'content': 'abc'}, {'role': 'user', 'content': 'def'}]`
+
+export const datatype_test_2 = `Executing: AllLiteralTypes
+String inPort:
+def
+Integer inPort:
+456
+Float inPort:
+4.56
+Boolean inPort:
+FAlse
+List inPort:
+['d', 'e', 'f']
+Tuple inPort:
+('d', 'e', 'f')
+Dict inPort:
+{"x": "xenon", "y": "yellow", "z": 2023}
+Secret inPort:
+def
+Chat inPort:
+[{'role': 'system', 'content': 'abc'}, {'role': 'user', 'content': 'def'}]`

--- a/ui-tests/e2e/expected_outputs/01_datatypes.ts
+++ b/ui-tests/e2e/expected_outputs/01_datatypes.ts
@@ -20,20 +20,20 @@ Chat inPort:
 
 export const datatype_test_2 = `Executing: AllLiteralTypes
 String inPort:
-def
+Updated String
 Integer inPort:
 456
 Float inPort:
 4.56
 Boolean inPort:
-FAlse
+False
 List inPort:
 ['d', 'e', 'f']
 Tuple inPort:
-('d', 'e', 'f')
+('g', 'h', 'i')
 Dict inPort:
-{"x": "xenon", "y": "yellow", "z": 2023}
+{'x': 'xenon', 'y': 'yellow', 'z': 2023}
 Secret inPort:
 def
 Chat inPort:
-[{'role': 'system', 'content': 'abc'}, {'role': 'user', 'content': 'def'}]`
+[{'role': 'user', 'content': 'updated user message'}, {'role': 'assistant', 'content': 'new assistant message'}]`

--- a/ui-tests/e2e/expected_outputs/01_datatypes.ts
+++ b/ui-tests/e2e/expected_outputs/01_datatypes.ts
@@ -1,0 +1,19 @@
+export const datatype_test_1 = `Executing: AllLiteralTypes
+String inPort:
+abc
+Integer inPort:
+123
+Float inPort:
+12.3
+Boolean inPort:
+True
+List inPort:
+['a', 'b', 'c']
+Tuple inPort:
+('a', 'b', 'c')
+Dict inPort:
+{'a': 'apple', 'b': 'banana', 'c': 2022}
+Secret inPort:
+554
+Chat inPort:
+[{'role': 'system', 'content': 'abc'}, {'role': 'user', 'content': 'def'}]`

--- a/ui-tests/playwright.config.ts
+++ b/ui-tests/playwright.config.ts
@@ -44,10 +44,10 @@ export default defineConfig({
       use: { ...devices['Desktop Firefox'] },
     },
 
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
 
     /* Test against mobile viewports. */
     // {

--- a/ui-tests/playwright.config.ts
+++ b/ui-tests/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 2 : 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/ui-tests/playwright.config.ts
+++ b/ui-tests/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 1,
+  retries: process.env.CI ? 3 : 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -28,7 +28,8 @@ export default defineConfig({
     // baseURL: 'http://127.0.0.1:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry'
+    trace: 'on-first-retry',
+    viewport: { width: 1280, height: 720 },
   },
 
   /* Configure projects for major browsers */

--- a/ui-tests/playwright.config.ts
+++ b/ui-tests/playwright.config.ts
@@ -28,9 +28,7 @@ export default defineConfig({
     // baseURL: 'http://127.0.0.1:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
-    viewport: { width: 1280, height: 720 },
-
+    trace: 'on-first-retry'
   },
 
   /* Configure projects for major browsers */

--- a/ui-tests/playwright.config.ts
+++ b/ui-tests/playwright.config.ts
@@ -10,6 +10,7 @@ import { defineConfig, devices } from '@playwright/test';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+  
   testDir: './e2e',
   /* Run tests in files in parallel */
   fullyParallel: true,
@@ -28,6 +29,8 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    viewport: { width: 1280, height: 720 },
+
   },
 
   /* Configure projects for major browsers */

--- a/ui-tests/playwright.config.ts
+++ b/ui-tests/playwright.config.ts
@@ -1,21 +1,77 @@
-import { PlaywrightTestConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
-const config: PlaywrightTestConfig = {
-  timeout: 60000,
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    // Browser options
-    headless: true,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
 
-    // Context options
-    viewport: { width: 1280, height: 720 },
-
-    // Artifacts
-    video: 'off',
-
-    launchOptions: {
-      slowMo: 500
-    }
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
   },
-};
 
-export default config;
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/ui-tests/xircuits_test_utils.tsx
+++ b/ui-tests/xircuits_test_utils.tsx
@@ -1,5 +1,14 @@
 import { Page, expect } from '@playwright/test';
 
+export async function startTerminalSession(page) {
+    await page.keyboard.press('Control+Shift+L');
+    await page.locator("xpath=//*[contains(@title, 'Start a new terminal session')]").first().click();
+}
+
+export async function inputTerminalCommand(page, cmd) {
+    await page.locator(`.xterm-helper-textarea`).fill(String(cmd));
+    await page.keyboard.press('Enter');
+}
 
 export async function navigateThroughJupyterDirectories(page, url: string) {
     const basePath = 'http://localhost:8888/lab/tree';
@@ -23,29 +32,23 @@ export async function cleanDirectory(page, url) {
     
     await page.goto('http://localhost:8888');
     await navigateThroughJupyterDirectories(page, url);
+    await startTerminalSession(page);
+    await inputTerminalCommand(page, "rm -rf *");
 
-    let fileItems = await page.$$('.jp-DirListing-item');
+}
 
-    while (fileItems.length > 0) {
+export async function copyFile(page, fileName, newFileName) {
+    
+    await startTerminalSession(page);
+    await inputTerminalCommand(page, `cp ${fileName} ${newFileName}`);
+    
+}
 
-        let fileItem = fileItems[0];
-
-        try {
-
-            if (await fileItem.isVisible()) {
-                await fileItem.click();
-                await page.keyboard.press('Delete');
-                await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-warn.jp-mod-styled').click();
-                await page.waitForTimeout(1000);
-            }
-
-        } catch (error) {
-            console.error(error);
-        }
-
-        // Refresh the list after an item has been processed
-        fileItems = await page.$$('.jp-DirListing-item');
-    }
+export async function deleteFile(page, fileName) {
+    
+    await startTerminalSession(page);
+    await inputTerminalCommand(page, `rm ${fileName}`);
+    
 }
 
 export async function compileAndRunXircuits(page: Page) {

--- a/ui-tests/xircuits_test_utils.tsx
+++ b/ui-tests/xircuits_test_utils.tsx
@@ -1,9 +1,24 @@
-import { Page, expect } from '@playwright/test';
+import { Page } from '@playwright/test';
 
 export async function startTerminalSession(page) {
-    await page.keyboard.press('Control+Shift+L');
+
+    const launcherElement = await page.$('.jp-Launcher-body');
+
+    if (launcherElement) {
+        const isVisible = await launcherElement.isVisible();
+
+        // If not visible, click on the tab
+        if (!isVisible) {
+            await page.locator(".lm-TabBar-tabLabel.p-TabBar-tabLabel").withText("Launcher").click();
+        }
+    } else {
+        // If the element doesn't exist, press the key combination
+        await page.keyboard.press('Control+Shift+L');
+    }
+
     await page.locator("xpath=//*[contains(@title, 'Start a new terminal session')]").first().click();
 }
+
 
 export async function inputTerminalCommand(page, cmd) {
     await page.locator(`.xterm-helper-textarea`).fill(String(cmd));

--- a/ui-tests/xircuits_test_utils.tsx
+++ b/ui-tests/xircuits_test_utils.tsx
@@ -24,9 +24,12 @@ export async function cleanDirectory(page, url) {
     await page.goto('http://localhost:8888');
     await navigateThroughJupyterDirectories(page, url);
 
-    const fileItems = await page.$$('.jp-DirListing-item');
+    let fileItems = await page.$$('.jp-DirListing-item');
 
-    for (let fileItem of fileItems) {
+    while (fileItems.length > 0) {
+
+        let fileItem = fileItems[0];
+
         try {
 
             if (await fileItem.isVisible()) {
@@ -35,12 +38,16 @@ export async function cleanDirectory(page, url) {
                 await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-warn.jp-mod-styled').click();
                 await page.waitForTimeout(1000);
             }
+
         } catch (error) {
             console.error(error);
         }
+
+        // Refresh the list after an item has been processed
+        fileItems = await page.$$('.jp-DirListing-item');
     }
 }
-  
+
 export async function compileAndRunXircuits(page: Page) {
     // Save and compile the Xircuits file, wait for the element to be visible before interacting
     await page.locator("xpath=//*[contains(@title, 'Save (Ctrl+S)')]").first().click();

--- a/ui-tests/xircuits_test_utils.tsx
+++ b/ui-tests/xircuits_test_utils.tsx
@@ -17,7 +17,6 @@ export async function startTerminalSession(page) {
     }
 
     const terminalButton = await page.locator("xpath=//*[contains(@title, 'Start a new terminal session')]").first();
-    await terminalButton.scrollIntoViewIfNeeded();
     await terminalButton.click();
 }
 

--- a/ui-tests/xircuits_test_utils.tsx
+++ b/ui-tests/xircuits_test_utils.tsx
@@ -1,5 +1,24 @@
 import { Page } from '@playwright/test';
 
+
+export async function navigateThroughJupyterDirectories(page, url: string) {
+    const basePath = 'http://localhost:8888/lab/tree';
+    
+    // Check if the url starts with the basePath
+    if (!url.startsWith(basePath)) {
+      throw new Error(`The URL should start with "${basePath}"`);
+    }
+    
+    // Remove the basePath from the url and split the rest into directories
+    const directories = url.replace(basePath, '').split('/');
+    
+    for (const dir of directories) {
+      if (dir) { // Skip any empty strings resulting from splitting the url
+        await page.locator(`[aria-label="File\\ Browser\\ Section"] >> text=${dir}`).dblclick();
+      }
+    }
+  }
+  
 export async function compileAndRunXircuits(page: Page) {
     // Save and compile the Xircuits file, wait for the element to be visible before interacting
     await page.locator("xpath=//*[contains(@title, 'Save (Ctrl+S)')]").first().click();

--- a/ui-tests/xircuits_test_utils.tsx
+++ b/ui-tests/xircuits_test_utils.tsx
@@ -16,7 +16,9 @@ export async function startTerminalSession(page) {
         await page.keyboard.press('Control+Shift+L');
     }
 
-    await page.locator("xpath=//*[contains(@title, 'Start a new terminal session')]").first().click();
+    const terminalButton = await page.locator("xpath=//*[contains(@title, 'Start a new terminal session')]").first();
+    await terminalButton.scrollIntoViewIfNeeded();
+    await terminalButton.click();
 }
 
 

--- a/ui-tests/xircuits_test_utils.tsx
+++ b/ui-tests/xircuits_test_utils.tsx
@@ -1,0 +1,39 @@
+import { Page } from '@playwright/test';
+
+export async function compileAndRunXircuits(page: Page) {
+    // Save and compile the Xircuits file, wait for the element to be visible before interacting
+    await page.locator("xpath=//*[contains(@title, 'Save (Ctrl+S)')]").first().click();
+    await page.locator("xpath=//*[contains(@title, 'Compile Xircuits')]").first().click();
+    await page.locator("xpath=//*[contains(@title, 'Compile and Run Xircuits')]").first().click();
+  
+    // Start and select the kernel for Xircuits
+    await page.locator('button:has-text("Start")').click();
+    await page.locator('button:has-text("Select")').click();
+}
+
+export interface NodeConnection {
+    sourceNode: string;
+    sourcePort: string;
+    targetNode: string;
+    targetPort: string;
+}
+  
+export const connectNodes = async (page: Page, connection: NodeConnection) => {
+    await page.locator(`div[data-default-node-name="${connection.sourceNode}"] >> div[data-name="${connection.sourcePort}"]`).hover();
+    await page.mouse.down();
+    await page.locator(`div[data-default-node-name="${connection.targetNode}"] >> div[data-name="${connection.targetPort}"]`).hover();
+    await page.mouse.up();
+};
+
+export interface UpdateLiteralNode {
+    type: string;
+    titleName: string;
+    updateValue: string;
+    inputType?: string;
+}
+
+export async function updateLiteral(page, {type, titleName, updateValue, inputType = 'input'}: UpdateLiteralNode) {
+    await page.locator(`div[data-default-node-name="${type}"]`).dblclick();
+    await page.locator(`${inputType}[name="${titleName}"]`).fill(updateValue);
+    await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-styled').click();
+}

--- a/ui-tests/xircuits_test_utils.tsx
+++ b/ui-tests/xircuits_test_utils.tsx
@@ -32,7 +32,7 @@ export async function cleanDirectory(page, url) {
     
     await page.goto('http://localhost:8888');
     await navigateThroughJupyterDirectories(page, url);
-    await startTerminalSession(page);
+    await page.locator("xpath=//*[contains(@title, 'Start a new terminal session')]").first().click();
     await inputTerminalCommand(page, "rm -rf *");
 
 }

--- a/ui-tests/xircuits_test_utils.tsx
+++ b/ui-tests/xircuits_test_utils.tsx
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
 
 
 export async function navigateThroughJupyterDirectories(page, url: string) {
@@ -18,6 +18,27 @@ export async function navigateThroughJupyterDirectories(page, url: string) {
       }
     }
   }
+
+export async function cleanDirectory(page, url) {
+    
+    await page.goto('http://localhost:8888');
+    await navigateThroughJupyterDirectories(page, url);
+
+    const fileItems = await page.$$('.jp-DirListing-item');
+
+    for (let fileItem of fileItems) {
+        
+        try {
+            await fileItem.click();
+            await page.keyboard.press('Delete');
+            await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-warn.jp-mod-styled').click();
+            await page.waitForTimeout(1000);
+        }
+        catch (error) {
+            console.error(error);
+        }
+  }
+}
   
 export async function compileAndRunXircuits(page: Page) {
     // Save and compile the Xircuits file, wait for the element to be visible before interacting
@@ -40,8 +61,10 @@ export interface NodeConnection {
 export const connectNodes = async (page: Page, connection: NodeConnection) => {
     await page.locator(`div[data-default-node-name="${connection.sourceNode}"] >> div[data-name="${connection.sourcePort}"]`).hover();
     await page.mouse.down();
+    await page.waitForTimeout(100);
     await page.locator(`div[data-default-node-name="${connection.targetNode}"] >> div[data-name="${connection.targetPort}"]`).hover();
     await page.mouse.up();
+    await page.waitForTimeout(100);
 };
 
 const literalTypeMapping = {
@@ -61,6 +84,7 @@ export interface UpdateLiteralNode {
 }
 
 export async function updateLiteral(page, {type, updateValue}: UpdateLiteralNode) {
+
     if (type === 'Literal Boolean') {
         await page.locator(`div[data-default-node-name="${type}"]`).dblclick();
         const isChecked = (await page.locator('input[role="switch"]').getAttribute('aria-checked')) === 'true';

--- a/ui-tests/xircuits_test_utils.tsx
+++ b/ui-tests/xircuits_test_utils.tsx
@@ -27,17 +27,18 @@ export async function cleanDirectory(page, url) {
     const fileItems = await page.$$('.jp-DirListing-item');
 
     for (let fileItem of fileItems) {
-        
         try {
-            await fileItem.click();
-            await page.keyboard.press('Delete');
-            await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-warn.jp-mod-styled').click();
-            await page.waitForTimeout(1000);
-        }
-        catch (error) {
+
+            if (await fileItem.isVisible()) {
+                await fileItem.click();
+                await page.keyboard.press('Delete');
+                await page.locator('.jp-Dialog-button.jp-mod-accept.jp-mod-warn.jp-mod-styled').click();
+                await page.waitForTimeout(1000);
+            }
+        } catch (error) {
             console.error(error);
         }
-  }
+    }
 }
   
 export async function compileAndRunXircuits(page: Page) {

--- a/ui-tests/xircuits_test_utils.tsx
+++ b/ui-tests/xircuits_test_utils.tsx
@@ -60,11 +60,12 @@ export interface NodeConnection {
   
 export const connectNodes = async (page: Page, connection: NodeConnection) => {
     await page.locator(`div[data-default-node-name="${connection.sourceNode}"] >> div[data-name="${connection.sourcePort}"]`).hover();
+    await page.waitForTimeout(100);
+
     await page.mouse.down();
-    await page.waitForTimeout(100);
     await page.locator(`div[data-default-node-name="${connection.targetNode}"] >> div[data-name="${connection.targetPort}"]`).hover();
-    await page.mouse.up();
     await page.waitForTimeout(100);
+    await page.mouse.up();
 };
 
 const literalTypeMapping = {


### PR DESCRIPTION
# Description

This PR adds a playwright test for Xircuits data types. It tests node connections for `String`, `Integer`, `Float`, `List`, `Tuple`, `Dict`, `Secret`, `Boolean`, as well as `Chat`, then performs tests on editing their values. It is updated to now test with 2 browsers, chrome, firefox.

This PR also introduces the groundwork for Xircuits - Playwright interface. Currently it supports:
- navigating through Jupyterlab directories
- compiling and running Xircuits
- connecting Nodes
- updating Literal values
- opening the jupyter xterm which basically enables any cmd commands.

I've also added a special component library for testing purposes [here](https://github.com/XpressAI/xai-tests). 

Finally, the github action now provides a playwright report to check the automation results. It is set to make a playwright report on failure.

## References
https://github.com/XpressAI/xircuits/pull/107


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [x] Xircuits Component Library
- [ ] Xircuits Project Template
- [x] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Verify that the Playwright Tests Work Locally**

**2. Verify that E2E Github Action Works**

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
