### PR TITLE
Click Link to Select, CTRL+Click to add a Point

### DIFF
--- a/src/components/XircuitsApp.ts
+++ b/src/components/XircuitsApp.ts
@@ -1,7 +1,6 @@
 import * as SRD from '@projectstorm/react-diagrams';
 import { CustomNodeFactory } from "./node/CustomNodeFactory";
 import { CustomNodeModel } from './node/CustomNodeModel';
-import { PanAndZoomCanvasAction } from '@projectstorm/react-canvas-core';
 import { CustomActionEvent } from '../commands/CustomActionEvent';
 import { ILabShell, JupyterFrontEnd } from '@jupyterlab/application';
 import { CustomDiagramState } from './state/CustomDiagramState'
@@ -10,6 +9,7 @@ import { ParameterLinkFactory, TriangleLinkFactory } from './link/CustomLinkFact
 import { PointModel } from '@projectstorm/react-diagrams';
 import { Point } from '@projectstorm/geometry';
 import { BaseComponentLibrary } from '../tray_library/BaseComponentLib';
+import { CustomPanAndZoomCanvasAction } from "./actions/CustomPanAndZoomCanvasAction";
 
 export class XircuitsApplication {
 
@@ -24,7 +24,7 @@ export class XircuitsApplication {
                 this.diagramEngine.getNodeFactories().registerFactory(new CustomNodeFactory(app, shell));
                 this.diagramEngine.getLinkFactories().registerFactory(new ParameterLinkFactory());
                 this.diagramEngine.getLinkFactories().registerFactory(new TriangleLinkFactory());
-                this.diagramEngine.getActionEventBus().registerAction(new PanAndZoomCanvasAction())
+                this.diagramEngine.getActionEventBus().registerAction(new CustomPanAndZoomCanvasAction())
                 this.diagramEngine.getActionEventBus().registerAction(new CustomActionEvent({ app }));
                 this.diagramEngine.getStateMachine().pushState(new CustomDiagramState());
                 

--- a/src/components/XircuitsApp.ts
+++ b/src/components/XircuitsApp.ts
@@ -1,7 +1,7 @@
 import * as SRD from '@projectstorm/react-diagrams';
 import { CustomNodeFactory } from "./node/CustomNodeFactory";
 import { CustomNodeModel } from './node/CustomNodeModel';
-import { ZoomCanvasAction } from '@projectstorm/react-canvas-core';
+import { PanAndZoomCanvasAction } from '@projectstorm/react-canvas-core';
 import { CustomActionEvent } from '../commands/CustomActionEvent';
 import { ILabShell, JupyterFrontEnd } from '@jupyterlab/application';
 import { CustomDiagramState } from './state/CustomDiagramState'
@@ -24,7 +24,7 @@ export class XircuitsApplication {
                 this.diagramEngine.getNodeFactories().registerFactory(new CustomNodeFactory(app, shell));
                 this.diagramEngine.getLinkFactories().registerFactory(new ParameterLinkFactory());
                 this.diagramEngine.getLinkFactories().registerFactory(new TriangleLinkFactory());
-                this.diagramEngine.getActionEventBus().registerAction(new ZoomCanvasAction({ inverseZoom: true }))
+                this.diagramEngine.getActionEventBus().registerAction(new PanAndZoomCanvasAction())
                 this.diagramEngine.getActionEventBus().registerAction(new CustomActionEvent({ app }));
                 this.diagramEngine.getStateMachine().pushState(new CustomDiagramState());
                 

--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -1098,6 +1098,14 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		hidePanel();
 	};
 
+	useEffect(() => {
+		const canvas = xircuitsApp.getDiagramEngine().getCanvas()
+		canvas.addEventListener('wheel', preventDefault);
+		return () => {
+			canvas.removeEventListener('wheel', preventDefault);
+		}
+	}, [xircuitsApp.getDiagramEngine().getCanvas()])
+
 	return (
 		<Body>
 			<Content>

--- a/src/components/actions/CustomPanAndZoomCanvasAction.ts
+++ b/src/components/actions/CustomPanAndZoomCanvasAction.ts
@@ -1,0 +1,74 @@
+import { WheelEvent } from 'react';
+import { Action, ActionEvent, InputType } from '@projectstorm/react-canvas-core';
+
+export interface CustomPanAndZoomCanvasActionOptions {
+	inverseZoom?: boolean;
+}
+
+export class CustomPanAndZoomCanvasAction extends Action {
+	constructor(options: CustomPanAndZoomCanvasActionOptions = {}) {
+		super({
+			type: InputType.MOUSE_WHEEL,
+			fire: (actionEvent: ActionEvent<WheelEvent>) => {
+				const { event } = actionEvent;
+				// we can block layer rendering because we are only targeting the transforms
+				for (let layer of this.engine.getModel().getLayers()) {
+					layer.allowRepaint(false);
+				}
+
+				const model = this.engine.getModel();
+				event.stopPropagation();
+				if (event.ctrlKey) {
+					// Pinch and zoom gesture
+					const oldZoomFactor = this.engine.getModel().getZoomLevel() / 100;
+
+					let scrollDelta = options.inverseZoom ? event.deltaY : -event.deltaY;
+					//check if it is pinch gesture
+          if (event.ctrlKey && scrollDelta % 1 !== 0) {
+            /*
+              Chrome and Firefox sends wheel event with deltaY that
+              have fractional part, also `ctrlKey` prop of the event is true
+              though ctrl isn't pressed
+            */
+            scrollDelta /= 3;
+          } else {
+            scrollDelta /= 60;
+          }
+
+					if (model.getZoomLevel() + scrollDelta > 10) {
+						model.setZoomLevel(model.getZoomLevel() + scrollDelta);
+					}
+
+					const zoomFactor = model.getZoomLevel() / 100;
+
+					const boundingRect = event.currentTarget.getBoundingClientRect();
+					const clientWidth = boundingRect.width;
+					const clientHeight = boundingRect.height;
+					// compute difference between rect before and after scroll
+					const widthDiff = clientWidth * zoomFactor - clientWidth * oldZoomFactor;
+					const heightDiff = clientHeight * zoomFactor - clientHeight * oldZoomFactor;
+					// compute mouse coords relative to canvas
+					const clientX = event.clientX - boundingRect.left;
+					const clientY = event.clientY - boundingRect.top;
+
+					// compute width and height increment factor
+					const xFactor = (clientX - model.getOffsetX()) / oldZoomFactor / clientWidth;
+					const yFactor = (clientY - model.getOffsetY()) / oldZoomFactor / clientHeight;
+
+					model.setOffset(model.getOffsetX() - widthDiff * xFactor, model.getOffsetY() - heightDiff * yFactor);
+				} else {
+					// Pan gesture
+					let yDelta = options.inverseZoom ? -event.deltaY : event.deltaY;
+					let xDelta = options.inverseZoom ? -event.deltaX : event.deltaX;
+					model.setOffset(model.getOffsetX() - xDelta, model.getOffsetY() - yDelta);
+				}
+				this.engine.repaintCanvas();
+
+				// re-enable rendering
+				for (let layer of this.engine.getModel().getLayers()) {
+					layer.allowRepaint(true);
+				}
+			}
+		});
+	}
+}

--- a/src/components/link/CustomLinkFactory.tsx
+++ b/src/components/link/CustomLinkFactory.tsx
@@ -50,7 +50,6 @@ function removeHover(model: TriangleLinkModel | ParameterLinkModel){
 class SelectOnClickLinkWidget extends DefaultLinkWidget {
 	constructor(type) {
 		super(type);
-		console.log(type)
 	}
 	addPointToLink(event: React.MouseEvent, index: number) {
 		if (


### PR DESCRIPTION
# Description

The old click to add point functionality grew quite annoying very quickly. In particular if we want to modify the graph to add some component, using shift+click to select a link ended up also selecting the node, because that particular behavior is meant for selecting multiple things.

By moving the add-point-to-link functionality to ctrl+click, we free up the regular click to be just a select, exactly how one expects it to be.

This also enables figma-like pinch-to-zoom and two-finger panning.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Manual Test**

    1. Create a link between two nodes (Start to finish is fine)
    2. Click the link to select it
    3. Before: Link node gets created; After: Link is selected
    4. CTRL+Click the link
    5. Before: Add component menu opens; After: Link node gets created


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
