### PR TITLE
🐛 Fix Components Not Refreshing on Reload from Canvas

### DIFF
--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -685,9 +685,9 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		  return;
 		}
 
+		await app.commands.execute(commandIDs.refreshComponentList);
 		let allNodes = xircuitsApp.getDiagramEngine().getModel().getNodes();
 		allNodes.forEach(node => node.setSelected(true));
-
 		const reloadPromise = app.commands.execute(commandIDs.reloadNode);
 	
 		// Trigger loading animation

--- a/src/context-menu/CanvasContextMenu.tsx
+++ b/src/context-menu/CanvasContextMenu.tsx
@@ -23,6 +23,7 @@ export class CanvasContextMenu extends React.Component<CanvasContextMenuProps> {
         let visibility = getMenuOptionsVisibility(models);
 
         const handleReloadNode = async () => {
+            await this.props.app.commands.execute(commandIDs.refreshComponentList);
             let loadPromise = await this.props.app.commands.execute(commandIDs.reloadNode);
             await this.props.app.commands.execute(commandIDs.triggerLoadingAnimation, { loadPromise,
                 loadingMessage: 'Reloading node...', loadingDisplayDuration: 10000, showLoadingAfter: 10 


### PR DESCRIPTION
# Description

https://github.com/XpressAI/xircuits/pull/293 implemented refactoring of the code fetching for components and the reload mechanism by implementing a cache for the component library code. However, this cache is currently only updated when the component tray button is pressed. This PR ensure that the cache is also refreshed when the "Reload Node" option is used from the right-click context menu or the "Reload All Nodes" option is selected from the toolbar.

## References

https://github.com/XpressAI/xircuits/pull/293

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Drag in a component. Update a port. Trigger reload by `Reload Node` and `Reload All Nodes`. Verify that it correctly updates.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Add if any.
