### PR TITLE
🐛 Literal Input Fixes

### DIFF
--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -843,12 +843,8 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 				const dialogOptions = inputDialog({ title:boolTitle, oldValue:"", type:'boolean'});
 				const dialogResult = await showFormDialog(dialogOptions);
 				if (cancelDialog(dialogResult)) return;
-				let boolValue = dialogResult["value"][boolTitle];
-				if (boolValue == false) {
-					nodeType = 'False'
-				} else {
-					nodeType = 'True'
-				}
+				let boolValue = dialogResult["value"][boolTitle].toLowerCase();
+				nodeType = boolValue === 'false' ? 'False' : 'True';
 				break;
 			case 'any':
 				// When inPort is 'any' type, get the correct literal type based on the first character inputed

--- a/src/dialog/FormDialog.tsx
+++ b/src/dialog/FormDialog.tsx
@@ -106,8 +106,9 @@ const preventDefaultDialogHandler = (
         event.stopPropagation();
         event.preventDefault();
       }
-      // When 'Enter' key is pressed while on input field, force focus to default button
-      if (dialog.node.getElementsByTagName('input')[0]){
+      // When 'Enter' key is pressed while on input dialog and the input isn't Literal Chat, force focus to submit button
+      const dialogInput = dialog.node.getElementsByTagName('input')[0];
+      if (dialogInput && dialogInput.name !== 'messages') {
         await defaultButton.focus();
       }
     } else {

--- a/src/helpers/InputSanitizer.tsx
+++ b/src/helpers/InputSanitizer.tsx
@@ -9,38 +9,46 @@ function checkInput(input: any, dataType: string): boolean {
     let processedInput = "";
     let errorDetails = "";
     let exampleInput = "";
+    let inputAsNumber;
 
     const formatError = (detail: string, example: string) => `Invalid ${dataType} input: ${detail} \nExample of a correct ${dataType} format: ${example}`;
-    
+
     switch (normalizedDataType) {
         case "int":
         case "integer":
-            // Regex: Matches possibly negative integers
-            if(!/^\-?\d+$/.test(input)){
-                errorDetails = "Input is not an integer.";
-                exampleInput = "e.g. 3";
-                alert(formatError(errorDetails, exampleInput));
-                return false;
-            }
-            processedInput = `${input}`;
-            break;
+            inputAsNumber = Number(input); // Parse the input as a number which can handle scientific notation
+            
+                // Check if the parsed number is an integer and not NaN
+                if(!Number.isInteger(inputAsNumber)){
+                    errorDetails = `${input} is not an integer.`;
+                    exampleInput = "e.g. 3, -4, or 5e2 (which is 500 in scientific notation)";
+                    alert(formatError(errorDetails, exampleInput));
+                    return false;
+                }
+                processedInput = `${input}`;
+                break;
+            
         case "float":
-            // Regex: Matches possibly negative floats
-            if(!/^\-?\d*\.\d+$/.test(input)){
-                errorDetails = "Input is not a float.";
-                exampleInput = "e.g. 3.14";
+            const floatVal = parseFloat(input);
+            inputAsNumber = Number(input);
+        
+            // Check if the parsed float is a number and if it equals the input when also parsed as a number
+            if(isNaN(floatVal) || floatVal !== inputAsNumber){
+                errorDetails = `${input} is not a float.`;
+                exampleInput = "e.g. 3.14, 3.14e2, or 314e-2";
                 alert(formatError(errorDetails, exampleInput));
                 return false;
             }
             processedInput = `${input}`;
             break;
+
         case "string":
         case "secret":
         case "chat":
             processedInput = JSON.stringify(input);
             break;
         case "list":
-        case "tuple": // validate tuple as list,as JS doesn't have native tuples
+        case "tuple": // Validate tuple as list, as JS doesn't have native tuples
             processedInput = `[${input}]`;
             break;
         case "dict":
@@ -51,7 +59,7 @@ function checkInput(input: any, dataType: string): boolean {
         case "boolean":
             return true;
         case "undefined_any":
-            //handler if called from any inputDialogue
+            // Handler if called from any inputDialogue
             alert(`Type is undefined or not provided. Please insert the first character as shown in example.`);
             return false;
         default:

--- a/ui-tests/e2e/datatype-test.spec.ts
+++ b/ui-tests/e2e/datatype-test.spec.ts
@@ -82,8 +82,8 @@ test('Test editing literal nodes', async ({ page, browserName }) => {
 
   const updateParamsList = [
     { type: "Literal String",   updateValue: "Updated String" },
-    { type: "Literal Integer",  updateValue: "456" },
-    { type: "Literal Float",    updateValue: "4.56" },
+    { type: "Literal Integer",  updateValue: "456e1" },
+    { type: "Literal Float",    updateValue: "456e-1" },
     { type: "Literal Boolean",  updateValue: false },
     { type: "Literal List",     updateValue: '"d", "e", "f"' },
     { type: "Literal Tuple",    updateValue: '"g", "h", "i"' },

--- a/ui-tests/e2e/expected_outputs/01_datatypes.ts
+++ b/ui-tests/e2e/expected_outputs/01_datatypes.ts
@@ -22,9 +22,9 @@ export const datatype_test_2 = `Executing: AllLiteralTypes
 String inPort:
 Updated String
 Integer inPort:
-456
+4560.0
 Float inPort:
-4.56
+45.6
 Boolean inPort:
 False
 List inPort:


### PR DESCRIPTION
# Description

This PR fixes the following bugs:
- fix floats to allow scientific notation
- fix floats to allow non-decimal inputs
- fix boolean dragging from ports to be always true
- fix literal chat being unable to carriage return on enter

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Verify that:

1. You can input scientific notation and non-decimal inputs on floats (also on integers)
2. When you create a literal bool from a port, it will correctly display True or False
3. You can carriage return on a literal chat interface

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
