### PR TITLE
🐛 Allow Empty Values for Certain Data Types

### DIFF
--- a/src/helpers/InputSanitizer.tsx
+++ b/src/helpers/InputSanitizer.tsx
@@ -1,15 +1,17 @@
 function checkInput(input: any, dataType: string): boolean {
 
-    if(input === ""){
-        alert("Input cannot be empty.");
-        return false;
-    }
-
     const normalizedDataType = dataType.toLowerCase();
     let processedInput = "";
     let errorDetails = "";
     let exampleInput = "";
     let inputAsNumber;
+
+    // Allow empty input for specific data types
+    const allowedEmptyTypes = ["string", "secret", "chat", "list", "tuple", "dict"];
+    if(input === "" && !allowedEmptyTypes.includes(normalizedDataType)){
+        alert("Input cannot be empty.");
+        return false;
+    }
 
     const formatError = (detail: string, example: string) => `Invalid ${dataType} input: ${detail} \nExample of a correct ${dataType} format: ${example}`;
 
@@ -49,10 +51,10 @@ function checkInput(input: any, dataType: string): boolean {
             break;
         case "list":
         case "tuple": // Validate tuple as list, as JS doesn't have native tuples
-            processedInput = `[${input}]`;
+            processedInput = input === "" ? "[]" : `[${input}]`;
             break;
         case "dict":
-            processedInput = `{${input}}`;
+            processedInput = input === "" ? "{}" : `{${input}}`;
             break;
         case "true":
         case "false":

--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -167,10 +167,13 @@ class %s(Component):
                     elif port.source.type == "chat":
                         value = json.loads(port.sourceLabel)
                     elif port.source.type == "tuple":
-                        value = eval(port.sourceLabel)
-                        if not isinstance(value, tuple):
-                            # handler for single entry tuple
-                            value = (value,)
+                        if port.sourceLabel == "":
+                            value = ()
+                        else:
+                            value = eval(port.sourceLabel)
+                            if not isinstance(value, tuple):
+                                # Handler for single entry tuple
+                                value = (value,)
                     else:
                         value = eval(port.sourceLabel)
                     tpl.body[0].value.value = value
@@ -208,7 +211,13 @@ class %s(Component):
                         elif port.source.type == "dict":
                             value = json.loads("{" + port.sourceLabel + "}")
                         elif port.source.type == "tuple":
-                            value = tuple(eval(port.sourceLabel))
+                            if port.sourceLabel == "":
+                                value = ()
+                            else:
+                                value = eval(port.sourceLabel)
+                                if not isinstance(value, tuple):
+                                    # Handler for single entry tuple
+                                    value = (value,)
                         else:
                             value = eval(port.sourceLabel)
                         dynaport_values.append(RefOrValue(value, False))


### PR DESCRIPTION
# Description

This PR allows users to set string, secret, chat, list, tuple, dict with empty values.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Test string, secret, chat, list, tuple, dict empty values** - Verify that they work as expected.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  