### PR TITLE
🐛 Fix Component Panel Freeze on Spawn

### DIFF
--- a/src/context-menu/ComponentsPanel.tsx
+++ b/src/context-menu/ComponentsPanel.tsx
@@ -121,7 +121,6 @@ export default function ComponentsPanel(props: ComponentsPanelProps) {
     const [componentList, setComponentList] = React.useState([]);
     const [category, setCategory] = React.useState([]);
     const [searchTerm, setSearchTerm] = useState('');
-    const [runOnce, setRunOnce] = useState(false);
     const [allowableComponents, setAllowableComponents] = useState([]);
 
     let handleOnChange = (event) => {
@@ -151,12 +150,8 @@ export default function ComponentsPanel(props: ComponentsPanelProps) {
     }
 
     useEffect(() => {
-        if (!runOnce) {
-            fetchComponentList();
-            setRunOnce(true);
-        }
-
-    }, [category, componentList]);
+        fetchComponentList();
+    }, []);
 
     function focusInput() {
         document.getElementById("add-component-input").focus();


### PR DESCRIPTION
# Description

Due to the cache implemented in https://github.com/XpressAI/xircuits/pull/293, things work much faster to the point where we discovered a bug where spawning the interface would loop freeze jupyterlab. 

## References

https://github.com/XpressAI/xircuits/pull/293

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Open a canvas. Try the chain component interface. It should properly spawn and not freeze the interface.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

