### PR TITLE
✨ Allow Users to Set Component Library Configurations

### DIFF
--- a/src/context-menu/CanvasContextMenu.tsx
+++ b/src/context-menu/CanvasContextMenu.tsx
@@ -59,27 +59,37 @@ export class CanvasContextMenu extends React.Component<CanvasContextMenuProps> {
 
 export function getMenuOptionsVisibility(models) {
 
-	function isParameterNode(node) {
+    function isLiteralNode(node) {
         return node.getOptions()?.name?.startsWith("Literal") ?? false;
-	}
+    }
 
-	let isNodeSelected = models.some(model => model instanceof NodeModel);
-	let isLinkSelected = models.some(model => model instanceof LinkModel);
-	let parameterNodes = models.filter(model => isParameterNode(model));
-	let isSingleParameterNodeSelected = parameterNodes.length === 1;
-	let multipleLinksSelected = models.filter(model => model instanceof LinkModel).length > 1;
-	let isSingleNonParameterNodeSelected = models.length === 1 && isNodeSelected && !isParameterNode(models[0]);
+    function isArgumentNode(node) {
+        return node.getOptions()?.name?.startsWith("Argument") ?? false;
+    }
 
-	return {
-		showCutCopyPaste: !models.length || isNodeSelected || isLinkSelected,
-		showReloadNode: isNodeSelected && !multipleLinksSelected,
-		showEdit: isSingleParameterNodeSelected,
-		showOpenScript: isSingleNonParameterNodeSelected,
-		showDelete: isNodeSelected || isLinkSelected || parameterNodes.length > 0,
-		showUndoRedo: !models.length,
-		showAddComment: !models.length
-	};
+    function isComponentNode(node) {
+        return !isLiteralNode(node) && !isArgumentNode(node);
+    }
+
+    let isNodeSelected = models.some(model => model instanceof NodeModel);
+    let isLinkSelected = models.some(model => model instanceof LinkModel);
+    let literalNodes = models.filter(model => isLiteralNode(model));
+    let componentNodes = models.filter(model => isComponentNode(model));
+    let isSingleLiteralNodeSelected = literalNodes.length === 1;
+    let isSingleComponentNodeSelected = componentNodes.length === 1;
+    let showReloadNode = isNodeSelected && componentNodes.length > 0;
+
+    return {
+        showCutCopyPaste: !models.length || isNodeSelected || isLinkSelected,
+        showReloadNode: showReloadNode,
+        showEdit: isSingleLiteralNodeSelected,
+        showOpenScript: isSingleComponentNodeSelected,
+        showDelete: isNodeSelected || isLinkSelected || literalNodes.length > 0,
+        showUndoRedo: !models.length,
+        showAddComment: !models.length
+    };
 }
+
 
 export function countVisibleMenuOptions(visibility) {
     let count = Object.values(visibility).filter(isVisible => isVisible).length;

--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -36,68 +36,46 @@ export const Content = styled.div`
     'border-top': '4px solid #dfe2e5'
 `;
 
-const headerList = [
-    { task: 'GENERAL', id: 1 }
-];
-
-const advancedList = [
-    { task: 'ADVANCED', id: 1 }
-];
-
-const colorList_adv = [
-    { task: "rgb(192,255,0)", id: 1 },
-    { task: "rgb(0,102,204)", id: 2 },
-    { task: "rgb(255,153,102)", id: 3 },
-    { task: "rgb(255,102,102)", id: 4 },
-    { task: "rgb(15,255,255)", id: 5 },
-    { task: "rgb(255,204,204)", id: 6 },
-    { task: "rgb(153,204,51)", id: 7 },
-    { task: "rgb(255,153,0)", id: 8 },
-    { task: "rgb(255,204,0)", id: 9 },
-    { task: "rgb(204,204,204)", id: 10 },
-    { task: "rgb(153,204,204)", id: 11 },
-    { task: "rgb(153,0,102)", id: 12 },
-    { task: "rgb(102,51,102)", id: 13 },
-    { task: "rgb(153,51,204)", id: 14 },
-    { task: "rgb(102,102,102)", id: 15 },
-    { task: "rgb(255,102,0)", id: 16 },
-    { task: "rgb(51,51,51)", id: 17 },
-];
-
-const colorList_general = [
-    { task: "rgb(21,21,51)", id: 1 }
-];
-
 export interface SidebarProps {
     app: JupyterFrontEnd;
     factory: XircuitsFactory;
 }
 
-async function fetchComponent(componentList: string[]) {
-    let component_root = componentList.map(x => x["category"]);
-
-    let headers = Array.from(new Set(component_root));
-    let headerList: any[] = [];
-    let headerList2: any[] = [];
-    let displayHeaderList: any[] = [];
+async function fetchComponent(componentList) {
+    let headers = Array.from(new Set(componentList.map(x => x.category)));
+    let parameterComponentList = [];
+    let libraryComponentList = [];
+    let displayHeaderList = [];
 
     for (let headerIndex = 0; headerIndex < headers.length; headerIndex++) {
-        if (headers[headerIndex] == 'ADVANCED' || headers[headerIndex] == 'GENERAL') {
-            headerList.push(headers[headerIndex]);
+        const currentHeader = headers[headerIndex];
+        if (currentHeader === 'ADVANCED' || currentHeader === 'GENERAL') {
+            parameterComponentList.push(currentHeader);
         } else {
-            headerList2.push(headers[headerIndex]);
+            libraryComponentList.push(currentHeader);
         }
     }
 
-    if (headerList.length != 0) {
-        headerList = headerList.sort((a, b) => a < b ? 1 : a > b ? -1 : 0);
-        headers = [...headerList, ...headerList2];
-        for (let headerIndex2 = 0; headerIndex2 < headers.length; headerIndex2++) {
-            displayHeaderList.push({
-                "task": headers[headerIndex2],
-                "id": headerIndex2 + 1
-            });
-        }
+    libraryComponentList.sort();
+
+    if (parameterComponentList.length !== 0) {
+        parameterComponentList.sort((a, b) => a < b ? 1 : a > b ? -1 : 0);
+        headers = [...parameterComponentList, ...libraryComponentList];
+    }
+
+    for (const header of headers) {
+        const componentsUnderHeader = componentList.filter(component => component.category === header);
+        const headerDetails = componentsUnderHeader.map(component => ({
+            category: component.category,
+            file_path: component.file_path,
+            package_name: component.package_name
+        }));
+
+        displayHeaderList.push({
+            task: header,
+            id: displayHeaderList.length + 1,
+            components: headerDetails
+        });
     }
 
     return displayHeaderList;
@@ -124,19 +102,19 @@ export default function Sidebar(props: SidebarProps) {
 
     const fetchComponentList = async () => {
           // get the component list 
-        const response_1 = await ComponentList();
+        const component_list = await ComponentList();
 
         // get the header from the components
-        const response_2 = await fetchComponent(response_1);
+        const component_library_name = await fetchComponent(component_list);
 
         // to ensure the component list is empty before setting the component list
-        if (response_1.length > 0) {
+        if (component_list.length > 0) {
             setComponentList([]);
             setCategory([]);
         }
 
-        setComponentList(response_1);
-        setCategory(response_2);
+        setComponentList(component_list);
+        setCategory(component_library_name);
     }
 
     useEffect(() => {
@@ -165,7 +143,48 @@ export default function Sidebar(props: SidebarProps) {
         return () => clearInterval(intervalId);
     },[componentList, handleRefreshOnClick]);
 
+    // Function to map components
+    const mapComponents = (components, searchTerm) => {
+        return components.filter((componentVal) => {
+            if (searchTerm === "") {
+                return componentVal;
+            } else if (componentVal.task.toLowerCase().includes(searchTerm.toLowerCase())) {
+                return componentVal;
+            }
+        }).map((componentVal, i) => (
+            <div key={`component-${i}`}>
+                <TrayItemWidget
+                    model={{ 
+                        type: componentVal.type, 
+                        name: componentVal.task,
+                        color: componentVal.color,
+                        path: componentVal.file_path,
+                        docstring: componentVal.docstring,
+                        lineNo: componentVal.lineno
+                    }}
+                    name={componentVal.task}
+                    color={componentVal.color}
+                    app={props.app}
+                    path={componentVal.file_path}
+                    lineNo= {componentVal.lineno} />
+            </div>
+        ));
+    }
 
+    // Function to map categories
+    const mapCategories = (categories, components) => {
+        return categories.map((val, i) => (
+            <AccordionItem key={`category-${i}`}>
+                <AccordionItemHeading>
+                    <AccordionItemButton onContextMenu={(e) => handleRightClick(e, val["task"])}>{val["task"]}</AccordionItemButton>
+                </AccordionItemHeading>
+                <AccordionItemPanel>
+                    {mapComponents(components.filter(component => component["category"].toString().toUpperCase() === val["task"].toString()), "")}
+                </AccordionItemPanel>
+            </AccordionItem>
+        ));
+    }
+    
     const [contextMenuState, setContextMenuState] = useState({
         visible: false,
         x: 0,
@@ -199,80 +218,13 @@ export default function Sidebar(props: SidebarProps) {
                             <a onClick={handleRefreshOnClick} className="search-input__button"><i className="fa fa-refresh "></i></a>
                         </div>
 
-                        <Accordion allowZeroExpanded>
-                            {
-                                category.filter((val) => {
-                                    if (searchTerm == "") {
-                                        return val;
-                                    }
-                                }).map((val, i) => {
-                                    return (
-                                        <AccordionItem key={`index-1-${val["task"].toString()}`}>
-                                            <AccordionItemHeading>
-                                                <AccordionItemButton onContextMenu={(e) => handleRightClick(e, val["task"])}>{val["task"]}</AccordionItemButton>
-                                            </AccordionItemHeading>
-                                            <AccordionItemPanel>
-                                                {
-                                                    componentList.filter((componentVal) => {
-                                                        if (searchTerm == "") {
-                                                            return componentVal;
-                                                        }
-                                                    }).map((componentVal, i2) => {
-                                                        if (componentVal["category"].toString().toUpperCase() == val["task"].toString()) {
-                                                            return (
-                                                                <div key={`index-1-${i2}`}>
-                                                                    <TrayItemWidget
-                                                                        model={{
-                                                                            type: componentVal.type,
-                                                                            name: componentVal.task,
-                                                                            color: componentVal.color,
-                                                                            path: componentVal.file_path,
-                                                                            docstring: componentVal.docstring,
-                                                                            lineNo: componentVal.lineno
-                                                                        }}
-                                                                        name={componentVal.task}
-                                                                        color={componentVal.color}
-                                                                        app={props.app}
-                                                                        path={componentVal.file_path}
-                                                                        lineNo= {componentVal.lineno}/>
-                                                                </div>
-                                                            );
-                                                        }
-                                                    })
-                                                }
-                                            </AccordionItemPanel>
-                                        </AccordionItem>
-                                    );
-                                })
-                            }
-
-                        </Accordion>
-                        {
-                            componentList.filter((val) => {
-                                if (searchTerm != "" && val.task.toLowerCase().includes(searchTerm.toLowerCase())) {
-                                    return val
-                                }
-                            }).map((val, i) => {
-                                return (
-                                    <div key={`index-3-${i}`}>
-                                        <TrayItemWidget
-                                            model={{ 
-                                                type: val.type, 
-                                                name: val.task,
-                                                color: val.color,
-                                                path: val.file_path,
-                                                docstring: val.docstring,
-                                                lineNo: val.lineno
-                                            }}
-                                            name={val.task}
-                                            color={val.color}
-                                            app={props.app}
-                                            path={val.file_path}
-                                            lineNo= {val.lineno} />
-                                    </div>
-                                );
-                            })
-                        }
+                        {searchTerm === "" ? (
+                            <Accordion allowZeroExpanded>
+                                {mapCategories(category, componentList)}
+                            </Accordion>
+                        ) : (
+                            mapComponents(componentList, searchTerm)
+                        )}
                     </div>
                 </TrayWidget>
             </Content>

--- a/xai_components/xai_controlflow/library-config.ini
+++ b/xai_components/xai_controlflow/library-config.ini
@@ -1,0 +1,3 @@
+[Paths]
+readme_path = README.md
+default_example_path = ControlflowBranch.xircuits

--- a/xai_components/xai_pytorch/library-config.ini
+++ b/xai_components/xai_pytorch/library-config.ini
@@ -1,0 +1,4 @@
+[Paths]
+readme_path = readme.md
+default_example_path = PytorchTrainModel.xircuits
+requirements_path = requirements.txt

--- a/xai_components/xai_sklearn/library-config.ini
+++ b/xai_components/xai_sklearn/library-config.ini
@@ -1,0 +1,3 @@
+[Paths]
+readme_path = readme.md
+requirements_path = requirements.txt

--- a/xai_components/xai_spark/library-config.ini
+++ b/xai_components/xai_spark/library-config.ini
@@ -1,0 +1,4 @@
+[Paths]
+readme_path = readme.md
+default_example_path = SparkSQLPlotBar.xircuits
+requirements_path = requirements.txt

--- a/xai_components/xai_template/library-config.ini
+++ b/xai_components/xai_template/library-config.ini
@@ -1,0 +1,2 @@
+[Paths]
+readme_path = readme.md

--- a/xai_components/xai_tensorflow_keras/library-config.ini
+++ b/xai_components/xai_tensorflow_keras/library-config.ini
@@ -1,0 +1,4 @@
+[Paths]
+readme_path = readme.md
+default_example_path = KerasModelPredict.xircuits
+requirements_path = requirements.txt

--- a/xai_components/xai_utils/library-config.ini
+++ b/xai_components/xai_utils/library-config.ini
@@ -1,0 +1,4 @@
+[Paths]
+readme_path = readme.md
+default_example_path = UtilsZipDirectory.xircuits
+requirements_path = requirements.txt

--- a/xai_components/xai_xgboost/library-config.ini
+++ b/xai_components/xai_xgboost/library-config.ini
@@ -1,0 +1,4 @@
+[Paths]
+readme_path = readme.md
+default_example_path = XGBoostClassifier.xircuits
+requirements_path = requirements.txt

--- a/xircuits/library/__init__.py
+++ b/xircuits/library/__init__.py
@@ -1,3 +1,2 @@
 from .list_library import list_component_library
-from .install_fetch_library import install_library
-from .install_fetch_library import fetch_library
+from .install_fetch_library import install_library, fetch_library, get_library_config

--- a/xircuits/library/install_fetch_library.py
+++ b/xircuits/library/install_fetch_library.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import configparser
 from pathlib import Path
 from ..utils import is_valid_url, is_empty
 from ..handlers.request_submodule import request_submodule_library
@@ -13,6 +14,16 @@ def build_component_library_path(component_library_query: str) -> str:
         component_library_query = "xai_components/" + component_library_query
 
     return component_library_query
+
+def get_library_config(library_name: str):
+    config_path = Path("xai_components") / f"xai_{library_name.lower()}" / "library-config.ini"
+    config = configparser.ConfigParser()
+    if config_path.exists():
+        config.read(config_path)
+        return config
+    else:
+        print(f"Config file for {library_name} not found at {config_path}.")
+        return None
 
 def get_component_library_path(library_name: str) -> str:
     if is_valid_url(library_name):
@@ -28,12 +39,15 @@ def install_library(library_name: str) -> str:
     if not Path(component_library_path).is_dir() or is_empty(component_library_path):
         request_submodule_library(component_library_path)
 
-    requirements_file = Path(component_library_path) / "requirements.txt"
+    # Get config and determine requirements path
+    config = get_library_config(library_name)
+    requirements_path = Path(config.get('requirements_path') if config and 'requirements_path' in config else Path(component_library_path) / "requirements.txt")
 
-    if requirements_file.exists():
+    # Install requirements if the file exists
+    if requirements_path.exists():
         try:
             print(f"Installing requirements for {library_name}...")
-            subprocess.run([sys.executable, "-m", "pip", "install", "-r", str(requirements_file)], check=True)
+            subprocess.run([sys.executable, "-m", "pip", "install", "-r", str(requirements_path)], check=True)
         except Exception as e:
             raise RuntimeError(f"An error occurred while installing requirements for {library_name}: {e}")
     else:


### PR DESCRIPTION
## Description

This pull request focuses has been on enabling users to set their own component library configurations. Specifically, they can add a `library-config.ini` and specify library-specific paths like `readme_path`, `default_example_path`, and `requirements_path` that will be loaded by the tray context menu. Configs for all the current internal XAI components (`xai_controlflow`, `xai_pytorch`, etc.) have been added in this PR.

This PR also fixes the spawn logic of several canvas context menu options.


## References

https://github.com/XpressAI/xircuits/pull/281

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [x] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

### Test A: Library Configurations

1. Run the right click commands options on the tray context menu. Verify they work. 
2. Change the example paths in one of the library config. Run the context menu again. Verify that the updates are applied correctly.

### Test B: Context Menu Functionality

1. Right click a component node, a literal node, or an argument node.
2. Verify that the appropriate menu options are visible based on the node type.


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

- In the next PR, further component library configurations is planned to be added on the installation scale. 
