### PR TITLE
✨ Enable Output Panel Spawn Location Through Config

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,7 @@ import { DocumentWidget } from '@jupyterlab/docregistry';
 import { runIcon, saveIcon } from '@jupyterlab/ui-components';
 import { addNodeActionCommands } from './commands/NodeActionCommands';
 import { Token } from '@lumino/coreutils';
+import { DockLayout } from '@lumino/widgets';
 import { xircuitsIcon, debuggerIcon, componentLibIcon, changeFavicon, xircuitsFaviconLink } from './ui-components/icons';
 import { startRunOutputStr } from './kernel/RunOutput';
 
@@ -231,10 +232,17 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       * @returns The panel
       */
     async function createPanel(): Promise<OutputPanel> {
+      let splitMode: DockLayout.InsertMode = 'split-bottom' as DockLayout.InsertMode; // default value
+        
+      try {
+        const data = await requestAPI<any>('config/split_mode');
+          splitMode = data.splitMode as DockLayout.InsertMode;
+      } catch (err) {
+        console.error('Error fetching split mode from server:', err);
+      }
+        
       outputPanel = new OutputPanel(app.serviceManager, rendermime, widgetFactory, translator);
-      app.shell.add(outputPanel, 'main', {
-        mode: 'split-right'
-      });
+      app.shell.add(outputPanel, 'main', { mode: splitMode });
       return outputPanel;
     }
 

--- a/xircuits/.xircuits/config.ini
+++ b/xircuits/.xircuits/config.ini
@@ -5,6 +5,9 @@ BASE_PATH = xai_components
 IP_ADD = http://127.0.0.1
 PORT = 5000
 
+[UI]
+splitMode = split-bottom
+
 [REMOTE_EXECUTION]
 # Xircuits remote execution configs using subprocess module (eg. for Spark submit etc.)
 # Each run types will be shown on the toolbar dropdown.

--- a/xircuits/handlers/__init__.py
+++ b/xircuits/handlers/__init__.py
@@ -2,7 +2,7 @@ from jupyter_server.utils import url_path_join
 
 from .compile_xircuits import CompileXircuitsFileRouteHandler
 from .components import ComponentsRouteHandler
-from .config import RunConfigRouteHandler
+from .config import RunConfigRouteHandler, SplitModeConfigHandler
 from .debugger import DebuggerRouteHandler
 from .spark_submit import SparkSubmitRouteHandler
 
@@ -20,6 +20,10 @@ def setup_handlers(web_app, url_path):
         (
             url_path_join(base_url, url_path, "config/run"),
             RunConfigRouteHandler
+        ),
+        (
+        url_path_join(base_url, url_path, "config/split_mode"),
+        SplitModeConfigHandler
         ),
         (
             url_path_join(base_url, url_path, "components/"),

--- a/xircuits/handlers/config.py
+++ b/xircuits/handlers/config.py
@@ -54,3 +54,14 @@ class RunConfigRouteHandler(APIHandler):
             "err_msg": err_msg
             }
         self.finish(json.dumps(data))
+
+
+class SplitModeConfigHandler(APIHandler):
+    @tornado.web.authenticated
+    def get(self):
+        cfg = get_config()
+        try:
+            split_mode = cfg.get('UI', 'splitMode', fallback='split-bottom')
+            self.finish(json.dumps({"splitMode": split_mode}))
+        except Exception as e:
+            self.finish(json.dumps({"error": str(e)}))


### PR DESCRIPTION
# Description

This PR allows users to specify the output panel and log panel spawn location via `config.ini`. 

## References

https://github.com/XpressAI/xircuits/pull/241

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**Test Update Output Panel Spawn Location**

    1. Run Xircuits and run a workflow. Verify that the output panel spawns at the bottom (default location)
    2. Navigate to `.xircuits/config.ini`
    3. Update the `splitMode. Options are split-bottom, split-top, split-right, split-left.
    4. Rrerun another workflow. Verify that the new spawn location is what have been specified. 

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
