### PR TITLE
Enforce that args are only picked up once for subxircuits

### DIFF
--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -108,6 +108,8 @@ class %s(Component):
         exec_code = []
         args_code = []
 
+        existing_args = set()
+
         # Instantiate all components
         init_code.extend([
             ast.parse("%s = %s()" % (named_nodes[n.id], n.name)) for n in component_nodes
@@ -141,7 +143,10 @@ class %s(Component):
                 assignment_source = "self.%s" % arg_name
                 tpl = ast.parse("%s = %s" % (assignment_target, assignment_source))
                 init_code.append(tpl)
-                args_code.append(ast.parse("%s: InArg[%s]" % (arg_name, arg_type)).body[0])
+                if arg_name not in existing_args:
+                    in_arg_def = ast.parse("%s: InArg[%s]" % (arg_name, arg_type)).body[0]
+                    args_code.append(in_arg_def)
+                    existing_args.add(arg_name)
 
             # Handle regular connections
             for port in (p for p in node.ports if


### PR DESCRIPTION
# Description

When an input to a subxircuit is used multiple times, it is added multiple times to the InArgs by the compiler. This fixes the problem. 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Manual Test**

    1. Compile the attached xircuits file ([untitled7.xircuits](https://github.com/user-attachments/files/15785634/untitled7.xircuits.json))
    2. Notice that the resulting python file doesn't have the input argument twice.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  



