### PR TITLE
🐛 Fix Reload All Nodes

### DIFF
--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -683,12 +683,14 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		if (shell.currentWidget?.id !== widgetId) {
 		  return;
 		}
-	
+
+		let allNodes = xircuitsApp.getDiagramEngine().getModel().getNodes();
+		allNodes.forEach(node => node.setSelected(true));
+
 		const reloadPromise = app.commands.execute(commandIDs.reloadNode);
 	
 		// Trigger loading animation
 		await triggerLoadingAnimation(reloadPromise, { loadingMessage: 'Reloading all nodes...'});
-	
 		console.log("Reload all complete.");
 	};
 


### PR DESCRIPTION
# Description

The reload all nodes function taps into reloading all nodes that were selected. This line was removed in a previous PR. 

## References

https://github.com/XpressAI/xircuits/pull/296

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Test All Nodes**

1. Open a canvas, ie `ControlflowBranch.xircuits`. Update one component (ie. adding a port to the `Print` component). Reload all nodes.
2. Verify that all the modified nodes are updated.


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

