### PR TITLE
Ignore hidden files when parsing for components

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "jupyterlab>=4.0.0,<5",
+    "jupyterlab>=4.0.0,<4.1",
     "jupyter_server>=2.0.1,<3",
     "requests",
     "gitpython",

--- a/xircuits/handlers/components.py
+++ b/xircuits/handlers/components.py
@@ -127,12 +127,12 @@ class ComponentsRouteHandler(APIHandler):
                         python_path = None
 
                     try:
-                        components.extend(chain.from_iterable(self.extract_components(f, directory, python_path) for f in python_files))
+                        components.extend(chain.from_iterable(self.extract_components(f, directory, python_path) for f in python_files if not f.name.startswith(".")))
                     except Exception:
                         error_msg = traceback.format_exc()
                         pass
                     finally:
-                        components.extend(chain.from_iterable(self.extract_components(f, directory, python_path) for f in python_files))
+                        components.extend(chain.from_iterable(self.extract_components(f, directory, python_path) for f in python_files if not f.name.startswith(".")))
 
 
         components = list({(c["header"], c["task"]): c for c in components}.values())


### PR DESCRIPTION
# Description

If someone has mac resource files around (usually starting with `._`), the parsing of components crashes. 

As we don't support hidden files as python files anyway, this change introduces a filter to skip any file that starts with `.`.
## References
- None

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests


**1. Reproduction Test**

    1. Create a file called `._foo.py` in a component directory and make it a invalid python file, ideally with some random binary data
    2. Without Change: Notice that component list can't be loaded anymore
    3. With Change: Notice things continue to work


## Tested on?

- [ ] Windows  
- [X] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  