### PR TITLE
🐛 Fix compiled script run breaking on unknown arguments

### DIFF
--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -386,8 +386,9 @@ pprint.pprint(flow.%s.value)
     def _generate_trailer(self):
         code = """
 if __name__ == '__main__':
-    main(parser.parse_args())
-    print("\\nFinished Executing")        
+    args, _ = parser.parse_known_args()
+    main(args)
+    print("\\nFinished Executing")
         """
         body = ast.parse(code).body[0]
         arg_parsing = self._generate_argument_parsing()


### PR DESCRIPTION
# Description

This pull request updates the main execution flow in the compiler to handle unrecognized command-line arguments. Previously, the script would fail when passing unknown arguments that were not explicitly handled. The change splits argument parsing to parse known arguments and ignore the rest, preventing execution failure when extra parameters are passed.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [x] Others: compiler 

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. pass extra arguments to the compiled script, like --extra-files example.py
2. Confirm that the script executes without errors and ignores unrecognized arguments.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
