### PR TITLE
🐛 Initialize Base Canvas For New Xircuits

### DIFF
--- a/src/helpers/CanvasInitializer.tsx
+++ b/src/helpers/CanvasInitializer.tsx
@@ -1,0 +1,31 @@
+import * as SRD from '@projectstorm/react-diagrams';
+import { BaseComponentLibrary } from '../tray_library/BaseComponentLib';
+import { ParameterLinkFactory, TriangleLinkFactory } from '../components/link/CustomLinkFactory';
+import { CustomNodeFactory } from '../components/node/CustomNodeFactory';
+import { JupyterFrontEnd } from '@jupyterlab/application';
+
+export function createInitXircuits(app: JupyterFrontEnd, shell) {
+
+    const diagramEngine = SRD.default({ registerDefaultZoomCanvasAction: false, registerDefaultDeleteItemsAction: false });
+    
+    // Create a new diagram model
+    const activeModel = new SRD.DiagramModel();
+
+    diagramEngine.getLinkFactories().registerFactory(new ParameterLinkFactory());
+    diagramEngine.getLinkFactories().registerFactory(new TriangleLinkFactory());
+    diagramEngine.getNodeFactories().registerFactory(new CustomNodeFactory(app, shell));
+
+    let startNode = BaseComponentLibrary('Start')
+    startNode.setPosition(100, 100);
+    let finishNode = BaseComponentLibrary('Finish')
+    finishNode.setPosition(700, 100);
+
+    activeModel.addAll(startNode, finishNode);
+    diagramEngine.setModel(activeModel);
+
+    let currentModel = diagramEngine.getModel().serialize();
+
+    let jsonString = JSON.stringify(currentModel, null, 4);
+
+    return jsonString;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,6 +26,7 @@ import { addNodeActionCommands } from './commands/NodeActionCommands';
 import { Token } from '@lumino/coreutils';
 import { DockLayout } from '@lumino/widgets';
 import { xircuitsIcon, componentLibIcon, changeFavicon, xircuitsFaviconLink } from './ui-components/icons';
+import { createInitXircuits } from './helpers/CanvasInitializer';
 
 
 const FACTORY = 'Xircuits editor';
@@ -168,17 +169,24 @@ const xircuits: JupyterFrontEndPlugin<void> = {
             type: "file",
             ext: ".xircuits"
           });
-        const newWidget = await app.commands.execute(
+
+          // get init SRD json
+          const fileContent = createInitXircuits(app, app.shell);
+
+          // Use the document manager to write to the file
+          await app.serviceManager.contents.save(model.path, {
+            type: 'file',
+            format: 'text',
+            content: fileContent
+          });
+
+        await app.commands.execute(
           commandIDs.openDocManager,
           {
             path: model.path,
             factory: FACTORY
           }
         );
-        await Promise.all([newWidget.context.ready, newWidget.content.renderPromise]);
-        await app.commands.execute(commandIDs.saveXircuit, {
-            path: model.path
-        });
       }
     });
 


### PR DESCRIPTION
# Description

This PR updates the `create a new xircuits` function to initializes a base xircuits json first, then writes it to the new file, then finally opening it. 

## References

If applicable, note issue numbers this pull request addresses. You can also note any other pull requests that address this issue and how this pull request is different.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Previously for new canvas, after dropping the first node, the second would not appear until you save the canvas. With this PR, it should function properly.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Add if any.
