### PR TITLE
✨ Add XpressAi Blog Notifications 

### DIFF
--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -20,16 +20,18 @@ def cmd_start_xircuits(args, extra_args=[]):
     if not component_library_path.exists():
         copy_from_installed_wheel('xai_components', '', 'xai_components')
 
+    news_url_option = '--LabApp.news_url="https://xpress.ai/blog/atom.xml"'
+
     # handler for extra jupyterlab launch options
     if extra_args:
         try:
-            launch_cmd = "jupyter lab" + " " + " ".join(extra_args)
+            launch_cmd = "jupyter lab" + " " + " ".join(extra_args) + " " + news_url_option
             os.system(launch_cmd)
         except Exception as e:
             print("Error in launch args! Error log:\n")
             print(e)
     else:
-        os.system("jupyter lab")
+        os.system(f"jupyter lab {news_url_option}")
 
 def cmd_download_examples(args, extra_args=[]):
     if not os.path.exists("examples") or is_empty("examples"):


### PR DESCRIPTION
# Description

This PR hooks the xircuits launch command to display news from the[ xpressai blog](https://xpress.ai/blog) atom feed.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Launch Xircuits. Verify that the blogposts notifications are accessible from the announcements icon.**

![image](https://github.com/XpressAI/xircuits/assets/68586800/43956665-ae7b-4432-9229-b2d953ceb6e7)



## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

