### PR TITLE
Await rendering of Xircuits diagram before saving

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -156,35 +156,29 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       label: (args) => (args['isLauncher'] ? 'Xircuits File' : 'Create New Xircuits'),
       icon: xircuitsIcon,
       caption: 'Create a new xircuits file',
-      execute: () => {
-
-        const currentBrowser = browserFactory.tracker.currentWidget 
-
+      execute: async () => {
+        const currentBrowser = browserFactory.tracker.currentWidget;
         if (!currentBrowser) {
-          console.error('No active file browser found.');
+          console.error("No active file browser found.");
           return;
         }
-
-        app.commands
+        const model = await app.commands
           .execute(commandIDs.newDocManager, {
             path: currentBrowser.model.path,
-            type: 'file',
-            ext: '.xircuits'
-          })
-          .then(async model => {
-            const newWidget = await app.commands.execute(
-              commandIDs.openDocManager,
-              {
-                path: model.path,
-                factory: FACTORY
-              }
-            );
-            newWidget.context.ready.then(() => {
-              app.commands.execute(commandIDs.saveXircuit, {
-                path: model.path
-              });
-            });
+            type: "file",
+            ext: ".xircuits"
           });
+        const newWidget = await app.commands.execute(
+          commandIDs.openDocManager,
+          {
+            path: model.path,
+            factory: FACTORY
+          }
+        );
+        await newWidget.content.renderPromise;
+        await app.commands.execute(commandIDs.saveXircuit, {
+            path: model.path
+        });
       }
     });
 


### PR DESCRIPTION
# Description

After the Jupyter Lab 4 migration, we've noticed that on slower machines sometimes the creation of a new Xircuits file resulted in a 0 byte file instead of creating a minimal xircuits diagram. 

The reason was that the context promise now resolves before the diagram is initially rendered. 
By awaiting the rendering of the diagram we ensure that the model is properly populated before we save it.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [X] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Reproduction**

    1. In developer tools set CPU performance to 6x slowdown
    2. Create a new Xircuits file
    3. Before the fix: In most cases (~80%) it can be observed that the created file has 0 bytes
    4. After the fix: The created file always has more than 0 bytes


## Tested on?

- [X] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  