### PR TITLE
✨ Add Loading Display for Workflow Operations

### DIFF
--- a/src/XircuitsFactory.ts
+++ b/src/XircuitsFactory.ts
@@ -43,10 +43,11 @@ export class XircuitsFactory extends ABCWidgetFactory<DocumentWidget> {
   runXircuitSignal: Signal<this, any>;
   runTypeXircuitSignal: Signal<this, any>;
   lockNodeSignal: Signal<this, any>;
+  triggerLoadingAnimationSignal: Signal<this, any>;
   reloadAllNodesSignal: Signal<this, any>;
   toggleAllLinkAnimationSignal: Signal<this, any>;
 
-
+  
   constructor(options: any) {
     super(options);
     this.app = options.app;
@@ -59,6 +60,7 @@ export class XircuitsFactory extends ABCWidgetFactory<DocumentWidget> {
     this.runXircuitSignal = new Signal<this, any>(this);
     this.runTypeXircuitSignal = new Signal<this, any>(this);
     this.lockNodeSignal = new Signal<this, any>(this);
+    this.triggerLoadingAnimationSignal = new Signal<this, any>(this);
     this.reloadAllNodesSignal = new Signal<this, any>(this);
     this.toggleAllLinkAnimationSignal = new Signal<this, any>(this);
   }
@@ -77,6 +79,7 @@ export class XircuitsFactory extends ABCWidgetFactory<DocumentWidget> {
       runXircuitSignal: this.runXircuitSignal,
       runTypeXircuitSignal: this.runTypeXircuitSignal,
       lockNodeSignal: this.lockNodeSignal,
+      triggerLoadingAnimationSignal: this.triggerLoadingAnimationSignal,
       reloadAllNodesSignal: this.reloadAllNodesSignal,
       toggleAllLinkAnimationSignal: this.toggleAllLinkAnimationSignal,
 

--- a/src/XircuitsWidget.tsx
+++ b/src/XircuitsWidget.tsx
@@ -23,6 +23,7 @@ export class XircuitsPanel extends ReactWidget {
   runXircuitSignal: Signal<this, any>;
   runTypeXircuitSignal: Signal<this, any>;
   lockNodeSignal: Signal<this, any>;
+  triggerLoadingAnimationSignal: Signal<this, any>;
   reloadAllNodesSignal: Signal<this, any>;
   toggleAllLinkAnimationSignal: Signal<this, any>;
 
@@ -42,6 +43,7 @@ export class XircuitsPanel extends ReactWidget {
     this.runXircuitSignal = options.runXircuitSignal;
     this.runTypeXircuitSignal = options.runTypeXircuitSignal;
     this.lockNodeSignal = options.lockNodeSignal;
+    this.triggerLoadingAnimationSignal = options.triggerLoadingAnimationSignal;
     this.reloadAllNodesSignal = options.reloadAllNodesSignal;
     this.toggleAllLinkAnimationSignal = options.toggleAllLinkAnimationSignal;
     this.xircuitsApp = new XircuitsApplication(this.app, this.shell);
@@ -92,6 +94,7 @@ export class XircuitsPanel extends ReactWidget {
         runXircuitSignal={this.runXircuitSignal}
         runTypeXircuitSignal={this.runTypeXircuitSignal}
         lockNodeSignal={this.lockNodeSignal}
+        triggerLoadingAnimationSignal={this.triggerLoadingAnimationSignal}
         reloadAllNodesSignal={this.reloadAllNodesSignal}
         toggleAllLinkAnimationSignal={this.toggleAllLinkAnimationSignal}
       />

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -24,6 +24,7 @@ import { Point } from '@projectstorm/geometry';
 import { handleLiteralInput } from '../tray_library/GeneralComponentLib';
 import { CustomDynaPortModel } from '../components/port/CustomDynaPortModel';
 import { fetchComponents } from '../tray_library/Component';
+import { BaseComponentLibrary } from '../tray_library/BaseComponentLib';
 
 /**
  * Add the commands for node actions.
@@ -222,28 +223,31 @@ export function addNodeActionCommands(
                 if (
                     selected_node.name.startsWith("Literal") || 
                     selected_node.name.startsWith("Argument") ||
-                    selected_node.name.startsWith("Start") ||
-                    selected_node.name.startsWith("Finish")
+                    selected_node.name.startsWith("Start")
                 ) {
                     console.info(selected_node.name + " cannot be reloaded.");
                     continue;
                 }
-
-                let current_node = await fetchNodeByName(selected_node.name)
-
+            
                 let node;
-
-                try {
-                    node = AdvancedComponentLibrary({ model: current_node });
-                  } catch (error) {
-                    let path = selected_node.getOptions()["extras"].path;
-                    console.log(`Error reloading component from path: ${path}. Error: ${error.message}`);
-                    selected_node.getOptions().extras["tip"] = `Component could not be loaded from path: \`${path}\`.\nPlease ensure that the component exists!`;
-                    selected_node.getOptions().extras["borderColor"]="red";
-                    nodesToHighlight.push(selected_node)
-                    continue;
-                  }
-
+            
+                if (selected_node.name.startsWith("Finish")) {
+                    node = BaseComponentLibrary('Finish');
+                } else {
+                    // For other nodes, fetch from AdvancedComponentLibrary
+                    try {
+                        let current_node = await fetchNodeByName(selected_node.name);
+                        node = AdvancedComponentLibrary({ model: current_node });
+                    } catch (error) {
+                        let path = selected_node.getOptions()["extras"].path;
+                        console.log(`Error reloading component from path: ${path}. Error: ${error.message}`);
+                        selected_node.getOptions().extras["tip"] = `Component could not be loaded from path: \`${path}\`.\nPlease ensure that the component exists!`;
+                        selected_node.getOptions().extras["borderColor"]="red";
+                        nodesToHighlight.push(selected_node);
+                        continue;
+                    }
+                }
+            
                 let nodePositionX = selected_node.getX();
                 let nodePositionY = selected_node.getY();
                 

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -23,6 +23,7 @@ import { PointModel } from '@projectstorm/react-diagrams';
 import { Point } from '@projectstorm/geometry';
 import { handleLiteralInput } from '../tray_library/GeneralComponentLib';
 import { CustomDynaPortModel } from '../components/port/CustomDynaPortModel';
+import { fetchComponents } from '../tray_library/Component';
 
 /**
  * Add the commands for node actions.
@@ -204,6 +205,9 @@ export function addNodeActionCommands(
     // Add command to reload selected node
     commands.addCommand(commandIDs.reloadNode, {
         execute: async () => {
+
+            await fetchComponents();
+
             const widget = tracker.currentWidget?.content as XircuitsPanel;
             const engine = widget.xircuitsApp.getDiagramEngine()
             const model = engine.getModel()

--- a/src/components/XircuitsApp.ts
+++ b/src/components/XircuitsApp.ts
@@ -9,6 +9,7 @@ import { ParameterLinkModel, TriangleLinkModel } from './link/CustomLinkModel';
 import { ParameterLinkFactory, TriangleLinkFactory } from './link/CustomLinkFactory';
 import { PointModel } from '@projectstorm/react-diagrams';
 import { Point } from '@projectstorm/geometry';
+import { BaseComponentLibrary } from '../tray_library/BaseComponentLib';
 
 export class XircuitsApplication {
 
@@ -26,17 +27,13 @@ export class XircuitsApplication {
                 this.diagramEngine.getActionEventBus().registerAction(new ZoomCanvasAction({ inverseZoom: true }))
                 this.diagramEngine.getActionEventBus().registerAction(new CustomActionEvent({ app }));
                 this.diagramEngine.getStateMachine().pushState(new CustomDiagramState());
-
-                let startNode = new CustomNodeModel({ name: 'Start', color: 'rgb(255,102,102)', extras: { "type": "Start" } });
-                startNode.addOutPortEnhance({label: '▶', name: 'out-0'});
+                
+                let startNode = BaseComponentLibrary('Start')
                 startNode.setPosition(100, 100);
+                let finishNode = BaseComponentLibrary('Finish')
+                finishNode.setPosition(700, 100);
 
-                let finishedNode = new CustomNodeModel({ name: 'Finish', color: 'rgb(255,102,102)', extras: { "type": "Finish" } });
-                finishedNode.addInPortEnhance({label: '▶', name: 'in-0'});
-                finishedNode.addInPortEnhance({label: 'outputs', name: 'parameter-dynalist-outputs', varName: 'outputs', dataType: 'dynalist'});
-                finishedNode.setPosition(700, 100);
-
-                this.activeModel.addAll(startNode, finishedNode);
+                this.activeModel.addAll(startNode, finishNode);
                 this.diagramEngine.setModel(this.activeModel);
         }
 

--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -126,6 +126,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 	const [floatNodes, setFloatNodes] = useState<string[]>([]);
 	const [boolNodes, setBoolNodes] = useState<string[]>([]);
 	const [componentList, setComponentList] = useState([]);
+	const [isLoading, setIsLoading] = useState(false);
 	const [inDebugMode, setInDebugMode] = useState<boolean>(false);
 	const [currentIndex, setCurrentIndex] = useState<number>(-1);
 	const [runType, setRunType] = useState<string>("run");
@@ -636,16 +637,17 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		});
 	}
 
-	const handleReloadAll = () => {
+	const handleReloadAll = async() => {
 		// This must be first to avoid unnecessary complication
 		if (shell.currentWidget?.id !== widgetId) {
 			return;
 		}
-
-		let allNodes = xircuitsApp.getDiagramEngine().getModel().getNodes()
+		setIsLoading(true);
+		let allNodes = xircuitsApp.getDiagramEngine().getModel().getNodes();
 		allNodes.forEach(node => node.setSelected(true));
-		app.commands.execute(commandIDs.reloadNode);
-		
+		await app.commands.execute(commandIDs.reloadNode);
+		setIsLoading(false);
+		console.log("Reload all complete.")
 	}
 
 	const handleToggleAllLinkAnimation = () => {
@@ -1057,6 +1059,11 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 	return (
 		<Body>
 			<Content>
+				{isLoading && (
+					<div className="loading-indicator">
+					<div className="loading-text">Reloading components...</div>
+					</div>
+				)}
 				<Layer
 					onDrop={handleDropEvent}
 					onDragOver={preventDefault}
@@ -1067,7 +1074,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 					onClick={handleClick}>
 					<XircuitsCanvasWidget>
 						<CanvasWidget engine={xircuitsApp.getDiagramEngine()} />
-						{/**Add Component Panel(ctrl + left-click, dropped link)*/}
+						{/* Add Component Panel(ctrl + left-click, dropped link) */}
 						{isComponentPanelShown && (
 							<div
 								onMouseEnter={()=>setDontHidePanel(true)}
@@ -1075,7 +1082,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 								id='component-panel'
 								style={{
 									top: componentPanelPosition.y,
-									left:componentPanelPosition.x
+									left: componentPanelPosition.x
 								}}
 								className="add-component-panel">
 								<ComponentsPanel
@@ -1085,10 +1092,10 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 									linkData={looseLinkData}
 									isParameter={isParameterLink}
 									key="component-panel"
-								></ComponentsPanel>
+								/>
 							</div>
 						)}
-						{/**Node Action Panel(left-click)*/}
+						{/* Node Action Panel(left-click) */}
 						{contextMenuShown && (
 							<div
 								id='context-menu'
@@ -1101,7 +1108,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 									app={app}
 									engine={xircuitsApp.getDiagramEngine()}
 									nodePosition={nodePosition}
-								></CanvasContextMenu>
+								/>
 							</div>
 						)}
 					</XircuitsCanvasWidget>

--- a/src/context-menu/CanvasContextMenu.tsx
+++ b/src/context-menu/CanvasContextMenu.tsx
@@ -22,6 +22,11 @@ export class CanvasContextMenu extends React.Component<CanvasContextMenuProps> {
         let models = this.props.engine.getModel().getSelectedEntities();
         let visibility = getMenuOptionsVisibility(models);
 
+        const handleReloadNode = async () => {
+            const reloadPromise = this.props.app.commands.execute(commandIDs.reloadNode);
+            await this.props.app.commands.execute(commandIDs.triggerLoadingAnimation, await reloadPromise);
+        };
+
         return (
             <div className="context-menu" onClick={this.hideCanvasContextMenu.bind(this)}>
                 {visibility.showCutCopyPaste && (
@@ -32,7 +37,7 @@ export class CanvasContextMenu extends React.Component<CanvasContextMenuProps> {
                     </>
                 )}
                 {visibility.showReloadNode && (
-                    <div className="context-menu-option" onClick={() => this.props.app.commands.execute(commandIDs.reloadNode)}>Reload Node</div>
+                <div className="context-menu-option" onClick={handleReloadNode}>Reload Node</div>
                 )}
                 {visibility.showEdit && (
                     <div className="context-menu-option" onClick={() => this.props.app.commands.execute(commandIDs.editNode)}>Edit</div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -319,6 +319,14 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       }
     });
 
+    // Add command signal to triggerLoadingAnimation
+    app.commands.addCommand(commandIDs.triggerLoadingAnimation, {
+      execute: args => {
+        console.log("loading animation triggered!");
+        widgetFactory.triggerLoadingAnimationSignal.emit(args);
+      }
+    });
+
     // Add command signal to reloadAllNodes
     app.commands.addCommand(commandIDs.reloadAllNodes, {
       execute: args => {

--- a/src/tray_library/BaseComponentLib.tsx
+++ b/src/tray_library/BaseComponentLib.tsx
@@ -1,0 +1,17 @@
+import { CustomNodeModel } from "../components/node/CustomNodeModel";
+
+export function BaseComponentLibrary(nodeName: string): CustomNodeModel{
+
+    if (nodeName === 'Start') {
+        let node = new CustomNodeModel({ name: 'Start', color: 'rgb(255,102,102)', extras: { "type": "Start" } });
+        node.addOutPortEnhance({label: '▶', name: 'out-0'});
+        return node;
+    }
+
+    if (nodeName === 'Finish') {
+        let node = new CustomNodeModel({ name: 'Finish', color: 'rgb(255,102,102)', extras: { "type": "Finish" } });
+        node.addInPortEnhance({label: '▶', name: 'in-0'});
+        node.addInPortEnhance({label: 'outputs', name: 'parameter-dynalist-outputs', varName: 'outputs', dataType: 'dynalist'});
+        return node;
+    }
+}

--- a/src/tray_library/Component.tsx
+++ b/src/tray_library/Component.tsx
@@ -6,7 +6,7 @@ let componentsCache = {
   data: null
 };
 
-async function fetchComponents() {
+export async function fetchComponents() {
   console.log("Fetching all components... this might take a while.")
   try {
     const componentsResponse = await requestAPI<any>('components/');

--- a/style/base.css
+++ b/style/base.css
@@ -58,26 +58,30 @@ input[type=number]::-webkit-inner-spin-button {
 
 /* Loading Indicator */
 .loading-indicator {
-  background-image: url(../style/icons/xpress-loading-2.gif);
   z-index: 10;
   position: absolute;
-  overflow: hidden;
-  background-size: 8%;
-  background-repeat: no-repeat;
-  background-position: center;
-  width: 100%; 
+  width: 100%;
   height: 100%;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-color: rgba(255, 255, 255, 0.8);
+  background-color: rgba(255, 255, 255, 0.9);
+}
+
+.loading-gif-wrapper {
+  width: 100px;
+  height: 100px;
+  background-image: url(../style/icons/xpress-loading-2.gif);
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 .loading-text {
-  position: absolute;
-  bottom: 20px;
+  margin-top: 20px;
   text-align: center;
-  width: 100%;
   color: #000;
-  font-size: 16px;
+  font-size: 18px;
+  font-weight: bold;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -55,3 +55,29 @@ input[type=number]::-webkit-inner-spin-button {
 .jp-Dialog-content .f1ozlkqi {
   position: relative;
 }
+
+/* Loading Indicator */
+.loading-indicator {
+  background-image: url(../style/icons/xpress-loading-2.gif);
+  z-index: 10;
+  position: absolute;
+  overflow: hidden;
+  background-size: 8%;
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 100%; 
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(255, 255, 255, 0.8);
+}
+
+.loading-text {
+  position: absolute;
+  bottom: 20px;
+  text-align: center;
+  width: 100%;
+  color: #000;
+  font-size: 16px;
+}


### PR DESCRIPTION
# Description

This PR introduces a loading interface for operations that may require extended loading times, such as node reloading and component fetching. The loading interface is designed to be extendable, allowing for easy integration by wrapping any Promise. Additionally, it offers customization options for setting the minimum time for it to trigger the loading animation and its display duration.

Changes include:
- Addition of `triggerLoadingAnimationSignal` to manage loading animations, enhancing user feedback during longer operations.
- Creation of `BaseComponentLibrary.tsx` to standardize the creation of 'Start' and 'Finish' nodes.
- UI enhancements with the introduction of a new loading indicator component, providing clear visual feedback during loading processes.
- Integration of the loading animation trigger into the command system and context menu, allowing for seamless operation within the Xircuits environment.
- Addition of CSS styles for the new loading indicator, ensuring visual alignment with the existing UI design.

This PR also updates the Xircuits canvas to enable the reloading of the `Finish` node with updated dynamic ports, ensuring older Xircuits canvases can be updated.
 
![reload screen preview](https://github.com/XpressAI/xircuits/assets/68586800/cd36a6b8-0f7b-46fa-ab57-314f01e99be0)


## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

The changes were tested to ensure that the new loading animation behaves as expected during node reloading and component fetching operations. Additionally, the creation of 'Start' and 'Finish' nodes using the new base component library was verified for correctness and stability.

**Tests**

    1. Trigger a node reload operation to observe the loading animation. You can set the CPU to be 6x slower + reload all.
    2. Verify that older canvases 'Finish' nodes are correctly updated using the base component library.
    3. Ensure no regression in existing functionalities.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
