### PR TITLE
Fix literal secret handling in Dynalists

### DIFF
--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -163,14 +163,12 @@ class %s(Component):
                 if port.source.id not in named_nodes:
                     # Literal
                     tpl = set_value(assignment_target, '1')
-                    if port.source.type == "string":
+                    if port.source.type == "string" or port.source.type == "secret":
                         value = port.sourceLabel
                     elif port.source.type == "list":
                         value = json.loads("[" + port.sourceLabel + "]")
                     elif port.source.type == "dict":
                         value = json.loads("{" + port.sourceLabel + "}")
-                    elif port.source.type == "secret":
-                        value = port.sourceLabel
                     elif port.source.type == "chat":
                         value = json.loads(port.sourceLabel)
                     elif port.source.type == "tuple":
@@ -211,7 +209,7 @@ class %s(Component):
                 for port in ports:
                     if port.source.id not in named_nodes:
                         # Handle Literals
-                        if port.source.type == "string":
+                        if port.source.type == "string" or port.source.type == "secret":
                             value = port.sourceLabel
                         elif port.source.type == "list":
                             value = json.loads("[" + port.sourceLabel + "]")
@@ -257,14 +255,12 @@ class %s(Component):
             if port.source.id not in named_nodes:
                 # Literal
                 tpl = set_value(assignment_target, '1')
-                if port.source.type == "string":
+                if port.source.type == "string" or port.source.type == "secret":
                     value = port.sourceLabel
                 elif port.source.type == "list":
                     value = json.loads("[" + port.sourceLabel + "]")
                 elif port.source.type == "dict":
                     value = json.loads("{" + port.sourceLabel + "}")
-                elif port.source.type == "secret":
-                    value = port.sourceLabel
                 elif port.source.type == "chat":
                     value = json.loads(port.sourceLabel)
                 elif port.source.type == "tuple":

--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -20,6 +20,28 @@ else:
         return f.getvalue()
 
 
+def _get_value_from_literal_port(port):
+    if port.source.type == "string" or port.source.type == "secret":
+        value = port.sourceLabel
+    elif port.source.type == "list":
+        value = json.loads("[" + port.sourceLabel + "]")
+    elif port.source.type == "dict":
+        value = json.loads("{" + port.sourceLabel + "}")
+    elif port.source.type == "chat":
+        value = json.loads(port.sourceLabel)
+    elif port.source.type == "tuple":
+        if port.sourceLabel == "":
+            value = ()
+        else:
+            value = eval(port.sourceLabel)
+            if not isinstance(value, tuple):
+                # Handler for single entry tuple
+                value = (value,)
+    else:
+        value = eval(port.sourceLabel)
+
+    return value
+
 class CodeGenerator:
     def __init__(self, graph, component_python_paths):
         self.graph = graph
@@ -163,25 +185,7 @@ class %s(Component):
                 if port.source.id not in named_nodes:
                     # Literal
                     tpl = set_value(assignment_target, '1')
-                    if port.source.type == "string" or port.source.type == "secret":
-                        value = port.sourceLabel
-                    elif port.source.type == "list":
-                        value = json.loads("[" + port.sourceLabel + "]")
-                    elif port.source.type == "dict":
-                        value = json.loads("{" + port.sourceLabel + "}")
-                    elif port.source.type == "chat":
-                        value = json.loads(port.sourceLabel)
-                    elif port.source.type == "tuple":
-                        if port.sourceLabel == "":
-                            value = ()
-                        else:
-                            value = eval(port.sourceLabel)
-                            if not isinstance(value, tuple):
-                                # Handler for single entry tuple
-                                value = (value,)
-                    else:
-                        value = eval(port.sourceLabel)
-                    tpl.body[0].value.value = value
+                    tpl.body[0].value.value = _get_value_from_literal_port(port)
                 else:
                     assignment_source = "%s.%s" % (
                         named_nodes[port.source.id],
@@ -208,23 +212,7 @@ class %s(Component):
 
                 for port in ports:
                     if port.source.id not in named_nodes:
-                        # Handle Literals
-                        if port.source.type == "string" or port.source.type == "secret":
-                            value = port.sourceLabel
-                        elif port.source.type == "list":
-                            value = json.loads("[" + port.sourceLabel + "]")
-                        elif port.source.type == "dict":
-                            value = json.loads("{" + port.sourceLabel + "}")
-                        elif port.source.type == "tuple":
-                            if port.sourceLabel == "":
-                                value = ()
-                            else:
-                                value = eval(port.sourceLabel)
-                                if not isinstance(value, tuple):
-                                    # Handler for single entry tuple
-                                    value = (value,)
-                        else:
-                            value = eval(port.sourceLabel)
+                        value = _get_value_from_literal_port(port)
                         dynaport_values.append(RefOrValue(value, False))
                     else:
                         # Handle named node references
@@ -255,21 +243,7 @@ class %s(Component):
             if port.source.id not in named_nodes:
                 # Literal
                 tpl = set_value(assignment_target, '1')
-                if port.source.type == "string" or port.source.type == "secret":
-                    value = port.sourceLabel
-                elif port.source.type == "list":
-                    value = json.loads("[" + port.sourceLabel + "]")
-                elif port.source.type == "dict":
-                    value = json.loads("{" + port.sourceLabel + "}")
-                elif port.source.type == "chat":
-                    value = json.loads(port.sourceLabel)
-                elif port.source.type == "tuple":
-                    value = eval(port.sourceLabel)
-                    if not isinstance(value, tuple):
-                        # handler for single entry tuple
-                        value = (value,)
-                else:
-                    value = eval(port.sourceLabel)
+                value = _get_value_from_literal_port(port)
                 tpl.body[0].value.value = value
                 port_type = type(value).__name__
             else:


### PR DESCRIPTION
# Description

Usage of literal secrets failed to compile when used with dynalists because the literal handling for dynalists was missing that case. 

To resolve the problem, I've refactored the handling into a single method that is used in every place. 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**1. Manual Test**

    1. Try to compile [secret-dynaport-compile.xircuits.json](https://github.com/user-attachments/files/15800530/secret-dynaport-compile.xircuits.json) 
    2. Without the fix it breaks, with the fix it works.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
