### PR TITLE
✨ Add Open Xircuits Workflow Component Context Menu Option

### DIFF
--- a/src/commands/CommandIDs.tsx
+++ b/src/commands/CommandIDs.tsx
@@ -10,7 +10,7 @@ export const commandIDs = {
   runXircuit: "Xircuit-editor:run-node",
   lockXircuit: "Xircuit-editor:lock-node",
   openScript: "Xircuit-editor:open-node-script",
-  openSubXircuits: "Xircuit-editor:open-subxircuits",
+  openXircuitsWorkflow: "Xircuit-editor:open-xircuits-workflow",
   undo: "Xircuit-editor:undo",
   redo: "Xircuit-editor:redo",
   cutNode: "Xircuit-editor:cut-node",

--- a/src/commands/CommandIDs.tsx
+++ b/src/commands/CommandIDs.tsx
@@ -10,6 +10,7 @@ export const commandIDs = {
   runXircuit: "Xircuit-editor:run-node",
   lockXircuit: "Xircuit-editor:lock-node",
   openScript: "Xircuit-editor:open-node-script",
+  openSubXircuits: "Xircuit-editor:open-subxircuits",
   undo: "Xircuit-editor:undo",
   redo: "Xircuit-editor:redo",
   cutNode: "Xircuit-editor:cut-node",

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -94,8 +94,24 @@ export function addNodeActionCommands(
     //Add command to open sub xircuits
     commands.addCommand(commandIDs.openSubXircuits, {
         execute: async (args) => {
-            let node, nodePath, nodeName, nodeLineNo;
-            console.log("called!")
+            let node, nodePath;
+
+            // call getLastSelectedNode() if opened from Xircuits canvas
+            if (args['nodePath'] === undefined && args['nodeName'] === undefined && args['nodeLineNo'] === undefined) {
+                node = getLastSelectedNode();
+            }
+    
+            // Assign values based on whether args were provided or derived from getLastSelectedNode()
+            nodePath = args['nodePath'] ?? node?.extras.path;
+            let subXircuitsPath = nodePath.replace(/\.py$/, '.xircuits');
+
+            try {
+                await app.commands.execute('docmanager:open', { path: subXircuitsPath });
+                await app.commands.execute('filebrowser:activate', { path: subXircuitsPath });
+                await app.commands.execute('filebrowser:go-to-path', { path: subXircuitsPath });
+            } catch (error) {
+                alert('Failed to Open SubXircuits: ' + error);
+            }
         }
     });
 

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -92,7 +92,7 @@ export function addNodeActionCommands(
     });
 
     //Add command to open sub xircuits
-    commands.addCommand(commandIDs.openSubXircuits, {
+    commands.addCommand(commandIDs.openXircuitsWorkflow, {
         execute: async (args) => {
             let node, nodePath;
 
@@ -103,14 +103,12 @@ export function addNodeActionCommands(
     
             // Assign values based on whether args were provided or derived from getLastSelectedNode()
             nodePath = args['nodePath'] ?? node?.extras.path;
-            let subXircuitsPath = nodePath.replace(/\.py$/, '.xircuits');
+            let xircuitsPath = nodePath.replace(/\.py$/, '.xircuits');
 
             try {
-                await app.commands.execute('docmanager:open', { path: subXircuitsPath });
-                await app.commands.execute('filebrowser:activate', { path: subXircuitsPath });
-                await app.commands.execute('filebrowser:go-to-path', { path: subXircuitsPath });
+                await app.commands.execute('docmanager:open', { path: xircuitsPath });
             } catch (error) {
-                alert('Failed to Open SubXircuits: ' + error);
+                alert('Failed to Open Xircuits Workflow: ' + error);
             }
         }
     });

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -91,6 +91,14 @@ export function addNodeActionCommands(
         }
     });
 
+    //Add command to open sub xircuits
+    commands.addCommand(commandIDs.openSubXircuits, {
+        execute: async (args) => {
+            let node, nodePath, nodeName, nodeLineNo;
+            console.log("called!")
+        }
+    });
+
     //Add command to undo
     commands.addCommand(commandIDs.undo, {
         execute: () => {

--- a/src/context-menu/CanvasContextMenu.tsx
+++ b/src/context-menu/CanvasContextMenu.tsx
@@ -48,8 +48,8 @@ export class CanvasContextMenu extends React.Component<CanvasContextMenuProps> {
                 {visibility.showOpenScript && (
                     <div className="context-menu-option" onClick={() => this.props.app.commands.execute(commandIDs.openScript)}>Open Script</div>
                 )}
-                {visibility.showOpenSubXircuits && (
-                    <div className="context-menu-option" onClick={() => this.props.app.commands.execute(commandIDs.openSubXircuits)}>Open SubXircuits</div>
+                {visibility.showopenXircuitsWorkflow && (
+                    <div className="context-menu-option" onClick={() => this.props.app.commands.execute(commandIDs.openXircuitsWorkflow)}>Open Workflow</div>
                 )}
                 {visibility.showDelete && (
                     <div className="context-menu-option" onClick={() => this.props.app.commands.execute(commandIDs.deleteEntity)}>Delete</div>
@@ -82,8 +82,8 @@ export function getMenuOptionsVisibility(models) {
         return !isLiteralNode(node) && !isArgumentNode(node);
     }
 
-    function isSubXircuits(node) {
-        return node.getOptions()?.extras?.type == 'subxircuits' ?? false;
+    function isXircuitsWorkflow(node) {
+        return node.getOptions()?.extras?.type == 'xircuits_workflow' ?? false;
     }
 
     let isNodeSelected = models.some(model => model instanceof NodeModel);
@@ -93,14 +93,14 @@ export function getMenuOptionsVisibility(models) {
     let isSingleLiteralNodeSelected = literalNodes.length === 1;
     let isSingleComponentNodeSelected = componentNodes.length === 1;
     let showReloadNode = isNodeSelected && componentNodes.length > 0;
-    let showOpenSubXircuits = isSingleComponentNodeSelected && models.some(model => isSubXircuits(model))
+    let showopenXircuitsWorkflow = isSingleComponentNodeSelected && models.some(model => isXircuitsWorkflow(model))
 
     return {
         showCutCopyPaste: !models.length || isNodeSelected || isLinkSelected,
         showReloadNode: showReloadNode,
         showEdit: isSingleLiteralNodeSelected,
         showOpenScript: isSingleComponentNodeSelected,
-        showOpenSubXircuits: showOpenSubXircuits,
+        showopenXircuitsWorkflow: showopenXircuitsWorkflow,
         showDelete: isNodeSelected || isLinkSelected || literalNodes.length > 0,
         showUndoRedo: !models.length,
         showAddComment: !models.length

--- a/src/context-menu/CanvasContextMenu.tsx
+++ b/src/context-menu/CanvasContextMenu.tsx
@@ -48,6 +48,9 @@ export class CanvasContextMenu extends React.Component<CanvasContextMenuProps> {
                 {visibility.showOpenScript && (
                     <div className="context-menu-option" onClick={() => this.props.app.commands.execute(commandIDs.openScript)}>Open Script</div>
                 )}
+                {visibility.showOpenSubXircuits && (
+                    <div className="context-menu-option" onClick={() => this.props.app.commands.execute(commandIDs.openSubXircuits)}>Open SubXircuits</div>
+                )}
                 {visibility.showDelete && (
                     <div className="context-menu-option" onClick={() => this.props.app.commands.execute(commandIDs.deleteEntity)}>Delete</div>
                 )}
@@ -79,6 +82,10 @@ export function getMenuOptionsVisibility(models) {
         return !isLiteralNode(node) && !isArgumentNode(node);
     }
 
+    function isSubXircuits(node) {
+        return node.getOptions()?.extras?.type == 'subxircuits' ?? false;
+    }
+
     let isNodeSelected = models.some(model => model instanceof NodeModel);
     let isLinkSelected = models.some(model => model instanceof LinkModel);
     let literalNodes = models.filter(model => isLiteralNode(model));
@@ -86,12 +93,14 @@ export function getMenuOptionsVisibility(models) {
     let isSingleLiteralNodeSelected = literalNodes.length === 1;
     let isSingleComponentNodeSelected = componentNodes.length === 1;
     let showReloadNode = isNodeSelected && componentNodes.length > 0;
+    let showOpenSubXircuits = isSingleComponentNodeSelected && models.some(model => isSubXircuits(model))
 
     return {
         showCutCopyPaste: !models.length || isNodeSelected || isLinkSelected,
         showReloadNode: showReloadNode,
         showEdit: isSingleLiteralNodeSelected,
         showOpenScript: isSingleComponentNodeSelected,
+        showOpenSubXircuits: showOpenSubXircuits,
         showDelete: isNodeSelected || isLinkSelected || literalNodes.length > 0,
         showUndoRedo: !models.length,
         showAddComment: !models.length

--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -88,7 +88,7 @@ from xai_components.base import SubGraphExecutor, InArg, OutArg, Component, xai_
 
     def _generate_flows(self, flow_name):
         mainFlowCls = ast.parse("""
-@xai_component        
+@xai_component(type="subxircuits")
 class %s(Component):
     def __init__(self):
         super().__init__()

--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -88,7 +88,7 @@ from xai_components.base import SubGraphExecutor, InArg, OutArg, Component, xai_
 
     def _generate_flows(self, flow_name):
         mainFlowCls = ast.parse("""
-@xai_component(type="subxircuits")
+@xai_component(type="xircuits_workflow")
 class %s(Component):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
# Description

This PR adds the option to open a workflow component from the workflow canvas.

![open-subxircuits](https://github.com/XpressAI/xircuits/assets/68586800/ef865e09-5da0-446d-9931-563f5dfdacf0)

## References

https://github.com/XpressAI/xircuits/pull/289

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Tests

**Test Open SubXircuits**

Create a SubXircuits. 
- create the new xircuits workflow in one of a component library dir
- save and compile
- the workflow should be available as a component 
- start a new xircuits, and drag that component in

Verify that : 
1. the option to open subxircuits only spawns on the subxircuits component
2. the subxircuits canvas is opened
3. things work as expected (can compile and run properly).


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

## Notes

Since at core it's simply calling a workflow in another workflow, `SubXircuits` terminology is simplified to xircuits_workflow and workflow components.