### PR TITLE
✨ / 🐛 Cache Fetch Component List

### DIFF
--- a/src/context-menu/ComponentsPanel.tsx
+++ b/src/context-menu/ComponentsPanel.tsx
@@ -1,9 +1,5 @@
-import ComponentList from '../tray_library/Component';
-
 import React, { useEffect, useState } from 'react';
-
 import styled from '@emotion/styled';
-
 import { JupyterFrontEnd } from '@jupyterlab/application';
 
 import {
@@ -17,6 +13,7 @@ import {
 import { DefaultLinkModel, DiagramEngine } from '@projectstorm/react-diagrams';
 import { TrayPanel } from './TrayPanel';
 import { TrayItemPanel } from './TrayItemPanel';
+import { ComponentList } from '../tray_library/Component';
 
 export const Body = styled.div`
   display: flex;

--- a/src/tray_library/AdvanceComponentLib.tsx
+++ b/src/tray_library/AdvanceComponentLib.tsx
@@ -1,5 +1,5 @@
 import { CustomNodeModel } from "../components/node/CustomNodeModel";
-import ComponentList from "./Component";
+import { ComponentList } from "./Component";
 
 interface AdvancedComponentLibraryProps {
     model: any;

--- a/src/tray_library/Component.tsx
+++ b/src/tray_library/Component.tsx
@@ -29,17 +29,13 @@ async function fetchComponents() {
   }
 }
 
-async function get_all_components_method() {
+export async function ComponentList() {
+
   if (!componentsCache.data) {
     componentsCache.data = await fetchComponents();
   }
 
   return componentsCache.data;
-}
-
-export async function ComponentList() {
-  let component_list_result = await get_all_components_method();
-  return component_list_result;
 }
 
 export async function refreshComponentListCache() {

--- a/src/tray_library/Component.tsx
+++ b/src/tray_library/Component.tsx
@@ -1,39 +1,47 @@
 import { showDialog, Dialog } from '@jupyterlab/apputils';
-
 import { requestAPI } from "../server/handler";
 import React from 'react';
 
-async function get_all_components_method() {
+let componentsCache = {
+  data: null
+};
 
-    try {
-      // Trigger the load library config on refresh
-      await requestAPI('library/reload_config', { method: 'POST', headers: { 'Content-Type': 'application/json' } });
-  
-      // Proceed with the GET request to fetch components
-      const componentsResponse = await requestAPI<any>('components/');
-      const components = componentsResponse["components"];
-      const error_msg = componentsResponse["error_msg"];
-  
-      if (error_msg) {
-        showDialog({
-          title: 'Parse Component Failed',
-          body: (
-            <pre>{error_msg}</pre>
-          ),
-          buttons: [Dialog.warnButton({ label: 'OK' })]
-        });
-      }
-  
-      return components;
-    } catch (error) {
-      console.error('Failed to get components or trigger library reload', error);
-      // Handle the error appropriately in your application
+async function fetchComponents() {
+  console.log("Fetching all components... this might take a while.")
+  try {
+    const componentsResponse = await requestAPI<any>('components/');
+    const components = componentsResponse["components"];
+    const error_msg = componentsResponse["error_msg"];
+
+    if (error_msg) {
+      showDialog({
+        title: 'Parse Component Failed',
+        body: (
+          <pre>{error_msg}</pre>
+        ),
+        buttons: [Dialog.warnButton({ label: 'OK' })]
+      });
     }
+    console.log("Fetch complete.")
+    return components;
+  } catch (error) {
+    console.error('Failed to get components', error);
   }
-  
+}
 
-export default async function ComponentList() {
-    let component_list_result: string[] = await get_all_components_method();
+async function get_all_components_method() {
+  if (!componentsCache.data) {
+    componentsCache.data = await fetchComponents();
+  }
 
-    return component_list_result;
+  return componentsCache.data;
+}
+
+export async function ComponentList() {
+  let component_list_result = await get_all_components_method();
+  return component_list_result;
+}
+
+export async function refreshComponentListCache() {
+  componentsCache.data = await fetchComponents();
 }

--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -1,9 +1,10 @@
-import ComponentList from './Component';
-import React, { useEffect, useState, useRef } from 'react';
+import { ComponentList, refreshComponentListCache } from './Component';
+import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { TrayItemWidget } from './TrayItemWidget';
 import { TrayWidget } from './TrayWidget';
 import { JupyterFrontEnd } from '@jupyterlab/application';
+import { requestAPI } from '../server/handler';
 
 import {
     Accordion,
@@ -101,7 +102,15 @@ export default function Sidebar(props: SidebarProps) {
     }
 
     const fetchComponentList = async () => {
-          // get the component list 
+
+        try {
+            // Trigger the load library config on refresh
+            await requestAPI('library/reload_config', { method: 'POST', headers: { 'Content-Type': 'application/json' } });
+        } catch (error){
+            console.error('Failed to reload config: ', error);
+        }
+
+        // get the component list 
         const component_list = await ComponentList();
 
         // get the header from the components
@@ -126,6 +135,7 @@ export default function Sidebar(props: SidebarProps) {
     }, [category, componentList]);
 
     function handleRefreshOnClick() {
+        refreshComponentListCache()
         fetchComponentList();
     }
 


### PR DESCRIPTION
# Description

On larger workflow canvas with a very large component library collection, the call to `fetchNodeByName` is a very expensive operation as it performs a server call to refresh and fetch the latest node information. This function is used in reloading nodes, or creating literals from component library nodes.

This PR caches the component list and only triggers it at the beginning or when the component tray refresh button is pressed.


## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Test Component Library Cache**

    1. Open the console on Xircuits launch. Confirm that it logs that Xircuits is fetching the component library, and it completes.
    2. Perform reload node, or create a literal from a component library. Confirm from the network tab that it does not fetch from the server.
    3. Press the refresh button from the tray. Confirm that it performs the fetch.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

