### PR TITLE
✨ Migrate from pkg_resources to importlib_resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pygithub",
     "tqdm",
     "toml",
+    "importlib_resources"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/xircuits/utils.py
+++ b/xircuits/utils.py
@@ -1,8 +1,8 @@
 import os
 import urllib
 import urllib.parse
-import pkg_resources
 import shutil
+from importlib import resources
 
 def is_empty(directory):
     # will return true for uninitialized submodules
@@ -19,5 +19,5 @@ def copy_from_installed_wheel(package_name, resource="", dest_path=None):
     if dest_path is None:
         dest_path = package_name
 
-    resource_path = pkg_resources.resource_filename(package_name, resource)
-    shutil.copytree(resource_path, dest_path)
+    with resources.path(package_name, resource) as resource_path:
+        shutil.copytree(resource_path, dest_path)

--- a/xircuits/utils.py
+++ b/xircuits/utils.py
@@ -1,8 +1,7 @@
 import os
-import urllib
 import urllib.parse
 import shutil
-from importlib import resources
+import importlib_resources
 
 def is_empty(directory):
     # will return true for uninitialized submodules
@@ -14,10 +13,14 @@ def is_valid_url(url):
         return all([result.scheme, result.netloc])
     except ValueError:
         return False
-    
+
 def copy_from_installed_wheel(package_name, resource="", dest_path=None):
     if dest_path is None:
         dest_path = package_name
 
-    with resources.path(package_name, resource) as resource_path:
+    # Get the resource reference
+    ref = importlib_resources.files(package_name) / resource
+
+    # Create the temporary file context
+    with importlib_resources.as_file(ref) as resource_path:
         shutil.copytree(resource_path, dest_path)


### PR DESCRIPTION
# Description

`pkg_resources` which is used to copy `.xircuits` and `xai_components` to the current working dir is deprecated. This PR updates it to use importlib_resources.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [x] Others: Xircuits CLI

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests
Install xircuits via wheel / pip. Verify that `.xircuits` and `xai_components` are correctly saved in the current working dir.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

## Notes

Currently using `importlib_resources` over `importlib.resources` for py3.8 compatibility. 
