### PR TITLE
✨ Context Menu Option to Copy Xircuits Workflows to Root

### DIFF
--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -73,6 +73,7 @@ export const commandIDs = {
 	saveDocManager: 'docmanager:save',
 	reloadDocManager: 'docmanager:reload',
 	createNewXircuit: 'Xircuit-editor:create-new',
+	copyXircuitsToRoot: 'Xircuit-editor:copy-to-root',
 	saveXircuit: 'Xircuit-editor:save-node',
 	compileXircuit: 'Xircuit-editor:compile-node',
 	runXircuit: 'Xircuit-editor:run-node',

--- a/src/context-menu/TrayContextMenu.tsx
+++ b/src/context-menu/TrayContextMenu.tsx
@@ -127,6 +127,8 @@ const TrayContextMenu = ({ app, x, y, visible, libraryName, status, refreshTrigg
             const examplePath = await buildLocalFilePath(libraryName, 'default_example_path');
             if (examplePath) {
                 await app.commands.execute('docmanager:open', { path: examplePath });
+                await app.commands.execute('filebrowser:activate', { path: examplePath });
+                await app.commands.execute('filebrowser:go-to-path', { path: examplePath });
             }
         } catch (error) {
             alert('Failed to Show Example: ' + error);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -365,8 +365,9 @@ const xircuits: JupyterFrontEndPlugin<void> = {
     
           try {
             await app.serviceManager.contents.copy(path, rootPath);
-            await app.commands.execute('filebrowser:go-to-path', { path: '/' });
             await app.commands.execute(commandIDs.openDocManager, { path: rootPath, factory: FACTORY });
+            await app.commands.execute('filebrowser:activate', { path: rootPath });
+            await app.commands.execute('filebrowser:go-to-path', { path: rootPath });
           } catch (err) {
             if (err.response && err.response.status === 400) {
               alert(`Error: The file '${fileName}' already exists in the root directory.`);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import {
   JupyterFrontEndPlugin,
   ILayoutRestorer
 } from '@jupyterlab/application';
+import { PathExt } from '@jupyterlab/coreutils';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { commandIDs } from './components/XircuitsBodyWidget';
 import {
@@ -351,6 +352,20 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       execute: args => {
         widgetFactory.toggleAllLinkAnimationSignal.emit(args);
       }
+    });
+
+    app.commands.addCommand(commandIDs.copyXircuitsToRoot, {
+      execute: args => {
+        const xircuitsFile = browserFactory.tracker.currentWidget?.selectedItems().next().value;
+        const path = xircuitsFile.path;
+        console.log(path);
+      },
+      label: 'Copy To Root Directory'
+    });
+
+    app.contextMenu.addItem({
+      command: commandIDs.copyXircuitsToRoot,
+      selector: '.jp-DirListing-item[data-file-type="xircuits"]',
     });
 
     // Add a launcher item if the launcher is available.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -356,17 +356,25 @@ const xircuits: JupyterFrontEndPlugin<void> = {
 
     app.commands.addCommand(commandIDs.copyXircuitsToRoot, {
       execute: async () => {
-        const xircuitsFile = browserFactory.tracker.currentWidget?.selectedItems().next().value;
-        const path = xircuitsFile.path;
-        const fileName = path.split('/').pop();
-        const rootPath = `/${fileName}`;
-
-        app.serviceManager.contents.copy(path, rootPath);
-        await app.commands.execute('filebrowser:activate', { path: rootPath });
-        await app.commands.execute('filebrowser:go-to-path', { path: '/' });
-        await app.commands.execute(commandIDs.openDocManager, { path: rootPath, factory: FACTORY });
+        const selectedItems = [...browserFactory.tracker.currentWidget.selectedItems()];
+        
+        for (const xircuitsFile of selectedItems) {
+          const path = xircuitsFile.path;
+          const fileName = path.split('/').pop();
+          const rootPath = `/${fileName}`;
+    
+          try {
+            await app.serviceManager.contents.copy(path, rootPath);
+            await app.commands.execute('filebrowser:go-to-path', { path: '/' });
+            await app.commands.execute(commandIDs.openDocManager, { path: rootPath, factory: FACTORY });
+          } catch (err) {
+            console.error(`Error copying file '${fileName}': ${err}`);
+          }
+        }
       },
-      label: 'Copy To Root Directory'
+      label: 'Copy To Root Directory',
+      isVisible: () => [...browserFactory.tracker.currentWidget.selectedItems()].length > 0,
+      icon: xircuitsIcon
     });
 
     app.contextMenu.addItem({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -355,10 +355,16 @@ const xircuits: JupyterFrontEndPlugin<void> = {
     });
 
     app.commands.addCommand(commandIDs.copyXircuitsToRoot, {
-      execute: args => {
+      execute: async () => {
         const xircuitsFile = browserFactory.tracker.currentWidget?.selectedItems().next().value;
         const path = xircuitsFile.path;
-        console.log(path);
+        const fileName = path.split('/').pop();
+        const rootPath = `/${fileName}`;
+
+        app.serviceManager.contents.copy(path, rootPath);
+        await app.commands.execute('filebrowser:activate', { path: rootPath });
+        await app.commands.execute('filebrowser:go-to-path', { path: '/' });
+        await app.commands.execute(commandIDs.openDocManager, { path: rootPath, factory: FACTORY });
       },
       label: 'Copy To Root Directory'
     });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -368,7 +368,11 @@ const xircuits: JupyterFrontEndPlugin<void> = {
             await app.commands.execute('filebrowser:go-to-path', { path: '/' });
             await app.commands.execute(commandIDs.openDocManager, { path: rootPath, factory: FACTORY });
           } catch (err) {
-            console.error(`Error copying file '${fileName}': ${err}`);
+            if (err.response && err.response.status === 400) {
+              alert(`Error: The file '${fileName}' already exists in the root directory.`);
+            } else {
+              alert(`Error copying file '${fileName}': ${err}`);
+            }
           }
         }
       },


### PR DESCRIPTION
# Description

This PR enables users to copy xircuits files to the root working dir and opens it.

![open in root](https://github.com/XpressAI/xircuits/assets/68586800/569aab24-307d-406f-9a22-fd1719522bc8)

You can select multiple workflows at the same time.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Right click a non .xircuits file in the file browser. Verify that the `Copy to Root Directory` option does not spawn.
2. Right click a .xircuits file in the file browser. Verify that the `Copy to Root Directory` option does spawns, and it copies it to root and opens the workflow.
3. Try it on a workflow with the same filename in root. Verify that the alert message spawns.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
