### PR TITLE
🐛 Fix Various Literal Parameter Input Handling

### DIFF
--- a/src/dialog/FormDialog.tsx
+++ b/src/dialog/FormDialog.tsx
@@ -119,10 +119,12 @@ const preventDefaultDialogHandler = (
 // Returns true if given element is valid
 const isFieldValid = (element: any): boolean => {
   if (element.type === 'number') {
-    return element.value === '' || Number(element.value.trim()) > 0
+    // Allow any number or an empty string for number inputs
+    return element.value === '' || !isNaN(Number(element.value.trim()))
       ? true
       : false;
   }
+  // For other input types, continue to check whether the input is not an empty string
   return element.value.trim() ? true : false;
 };
 

--- a/src/dialog/input-dialogues/TextAreaInput.tsx
+++ b/src/dialog/input-dialogues/TextAreaInput.tsx
@@ -1,21 +1,39 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 
 export const TextAreaInput = ({ title, oldValue }): JSX.Element => {
+	const textAreaRef = useRef(null);
+
+    // auto focus selector for text area
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            const textarea = textAreaRef.current;
+            if (textarea) {
+                textarea.focus();
+                const length = textarea.value.length;
+                textarea.selectionStart = length;
+                textarea.selectionEnd = length;
+            }
+        }, 10); // Delay to ensure the component is fully mounted.
+    
+        return () => clearTimeout(timer);
+    }, []);
+    
+    
+
 	return (
         <form>
             <h3 style={{ marginTop: 0, marginBottom: 5 }}>
                 Enter String Value (Without Quotes):
             </h3>
             <div>
-            <TextareaAutosize
-                defaultValue={oldValue}
-                minRows={14}
-                name={title}
-                style={{ width: 400, height: 200, fontSize: 12 }}
-                autoFocus />
+                <TextareaAutosize
+                    defaultValue={oldValue}
+                    minRows={14}
+                    name={title}
+                    style={{ width: 400, height: 200, fontSize: 12 }}
+                    ref={textAreaRef} />
             </div>
-    </form>
-
+        </form>
 	);
 }

--- a/src/helpers/InputSanitizer.tsx
+++ b/src/helpers/InputSanitizer.tsx
@@ -1,5 +1,10 @@
 function checkInput(input: any, dataType: string): boolean {
 
+    if(input === ""){
+        alert("Input cannot be empty.");
+        return false;
+    }
+
     const normalizedDataType = dataType.toLowerCase();
     let processedInput = "";
     let errorDetails = "";

--- a/src/helpers/InputSanitizer.tsx
+++ b/src/helpers/InputSanitizer.tsx
@@ -15,10 +15,20 @@ function checkInput(input: any, dataType: string): boolean {
     switch (normalizedDataType) {
         case "int":
         case "integer":
+            // Regex: Matches possibly negative integers
+            if(!/^\-?\d+$/.test(input)){
+                errorDetails = "Input is not an integer.";
+                exampleInput = "e.g. 3";
+                alert(formatError(errorDetails, exampleInput));
+                return false;
+            }
+            processedInput = `${input}`;
+            break;
         case "float":
-            if (isNaN(Number(input))) {
-                errorDetails = "Input is not a number.";
-                exampleInput = normalizedDataType === "float" ? "e.g. 3.14" : "e.g. 3";
+            // Regex: Matches possibly negative floats
+            if(!/^\-?\d*\.\d+$/.test(input)){
+                errorDetails = "Input is not a float.";
+                exampleInput = "e.g. 3.14";
                 alert(formatError(errorDetails, exampleInput));
                 return false;
             }

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -21,21 +21,15 @@ const TYPE_ARGUMENTS = ['string', 'int', 'float', 'boolean'];
 const SPECIAL_LITERALS = ['chat'];
 
 export async function handleLiteralInput(nodeName, nodeData, inputValue = "", type, title = "New Literal Input") {
-    
-    let dialogOptions = inputDialog({ title, oldValue:inputValue, type });
-    let dialogResult = await showFormDialog(dialogOptions);
-    if (cancelDialog(dialogResult)) return;
-
-    inputValue = dialogResult["value"][title] || dialogResult["value"];;
-
-    while (!checkInput(inputValue, type)){
-        dialogOptions = inputDialog({ title: type, oldValue: inputValue, type });
-        dialogResult = await showFormDialog(dialogOptions);
-
+    do {
+        let dialogOptions = inputDialog({ title, oldValue: inputValue, type });
+        let dialogResult = await showFormDialog(dialogOptions);
         if (cancelDialog(dialogResult)) return;
-        inputValue = dialogResult["value"][title] || dialogResult["value"];
-        
-    }
+
+        // lit chat value accessed through dialogResult["value"]
+        inputValue = dialogResult["value"][title] || dialogResult["value"] || "";
+
+    } while (!checkInput(inputValue, type))
 
     if (SPECIAL_LITERALS.includes(type)) inputValue = JSON.stringify(inputValue);
     if (nodeName === 'Literal True' || nodeName === 'Literal False') nodeName = 'Literal Boolean';

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -26,8 +26,12 @@ export async function handleLiteralInput(nodeName, nodeData, inputValue = "", ty
         let dialogResult = await showFormDialog(dialogOptions);
         if (cancelDialog(dialogResult)) return;
 
-        // lit chat value accessed through dialogResult["value"]
-        inputValue = dialogResult["value"][title] || dialogResult["value"] || "";
+        if (SPECIAL_LITERALS.includes(type)) {
+            // lit chat values accessed through dialogResult["value"]
+            inputValue = dialogResult["value"];
+        } else {
+            inputValue = dialogResult["value"][title];
+        }
 
     } while (!checkInput(inputValue, type))
 


### PR DESCRIPTION

# Description

This PR:
- bugfix: add handler if users submit empty parameter value
- bugfix: allow neg number parameters, add int / float typechecks
- bugfix: handle empty string validation
- enable autofocus on text string input

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Drag in any literal component. Do not enter anything and press submit. Verify that an error message spawns and you can correct it.
2. Drag in an Int / Float. Verify that you can enter 0s and negative values. Also verify that each will correctly type check (ie entering 1.5 in integers will throw out an error message)
3. Drag in a Literal String. Verify that it doesn't explode and an error message spawns on empty content. 
4. Also verify that spawning the Literal String will autofocus on the text area, and on edit Literal String will focus on the end of the string.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
