### PR TITLE
✨ Revamp Xircuits CLI

### DIFF
--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Install Xircuits Test Component Library
       run: |
-        xircuits-submodules tests
+        xircuits install tests
 
 
     - uses: actions/setup-node@v3

--- a/setup.py
+++ b/setup.py
@@ -102,14 +102,10 @@ setup_args = dict(
         "Framework :: Jupyter :: JupyterLab :: Extensions",
         "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
     ],
-    entry_points ={
+    entry_points = {
         'console_scripts': [
             'xircuits = xircuits.start_xircuits:main',
-            'xircuits-examples = xircuits.start_xircuits:download_examples',
-            'xircuits-components = xircuits.start_xircuits:fetch_component_library',
-            'xircuits-submodules = xircuits.start_xircuits:download_submodule_library',
-            'xircuits-compile = xircuits.compiler.compiler:main'
-            ]}
+        ]}
 )
 
 try:

--- a/xircuits/compiler/compiler.py
+++ b/xircuits/compiler/compiler.py
@@ -12,23 +12,3 @@ def compile(input_file, output_file, component_python_paths=None):
     graph = parser.parse(input_file)
     generator = CodeGenerator(graph, component_python_paths)
     generator.generate(output_file)
-
-
-def main():
-    import argparse
-    parser = argparse.ArgumentParser()
-    parser.add_argument('source_file', type=argparse.FileType('r', encoding='utf-8'))
-    parser.add_argument('out_file', type=argparse.FileType('w', encoding='utf-8'))
-    parser.add_argument("python_paths_file", nargs='?', default=None, type=argparse.FileType('r'),
-                        help="JSON file with a mapping of component name to required python path. "
-                             "e.g. {'MyComponent': '/some/path'}")
-
-    args = parser.parse_args()
-    component_paths = {}
-    if args.python_paths_file:
-        component_paths = json.load(args.python_paths_file)
-    compile(args.source_file, args.out_file, component_python_paths=component_paths)
-
-
-if __name__ == '__main__':
-    main()

--- a/xircuits/handlers/request_folder.py
+++ b/xircuits/handlers/request_folder.py
@@ -2,7 +2,10 @@ from tqdm import tqdm
 import os
 from urllib import request, parse
 from github import Github, GithubException
+from typing import Optional
 from .request_submodule import get_submodules
+import subprocess
+import re 
 
 def request_folder(folder, repo_name="XpressAi/Xircuits", branch="master"):
     print("Downloading " + folder + " from " + repo_name + " branch " + branch)
@@ -48,3 +51,44 @@ def request_folder(folder, repo_name="XpressAi/Xircuits", branch="master"):
         except:
             if urls[url] not in submodules:
                 print("Unable to retrieve " + urls[url] + ". Skipping...")
+
+
+def extract_library_details_from_url(github_url):
+    """Extract organization and repository name from GitHub URL."""
+    match = re.search(r'github.com/([^/]+)/xai-(.+)$', github_url)
+    if not match:
+        raise ValueError("Invalid GitHub URL format.")
+
+    org_name = match.group(1)
+    repo_name = match.group(2).replace('-', '_')
+    return org_name, repo_name
+
+def clone_repo(github_url, target_path):
+    """Clone a repository from GitHub URL to the specified target path."""
+    try:
+        subprocess.run(["git", "clone", github_url, target_path], check=True)
+    except subprocess.CalledProcessError:
+        print(f"Error: Unable to clone {github_url} into {target_path}. The directory may already exist and is not empty.")
+        return target_path
+
+    return target_path
+
+def clone_from_github_url(github_url: str) -> str:
+    # Create a Github instance
+    g = Github()
+
+    org_name, repo_name = extract_library_details_from_url(github_url)
+    target_path = f"xai_components/xai_{repo_name}"
+
+    # Retrieve the repository
+    try:
+        repo = g.get_repo(f"{org_name}/xai-{repo_name}")
+
+        # Check if repo exists, otherwise GithubException will be raised
+        if repo:
+            return clone_repo(github_url, target_path)
+        else:
+            raise ValueError(f"No repository found at {github_url}")
+
+    except GithubException as e:
+        raise RuntimeError(f"Error accessing the repository: {e}")

--- a/xircuits/handlers/request_submodule.py
+++ b/xircuits/handlers/request_submodule.py
@@ -20,7 +20,7 @@ def get_submodule_config(user_query):
         return
         
     if len(submodule_keys) > 1:
-        print("Multiple '" + user_query + "' found. Returning first instance.")
+        raise ValueError(f"Multiple instances of '{user_query}' found.")
 
     submodule_key = submodule_keys.pop(0)
     

--- a/xircuits/handlers/request_submodule.py
+++ b/xircuits/handlers/request_submodule.py
@@ -31,13 +31,6 @@ def get_submodule_config(user_query):
 
 
 def request_submodule_library(component_library_query):
-
-    # ensure syntax is as xai_components/xai_library_name
-    if "xai" not in component_library_query:
-        component_library_query = "xai_" + component_library_query
-
-    if "xai_components" not in component_library_query:
-        component_library_query = "xai_components/" + component_library_query
     
     submodule_path, submodule_url = get_submodule_config(component_library_query)
     

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -185,12 +185,12 @@ def main():
     start_parser.set_defaults(func=cmd_start_xircuits)
 
     # Adding parser for 'install' command
-    install_parser = subparsers.add_parser('install', help='Install a library for Xircuits.')
+    install_parser = subparsers.add_parser('install', help='Fetch and installs a library for Xircuits.')
     install_parser.add_argument('library_name', type=str, help='Name of the library to install')
     install_parser.set_defaults(func=cmd_install_library)
 
     # Adding parser for 'fetch' command
