### PR TITLE
Await both context.ready and content.renderPromise before saving 

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -175,7 +175,7 @@ const xircuits: JupyterFrontEndPlugin<void> = {
             factory: FACTORY
           }
         );
-        await newWidget.content.renderPromise;
+        await Promise.all([newWidget.context.ready, newWidget.content.renderPromise]);
         await app.commands.execute(commandIDs.saveXircuit, {
             path: model.path
         });


### PR DESCRIPTION
# Description

In https://github.com/XpressAI/xircuits/pull/290 we changed the promise we wait for, thinking that rendering will always happen after the context is ready. It turns out to be wrong when running with a remote setup. 

This change now requires that both of these promises are ready.
## References
- https://github.com/XpressAI/xircuits/pull/290

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
