### PR TITLE
🐛 Fix Open Component Script Features

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -80,10 +80,10 @@ export function addNodeActionCommands(
             );
             newWidget.context.ready.then(() => {
                 // Go to end of node's line first before go to its class
-                app.commands.execute('codemirror:go-to-line', {
+                app.commands.execute('fileeditor:go-to-line', {
                     line: nodeLineNo[0].end_lineno
                 }).then(() => {
-                    app.commands.execute('codemirror:go-to-line', {
+                    app.commands.execute('fileeditor:go-to-line', {
                         line: nodeLineNo[0].lineno
                     })
                 })

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -17,8 +17,6 @@ import { formDialogWidget } from '../dialog/formDialogwidget';
 import { CommentDialog } from '../dialog/CommentDialog';
 import React from 'react';
 import { showFormDialog } from '../dialog/FormDialog';
-import { inputDialog } from '../dialog/LiteralInputDialog';
-import { checkInput } from '../helpers/InputSanitizer';
 import { CustomPortModel } from '../components/port/CustomPortModel';
 import { CustomLinkModel, ParameterLinkModel, TriangleLinkModel } from '../components/link/CustomLinkModel';
 import { PointModel } from '@projectstorm/react-diagrams';
@@ -58,11 +56,18 @@ export function addNodeActionCommands(
     //Add command to open node's script at specific line
     commands.addCommand(commandIDs.openScript, {
         execute: async (args) => {
-            const node = getLastSelectedNode();
-            const nodePath = args['nodePath'] as string ?? node.extras.path;
-            const nodeName = args['nodeName'] as string ?? node.name;
-            const nodeLineNo = args['nodeLineNo'] as number ?? node.extras.lineNo;
+            let node, nodePath, nodeName, nodeLineNo;
 
+            // call getLastSelectedNode() if opened from Xircuits canvas
+            if (args['nodePath'] === undefined && args['nodeName'] === undefined && args['nodeLineNo'] === undefined) {
+                node = getLastSelectedNode();
+            }
+    
+            // Assign values based on whether args were provided or derived from getLastSelectedNode()
+            nodePath = args['nodePath'] ?? node?.extras.path;
+            nodeName = args['nodeName'] ?? node?.name;
+            nodeLineNo = args['nodeLineNo'] ?? node?.extras.lineNo;
+    
             if (nodeName.startsWith('Literal') || nodeName.startsWith('Argument')) {
                 showDialog({
                     title: `${node.name} don't have its own script`,

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -77,22 +77,15 @@ export function addNodeActionCommands(
             }
 
             // Open node's file name
-            const newWidget = await app.commands.execute(
-                commandIDs.openDocManager,
-                {
-                    path: nodePath
-                }
-            );
-            newWidget.context.ready.then(() => {
-                // Go to end of node's line first before go to its class
-                app.commands.execute('fileeditor:go-to-line', {
-                    line: nodeLineNo[0].end_lineno
-                }).then(() => {
-                    app.commands.execute('fileeditor:go-to-line', {
-                        line: nodeLineNo[0].lineno
-                    })
-                })
-            });
+            const newWidget = await app.commands.execute(commandIDs.openDocManager, { path: nodePath });
+            await newWidget.context.ready;
+
+            // Go to end of node's line first before go to its class
+            await app.commands.execute('fileeditor:go-to-line', { line: nodeLineNo[0].end_lineno });
+
+            await new Promise(resolve => setTimeout(resolve, 10));
+            // Then go to the specific line
+            await app.commands.execute('fileeditor:go-to-line', { line: nodeLineNo[0].lineno });
         }
     });
 


### PR DESCRIPTION
# Description

This PR fixes the following bugs:
- Fix open component script from canvas introduced in the upgrade to jupyterlab 4.
- Fix opening component script from tray when a canvas is not active
- Fix open script from not auto-centering

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Open a workflow canvas, drag in a component and open script from the context menu. 
2. Open the component library tray sidebar, and double click to open script. 
For both steps, ensure that the component script opens and is centered. 

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

