### PR TITLE
🐛 Fix Duplicate Library Creation on Non-Windows Due to Case Sensitivity

### DIFF
--- a/xircuits/handlers/request_library.py
+++ b/xircuits/handlers/request_library.py
@@ -151,7 +151,7 @@ class CreateNewLibraryHandler(APIHandler):
     @tornado.web.authenticated
     def post(self):
         input_data = self.get_json_body()
-        library_name = input_data.get("libraryName")
+        library_name = input_data.get("libraryName", "").lower()
         component_filename = input_data.get("componentFilename", "new_component.py")
         component_content = input_data.get("componentCode", "")
 

--- a/xircuits/library/generate_component_library_config.py
+++ b/xircuits/library/generate_component_library_config.py
@@ -1,4 +1,5 @@
 import os
+import posixpath
 import json
 import toml
 from configparser import ConfigParser
@@ -14,7 +15,7 @@ def parse_gitmodules(gitmodules_path):
         library_id = path.replace('xai_components/xai_', '').upper()
         if path and url:
             modules.append({
-                'path': os.path.normpath(path),
+                'path': posixpath.normpath(path),
                 'url': url,
                 'library_id': library_id 
             })
@@ -44,11 +45,11 @@ def extract_library_info(lib_path, base_path, status="remote"):
     if is_installed_component(lib_path):
         status = "installed"
 
-    library_id = os.path.basename(lib_path).replace('xai_', '').replace('xai-', '').upper()
+    library_id = posixpath.basename(lib_path).replace('xai_', '').replace('xai-', '').upper()
     lib_info = {
-        "name": os.path.basename(lib_path),
+        "name": posixpath.basename(lib_path),
         "library_id": library_id,
-        "local_path": os.path.join(base_path, os.path.relpath(lib_path, start=base_path)),
+        "local_path": posixpath.join(base_path, posixpath.relpath(lib_path, start=base_path)),
         "status": status
     }
 
@@ -74,7 +75,7 @@ def generate_component_library_config(base_path="xai_components", gitmodules_pat
 
     if not os.path.exists(gitmodules_path):
         # Construct the .xircuits/.gitmodules path
-        gitmodules_path = os.path.join('.xircuits', '.gitmodules')
+        gitmodules_path = posixpath.join('.xircuits', '.gitmodules')
     
     libraries = {}
     library_id_map = {}  # Map library IDs to library info
@@ -83,9 +84,9 @@ def generate_component_library_config(base_path="xai_components", gitmodules_pat
     if os.path.exists(gitmodules_path):
         submodules = parse_gitmodules(gitmodules_path)
         for submodule in submodules:
-            submodule_path = os.path.normpath(submodule['path'])
+            submodule_path = posixpath.normpath(submodule['path'])
             library_info = {
-                "name": os.path.basename(submodule_path),
+                "name": posixpath.basename(submodule_path),
                 "library_id": submodule['library_id'],  # Use the library ID from the submodule info
                 "repository": submodule['url'],
                 "local_path": submodule_path,
@@ -96,7 +97,7 @@ def generate_component_library_config(base_path="xai_components", gitmodules_pat
 
     def explore_directory(directory, base_path):
         for item in os.listdir(directory):
-            full_path = os.path.normpath(os.path.join(directory, item))
+            full_path = posixpath.normpath(posixpath.join(directory, item))
             if os.path.isdir(full_path) and item.startswith("xai_"):
                 lib_info = extract_library_info(full_path, base_path)
                 if lib_info:  # If a valid pyproject.toml is found


### PR DESCRIPTION
# Description

This fix addresses a case sensitivity issue on non-Windows OS like Linux when saving new component libraries in Xircuits. On Windows, file paths are case-insensitive, preventing files or directories with the same name in different cases. However, on Linux, this allowed for the accidental creation of duplicate component libraries with varying capitalizations. By converting library names to lowercase before saving, this update prevents such duplicates, ensuring consistent behavior across all operating systems.

## References

https://github.com/XpressAI/xircuits/pull/309

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Run the new xircuits library interface on a Linux. Enter a component library with mixed caps. Verify that there are no duplicate component libraries created with different caps.

## Tested on?

- [x] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