-    fetch_parser = subparsers.add_parser('fetch', help='Fetch a library for Xircuits. Does not install.')
+    fetch_parser = subparsers.add_parser('fetch-only', help='Fetch a library for Xircuits. Does not install.')
     fetch_parser.add_argument('library_name', type=str, help='Name of the library to fetch')
     fetch_parser.set_defaults(func=cmd_fetch_library)
 
@@ -218,7 +218,8 @@ def main():
     if hasattr(args, 'func'):
         args.func(args, unknown_args)
     else:
-        if "--help" in unknown_args or "-h" in unknown_args:
+        valid_help_args = {"-h", "--h" "-help", "--help"}
+        if any(arg in unknown_args for arg in valid_help_args):
             parser.print_help()
         else:
             # Default behavior: if no sub-command is provided, start xircuits.

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -49,9 +49,7 @@ def cmd_start_xircuits(args, extra_args=[]):
     # fetch xai_components
     component_library_path = Path(os.getcwd()) / "xai_components"
     if not component_library_path.exists():
-        val = input("Xircuits Component Library is not found. Would you like to load it in the current path (Y/N)? ")
-        if val.lower() in ("y", "yes"):
-            copy_from_installed_wheel('xai_components', '', 'xai_components')
+        copy_from_installed_wheel('xai_components', '', 'xai_components')
 
     # handler for extra jupyterlab launch options
     if extra_args:
@@ -127,6 +125,11 @@ def check_requirements_installed(requirements_path):
     return required_packages.issubset(installed_packages)
 
 def cmd_list_libraries(args, extra_args=[]):
+    
+    component_library_path = Path(os.getcwd()) / "xai_components"
+    if not component_library_path.exists():
+        copy_from_installed_wheel('xai_components', '', 'xai_components')
+
     print("Checking installed packages... This might take a moment.")
     # Fetch libraries from .gitmodules
     gitmodules_path = Path(".gitmodules") if Path(".gitmodules").exists() else Path(".xircuits/.gitmodules")

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -28,7 +28,8 @@ def build_component_library_path(component_library_query: str) -> str:
     return component_library_query
 
 def is_empty(directory):
-    return not os.listdir(directory)
+    # will return true for uninitialized submodules
+    return not os.path.exists(directory) or not os.listdir(directory)
 
 def is_valid_url(url):
     try:


### PR DESCRIPTION
# Description

This PR revamps the Xircuits CLI. 

### `xircuits` or `xircuits start`
- Start Xircuits
- You may also append any [Jupyterlab launch commands](https://nocomplexity.com/documents/jupyterlab/notebooks/jupyterlab-cli.html), eg `xircuits start --no-browser`

### `xircuits install <component library name>`
- Fetches and pip installs a component library for Xircuits based on their requirements.txt.
- You may provide a component library name listed in the [component library list](https://github.com/XpressAI/xircuits/tree/master/xai_components), or provide a github repository url.

### `xircuits fetch-only <component library name>`
- Fetches and but does not install a component library for Xircuits.
- You may provide a component library name listed in the [component library list](https://github.com/XpressAI/xircuits/tree/master/xai_components), or provide a github repository url.
- Will return an error if the directory already exists. 

### `xircuits examples`
- Download the `examples` and `dataset` directory from the Xircuits repository.

### `xircuits compile <source_file> <out_file> [python_paths_file]`
- compiles a Xircuits workflow into the python script.
- optionally provide `python_paths_file`, a JSON file with a mapping of component name to required python path. e.g. {'MyComponent': '/some/path'}

### `xircuits list`
- Lists `installed`, `available`, and `remote` component libraries for Xircuits.

Each command also comes with the `-h` help option.
 
## References
https://github.com/XpressAI/xircuits/pull/226
https://github.com/XpressAI/xircuits/pull/152
https://github.com/XpressAI/xircuits/pull/132

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [x] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Tests

#### Test A: `xircuits` or `xircuits start`

1. Execute `xircuits`.
    - **Expectation**: Xircuits should start up.
2. Execute `xircuits start --no-browser`.
    - **Expectation**: Xircuits should start up without opening a browser window.

#### Test B: `xircuits install <component library name>`

1. Execute `xircuits install tests`.
    - **Expectation**: The component library named "tests" should be fetched and pip-installed based on its requirements.txt.
2. Execute `xircuits install https://github.com/XpressAI/xai-tests`.
    - **Expectation**: The component library from the provided GitHub repository URL should be fetched and pip-installed.

#### Test C: `xircuits fetch tests`

1. Execute `xircuits fetch tests`.
    - **Expectation**: The component library named "tests" should be fetched but not installed.
2. Execute `xircuits fetch https://github.com/XpressAI/xai-tests`.
    - **Expectation**: The component library from the provided GitHub repository URL should be fetched but not installed.
3. Re-execute either of the above commands.
    - **Expectation**: Should return an error stating the directory already exists.

#### Test D: `xircuits examples`

1. Execute `xircuits examples`.
    - **Expectation**: The `examples` and `dataset` directories should be downloaded from the Xircuits repository.

#### Test E: `xircuits compile <source_file> <out_file> [python_paths_file]`

1. Execute `xircuits compile myWorkflow.xircuits output.py`.
    - **Expectation**: The Xircuits workflow "myWorkflow.xircuits" should be compiled into the Python script "output.py".

#### Test F: `xircuits list`

1. Execute `xircuits list`.
    - **Expectation**: Should list the `installed`, `available`, and `remote` component libraries for Xircuits.



## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Add if any.
