### PR TITLE
Only set has_next to True if `.next` was actually set

### DIFF
--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -278,8 +278,8 @@ class %s(Component):
         for node in component_nodes:
             has_next = False
             for port in (p for p in node.ports if p.direction == "out" and p.type == "triangle-link"):
-                has_next = True
                 if port.name == "out-0":
+                    has_next = True
                     assignment_target = "%s.next" % named_nodes[port.source.id]
                     assignment_source = named_nodes[port.target.id] if port.target.id in named_nodes else None
                     init_code.append(


### PR DESCRIPTION
# Description

When using components with sub-graphs as ports, it can happen that their `.next` field is not set to None, because the `has_next` flag in the code generator is set prematurely. 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Manual test**

    1. Create a new Xircuits File
    2. Pull in a branch component and a loop component
    3. Connect the loop component to the branch components "when_true" port
    4. Connect the branch component to start and finish
    5. Compile
    6. Observe that the loop component doesn't have a `.next = None` set up in the compiled python code


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
