### PR TITLE
Allow waiting for futures

### DIFF
--- a/xai_components/xai_utils/RunParallelExample.xircuits
+++ b/xai_components/xai_utils/RunParallelExample.xircuits
@@ -1,64 +1,36 @@
 {
     "id": "65785881-5e54-45c2-bb93-1f3365a04192",
-    "offsetX": 617,
-    "offsetY": -10,
-    "zoom": 100,
+    "offsetX": 196.63043478260875,
+    "offsetY": 15.699999999999761,
+    "zoom": 130.00000000000006,
     "gridSize": 0,
     "layers": [
         {
-            "id": "6f23be13-9ffa-43c0-a808-077427a1cfdf",
+            "id": "6d1d3123-b5e5-436c-bb27-817ea35a2d22",
             "type": "diagram-links",
             "isSvg": true,
             "transformed": true,
             "models": {
-                "f47664d6-47c4-4463-8ed0-b791f7b6b14a": {
-                    "id": "f47664d6-47c4-4463-8ed0-b791f7b6b14a",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "3a2bfac2-940a-4632-b3a2-844cbaf3b867",
-                    "sourcePort": "bf97b78d-8c9d-4267-8815-8c8ba47b87c5",
-                    "target": "0686fd47-a5aa-4d27-a626-96f400d50738",
-                    "targetPort": "2176a68a-0130-4b15-96ff-07ee2852f7b2",
-                    "points": [
-                        {
-                            "id": "b132bfc2-3b59-486d-b8c4-23030a748dd5",
-                            "type": "point",
-                            "x": -234.390625,
-                            "y": 284.5
-                        },
-                        {
-                            "id": "d137d15e-a3d5-465e-8b07-ea51e2772f30",
-                            "type": "point",
-                            "x": 654.5,
-                            "y": 286.5
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
                 "e1541fe3-04a7-40e0-9ef6-21872a678171": {
                     "id": "e1541fe3-04a7-40e0-9ef6-21872a678171",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "3a2bfac2-940a-4632-b3a2-844cbaf3b867",
-                    "sourcePort": "7441a1e4-70d6-402b-b853-6c52363a3261",
-                    "target": "beebace6-f1cb-452d-abde-60ee16b04095",
-                    "targetPort": "a9fdf23e-c9f5-4eb9-8a00-1034d605a551",
+                    "source": "5141d7b0-c5f1-47e7-b208-6a44418cd420",
+                    "sourcePort": "5c0591da-0dfc-4aca-924e-50a20fb28983",
+                    "target": "2b131fe6-efc7-4d4f-867f-927fbb1a5884",
+                    "targetPort": "340bd492-b03f-4aea-bfc2-e35de417dff4",
                     "points": [
                         {
                             "id": "7150f7b9-fe05-491e-86f1-9acff36ccfdb",
                             "type": "point",
-                            "x": -234.390625,
-                            "y": 306.5
+                            "x": -215.3906153037795,
+                            "y": 149.50000234750615
                         },
                         {
                             "id": "68d076b6-d77e-424f-a285-73969a853541",
                             "type": "point",
-                            "x": -56.5,
-                            "y": 327.5
+                            "x": -75.03124734629756,
+                            "y": 221.95312265249407
                         }
                     ],
                     "labels": [],
@@ -73,20 +45,20 @@
                     "selected": false,
                     "source": "73115ab7-a0ac-47bb-a0a0-d299ad3d1579",
                     "sourcePort": "a0e0c926-b7a0-4f46-95ee-db4826658d12",
-                    "target": "3a2bfac2-940a-4632-b3a2-844cbaf3b867",
-                    "targetPort": "c6d1f8d7-d8bb-41eb-b4c6-9dbcf6ca5c6c",
+                    "target": "5141d7b0-c5f1-47e7-b208-6a44418cd420",
+                    "targetPort": "c7851ee5-c162-4394-9e4c-7df28e2e86f6",
                     "points": [
                         {
                             "id": "40886c5e-19e8-4715-942f-8d70317501f9",
                             "type": "point",
-                            "x": -430.21875,
+                            "x": -430.2187191762253,
                             "y": 348.5
                         },
                         {
                             "id": "5cf78565-0527-4b3a-bda4-3b7f3fcebb3c",
                             "type": "point",
-                            "x": -387.5,
-                            "y": 306.5
+                            "x": -368.4999926512854,
+                            "y": 149.50000234750615
                         }
                     ],
                     "labels": [],
@@ -101,48 +73,20 @@
                     "selected": false,
                     "source": "3fb4fb2c-5d01-4aca-8dff-d5b6daf96cbd",
                     "sourcePort": "f9a56451-a445-433d-b4af-5d8c74e5b56a",
-                    "target": "3a2bfac2-940a-4632-b3a2-844cbaf3b867",
-                    "targetPort": "db805666-c087-466e-8bad-71dcb6768e75",
+                    "target": "5141d7b0-c5f1-47e7-b208-6a44418cd420",
+                    "targetPort": "cc627738-2656-4e0f-919e-20b935810e74",
                     "points": [
                         {
                             "id": "c98c177f-b3b6-4987-8122-9cb6984481dd",
                             "type": "point",
-                            "x": -504.5,
-                            "y": 281.5
+                            "x": -504.4999832612614,
+                            "y": 281.49999530498803
                         },
                         {
                             "id": "b8704c25-58e7-489a-a97e-5dd498887b1d",
                             "type": "point",
-                            "x": -387.5,
-                            "y": 284.5
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "1e10c79c-bc3f-48a4-b29b-973c96304a86": {
-                    "id": "1e10c79c-bc3f-48a4-b29b-973c96304a86",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "beebace6-f1cb-452d-abde-60ee16b04095",
-                    "sourcePort": "2e41e9b8-418e-4380-9de5-7c4695355d21",
-                    "target": "b7b82f31-c069-4268-9ed4-e3f299a5ca41",
-                    "targetPort": "29b8fd51-14b7-4f62-9ea1-0670af194c6c",
-                    "points": [
-                        {
-                            "id": "ca593a6f-b924-4be0-aa60-d23937f2eebf",
-                            "type": "point",
-                            "x": 69.109375,
-                            "y": 349.5
-                        },
-                        {
-                            "id": "2dcfad93-72cc-47da-94e5-20b8bb7d4056",
-                            "type": "point",
-                            "x": 155.5,
-                            "y": 349.5
+                            "x": -368.4999926512854,
+                            "y": 127.49998591496407
                         }
                     ],
                     "labels": [],
@@ -155,50 +99,22 @@
                     "id": "8541f82e-3faf-41c6-83e9-2efb635d590d",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "b7b82f31-c069-4268-9ed4-e3f299a5ca41",
-                    "sourcePort": "a9128b9f-05bf-4fff-a977-d90261fae650",
-                    "target": "4ec75bdd-22cc-4f21-8779-4ef0b85f30a9",
-                    "targetPort": "b0517ec3-eec7-4fc2-b602-d3605facd266",
+                    "source": "129162da-8768-41cf-938c-3fe3fd73f07f",
+                    "sourcePort": "4f197b8c-c35b-4d8f-9815-06f682c5dc47",
+                    "target": "c5e10350-41b7-4f15-b571-371fa1e0fbd2",
+                    "targetPort": "2359e786-e909-443d-b2f3-9811937c5178",
                     "points": [
                         {
                             "id": "b84bb4d2-0850-4f4e-9dbd-e44f6ad3401e",
                             "type": "point",
-                            "x": 304.34375,
-                            "y": 349.5
+                            "x": 320.3437432636782,
+                            "y": 391.49999530498803
                         },
                         {
                             "id": "c6e765df-b778-43aa-bfc7-6f740b57bb68",
                             "type": "point",
-                            "x": 354.5,
-                            "y": 349.5
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "1644436e-4c3d-45d6-a975-1fc79bc0703e": {
-                    "id": "1644436e-4c3d-45d6-a975-1fc79bc0703e",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "4ec75bdd-22cc-4f21-8779-4ef0b85f30a9",
-                    "sourcePort": "4fe24f48-d11a-4ef2-8363-f56cda03314a",
-                    "target": "4109f066-62e2-4c2c-83cc-f857608f1014",
-                    "targetPort": "14d0ef6d-2104-4133-976f-e7fd434fa01a",
-                    "points": [
-                        {
-                            "id": "afc8afd5-6081-4ea4-8566-4e4e682b134c",
-                            "type": "point",
-                            "x": 462.515625,
-                            "y": 349.5
-                        },
-                        {
-                            "id": "2582f7ae-d5bb-4002-813c-382c19aeb0b5",
-                            "type": "point",
-                            "x": 521.5,
-                            "y": 350.5
+                            "x": 366.6405994836301,
+                            "y": 391.562485914964
                         }
                     ],
                     "labels": [],
@@ -211,40 +127,34 @@
                     "id": "2a2711c9-f8d9-4fe3-b068-6b562d62972a",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "3a2bfac2-940a-4632-b3a2-844cbaf3b867",
-                    "sourcePort": "196f6065-c117-4062-b3d0-bbbed121b146",
-                    "target": "4109f066-62e2-4c2c-83cc-f857608f1014",
-                    "targetPort": "f1ff06cc-66b7-4225-b9b5-35d07fd4ed0a",
+                    "source": "5141d7b0-c5f1-47e7-b208-6a44418cd420",
+                    "sourcePort": "84abd6b7-b88d-491a-9e36-35b5485b4315",
+                    "target": "67f85ef9-0410-4067-b9b1-b5c54b46a0ed",
+                    "targetPort": "b2d0bb34-e798-41ad-8900-cac09e8614fc",
                     "points": [
                         {
                             "id": "47f38cb9-a92d-4162-9dc6-f730e4568ad5",
                             "type": "point",
-                            "x": -234.390625,
-                            "y": 328.5
-                        },
-                        {
-                            "id": "476d5c76-6a54-429b-99dd-e53f1a919891",
-                            "type": "point",
-                            "x": -189,
-                            "y": 329
+                            "x": -215.3906153037795,
+                            "y": 171.4999953049881
                         },
                         {
                             "id": "52541587-3417-4085-a3eb-da707c320048",
                             "type": "point",
-                            "x": -191,
-                            "y": 548
+                            "x": -217,
+                            "y": 525
                         },
                         {
                             "id": "bddddf97-8ad4-4539-b3bb-766de4a88a26",
                             "type": "point",
-                            "x": 521,
-                            "y": 545
+                            "x": 726.6923076923076,
+                            "y": 525.8461538461538
                         },
                         {
                             "id": "9f1b4a31-11ba-417a-9e39-118707a43a15",
                             "type": "point",
-                            "x": 521.5,
-                            "y": 372.5
+                            "x": 726.3437573487141,
+                            "y": 457.42186091496393
                         }
                     ],
                     "labels": [],
@@ -257,22 +167,22 @@
                     "id": "961d8378-bcef-4be3-aa8e-bc92025f789d",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "b7b82f31-c069-4268-9ed4-e3f299a5ca41",
-                    "sourcePort": "5429e217-4f24-4f30-867b-3c081f1622da",
-                    "target": "4ec75bdd-22cc-4f21-8779-4ef0b85f30a9",
-                    "targetPort": "c627ddb5-fc9d-45e1-baba-defbba793117",
+                    "source": "129162da-8768-41cf-938c-3fe3fd73f07f",
+                    "sourcePort": "257a9118-1d57-4051-8857-547b8459bcbe",
+                    "target": "c5e10350-41b7-4f15-b571-371fa1e0fbd2",
+                    "targetPort": "26c5f968-ac72-4047-ac13-62f9a9549b07",
                     "points": [
                         {
                             "id": "0a480c3f-cead-4558-a10f-c2ce8d5da049",
                             "type": "point",
-                            "x": 304.34375,
-                            "y": 371.5
+                            "x": 320.3437432636782,
+                            "y": 413.4999765249399
                         },
                         {
                             "id": "af5e62bd-898e-4b2d-9abe-268e74fa114e",
                             "type": "point",
-                            "x": 354.5,
-                            "y": 371.5
+                            "x": 366.6405994836301,
+                            "y": 413.56249060997595
                         }
                     ],
                     "labels": [],
@@ -287,20 +197,20 @@
                     "selected": false,
                     "source": "0ad4befa-2216-4019-82b1-7b5c94640241",
                     "sourcePort": "36d144cf-c9d3-4740-8bc1-22892b751219",
-                    "target": "b7b82f31-c069-4268-9ed4-e3f299a5ca41",
-                    "targetPort": "b321db1b-97bd-48ea-b46d-38f97f6e3d10",
+                    "target": "129162da-8768-41cf-938c-3fe3fd73f07f",
+                    "targetPort": "eda07ee2-c588-4cfe-8955-17f7e0775980",
                     "points": [
                         {
                             "id": "cc22e132-6b03-48eb-bfc6-45a984170a7a",
                             "type": "point",
-                            "x": 90.78125,
-                            "y": 462.5
+                            "x": 90.78124795869036,
+                            "y": 462.49998591496393
                         },
                         {
                             "id": "a4c74cc2-6c15-4e92-998d-a8542f728445",
                             "type": "point",
-                            "x": 155.5,
-                            "y": 393.5
+                            "x": 171.49998387365426,
+                            "y": 435.50000469501197
                         }
                     ],
                     "labels": [],
@@ -315,20 +225,20 @@
                     "selected": false,
                     "source": "0d68b66a-d1a9-46dc-b078-22c397062ef8",
                     "sourcePort": "0673aa39-2a54-4011-b722-f2fc6dd4e0f8",
-                    "target": "b7b82f31-c069-4268-9ed4-e3f299a5ca41",
-                    "targetPort": "01f70577-452f-48e5-8a0f-6ba2c1aed1e8",
+                    "target": "129162da-8768-41cf-938c-3fe3fd73f07f",
+                    "targetPort": "1bfd0b11-543c-4e30-b8de-ab609456b5d4",
                     "points": [
                         {
                             "id": "23873274-0c20-4a0e-b4da-3cdf2214499d",
                             "type": "point",
-                            "x": 89.78125,
-                            "y": 412.5
+                            "x": 89.7812338736543,
+                            "y": 412.49998591496393
                         },
                         {
                             "id": "c3eb3356-cf76-46c7-817c-f4dfa5967449",
                             "type": "point",
-                            "x": 155.5,
-                            "y": 371.5
+                            "x": 171.49998387365426,
+                            "y": 413.4999765249399
                         }
                     ],
                     "labels": [],
@@ -343,20 +253,188 @@
                     "selected": false,
                     "source": "e7ef03fc-2499-4cae-b2cd-19b58a542853",
                     "sourcePort": "ed277422-befe-49c7-ac54-6f552ab97ef4",
-                    "target": "beebace6-f1cb-452d-abde-60ee16b04095",
-                    "targetPort": "9fb71913-6605-4b85-bb2c-70a163cdb62d",
+                    "target": "2b131fe6-efc7-4d4f-867f-927fbb1a5884",
+                    "targetPort": "e39ed6ef-364b-478f-a00e-f4ffee4e9499",
                     "points": [
                         {
                             "id": "2b8747bd-bae1-4592-9450-ac9165fdf4d8",
                             "type": "point",
-                            "x": -96.21875,
-                            "y": 358.5
+                            "x": -131.35937234629753,
+                            "y": 251.6406226524941
                         },
                         {
                             "id": "bf1059ef-07c1-48ce-8e79-6d595328ede1",
                             "type": "point",
-                            "x": -56.5,
-                            "y": 349.5
+                            "x": -75.03124734629756,
+                            "y": 243.9531273475061
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "999a094e-42c4-4d97-9925-13698b0dd975": {
+                    "id": "999a094e-42c4-4d97-9925-13698b0dd975",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "2b131fe6-efc7-4d4f-867f-927fbb1a5884",
+                    "sourcePort": "6be808ba-bcef-4731-ab99-2274172d0cb2",
+                    "target": "129162da-8768-41cf-938c-3fe3fd73f07f",
+                    "targetPort": "16d06106-81e6-4d63-ac1f-071980af9582",
+                    "points": [
+                        {
+                            "id": "7d705336-7d7c-43b5-b60d-b2fb55034525",
+                            "type": "point",
+                            "x": 60.35937765370238,
+                            "y": 287.95312500000006
+                        },
+                        {
+                            "id": "e3ec3fb5-dbc0-4048-82a6-10862ac26cbe",
+                            "type": "point",
+                            "x": 171.49998387365426,
+                            "y": 391.49999530498803
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "0c54e7aa-1dfa-473d-ac04-ca3e40512c85": {
+                    "id": "0c54e7aa-1dfa-473d-ac04-ca3e40512c85",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "c5e10350-41b7-4f15-b571-371fa1e0fbd2",
+                    "sourcePort": "52b70132-5963-4dab-bf95-68f6ab52bd9c",
+                    "target": "eb60672f-42e3-4d7b-bb64-d03aa0f44c1a",
+                    "targetPort": "bbca24e7-4b98-4c30-8307-3773062305b2",
+                    "points": [
+                        {
+                            "id": "d85dc7f4-733d-41e1-be4d-442345c18446",
+                            "type": "point",
+                            "x": 474.65618222852197,
+                            "y": 391.562485914964
+                        },
+                        {
+                            "id": "9494b8d0-1281-4440-997a-93daa18b3d1f",
+                            "type": "point",
+                            "x": 518.796807228522,
+                            "y": 391.640610914964
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "1c9336d9-3799-4aa9-9112-7ca9e92b8ad1": {
+                    "id": "1c9336d9-3799-4aa9-9112-7ca9e92b8ad1",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "eb60672f-42e3-4d7b-bb64-d03aa0f44c1a",
+                    "sourcePort": "5f5d0880-a10e-4bae-9c1f-acfb0bd40990",
+                    "target": "67f85ef9-0410-4067-b9b1-b5c54b46a0ed",
+                    "targetPort": "0c8ddacc-0227-4bb2-ba0e-66e0402ce3f0",
+                    "points": [
+                        {
+                            "id": "0fbedc0c-6792-4615-87ff-ffcfe8d6a226",
+                            "type": "point",
+                            "x": 654.1874322285219,
+                            "y": 457.6406015249399
+                        },
+                        {
+                            "id": "5f3521df-c4b9-4f50-99e4-f95d8c5c9848",
+                            "type": "point",
+                            "x": 726.3437573487141,
+                            "y": 435.42187969501197
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "8e7a4a5a-3d49-44f9-a6ad-40924f3f59d6": {
+                    "id": "8e7a4a5a-3d49-44f9-a6ad-40924f3f59d6",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "5141d7b0-c5f1-47e7-b208-6a44418cd420",
+                    "sourcePort": "60162b1d-d213-4d05-b8c6-4f1e19d9b3b8",
+                    "target": "ef83a274-010a-4510-bc09-7e50adb6b62b",
+                    "targetPort": "868fa100-aecd-4178-baae-8080545f5bc0",
+                    "points": [
+                        {
+                            "id": "1b498396-09b7-4b2d-9d11-ccc8c6322dd6",
+                            "type": "point",
+                            "x": -215.3906153037795,
+                            "y": 127.49998591496407
+                        },
+                        {
+                            "id": "baa8d28f-bcb8-43ef-8e0b-048e7da9b8f6",
+                            "type": "point",
+                            "x": 112.54687765370237,
+                            "y": 117.03123591496409
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "d0a41651-90a3-4827-91ac-29d8a00859dd": {
+                    "id": "d0a41651-90a3-4827-91ac-29d8a00859dd",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "2b131fe6-efc7-4d4f-867f-927fbb1a5884",
+                    "sourcePort": "d19d4f99-86f0-4b58-b5cd-d3a2ebe5fbd1",
+                    "target": "ef83a274-010a-4510-bc09-7e50adb6b62b",
+                    "targetPort": "e3f6a117-a842-48ec-b8b1-1dc1f0e58dd9",
+                    "points": [
+                        {
+                            "id": "be92080b-f25b-44d7-9b27-f355437af737",
+                            "type": "point",
+                            "x": 60.35937765370238,
+                            "y": 243.9531273475061
+                        },
+                        {
+                            "id": "aff0f2a4-72ca-4bcf-9fa4-126eec7b3228",
+                            "type": "point",
+                            "x": 112.54687765370237,
+                            "y": 139.03125234750615
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "f6048c4e-6740-41d1-90d2-11b7a7b31106": {
+                    "id": "f6048c4e-6740-41d1-90d2-11b7a7b31106",
+                    "type": "default",
+                    "selected": true,
+                    "source": "ef83a274-010a-4510-bc09-7e50adb6b62b",
+                    "sourcePort": "64cb8e81-506f-4b03-8d50-7a0099d29830",
+                    "target": "c2251c90-1e68-424c-b046-bbdca8b12c4c",
+                    "targetPort": "4c53720d-272d-48cb-bba8-00995c39bf07",
+                    "points": [
+                        {
+                            "id": "99445950-88a2-48aa-a165-aa2a151ec8e8",
+                            "type": "point",
+                            "x": 206.34373387365426,
+                            "y": 117.03123591496409
+                        },
+                        {
+                            "id": "77f7d468-eaad-4691-94a4-6e46c0c8ab02",
+                            "type": "point",
+                            "x": 659.5150501672238,
+                            "y": 121.00000000000014
                         }
                     ],
                     "labels": [],
@@ -368,7 +446,7 @@
             }
         },
         {
-            "id": "60e2f825-8553-4643-9df7-10f56c956f10",
+            "id": "f0b52d0f-3366-414c-ba54-7a227d881a0a",
             "type": "diagram-nodes",
             "isSvg": false,
             "transformed": true,
@@ -388,8 +466,8 @@
                             "id": "f9a56451-a445-433d-b4af-5d8c74e5b56a",
                             "type": "default",
                             "extras": {},
-                            "x": -515,
-                            "y": 271,
+                            "x": -515.0000020413095,
+                            "y": 271.00000000000006,
                             "name": "out-0",
                             "alignment": "right",
                             "parentNode": "3fb4fb2c-5d01-4aca-8dff-d5b6daf96cbd",
@@ -410,310 +488,6 @@
                         "f9a56451-a445-433d-b4af-5d8c74e5b56a"
                     ]
                 },
-                "0686fd47-a5aa-4d27-a626-96f400d50738": {
-                    "id": "0686fd47-a5aa-4d27-a626-96f400d50738",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "Finish"
-                    },
-                    "x": 643,
-                    "y": 252,
-                    "ports": [
-                        {
-                            "id": "2176a68a-0130-4b15-96ff-07ee2852f7b2",
-                            "type": "default",
-                            "extras": {},
-                            "x": 644,
-                            "y": 276,
-                            "name": "in-0",
-                            "alignment": "left",
-                            "parentNode": "0686fd47-a5aa-4d27-a626-96f400d50738",
-                            "links": [
-                                "f47664d6-47c4-4463-8ed0-b791f7b6b14a"
-                            ],
-                            "in": true,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "87eda88e-c57f-417c-a8be-c0602ccf4add",
-                            "type": "default",
-                            "extras": {},
-                            "x": 644,
-                            "y": 298,
-                            "name": "parameter-dynalist-outputs",
-                            "alignment": "left",
-                            "parentNode": "0686fd47-a5aa-4d27-a626-96f400d50738",
-                            "links": [],
-                            "in": true,
-                            "label": "outputs",
-                            "varName": "outputs",
-                            "portType": "",
-                            "dataType": "dynalist",
-                            "dynaPortOrder": 0,
-                            "dynaPortRef": {
-                                "previous": null,
-                                "next": null
-                            }
-                        }
-                    ],
-                    "name": "Finish",
-                    "color": "rgb(255,102,102)",
-                    "portsInOrder": [
-                        "2176a68a-0130-4b15-96ff-07ee2852f7b2",
-                        "87eda88e-c57f-417c-a8be-c0602ccf4add"
-                    ],
-                    "portsOutOrder": []
-                },
-                "beebace6-f1cb-452d-abde-60ee16b04095": {
-                    "id": "beebace6-f1cb-452d-abde-60ee16b04095",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "debug",
-                        "path": "xai_components/xai_utils/utils.py",
-                        "description": "Executes a given body in a separate thread using a thread pool executor.\n\n##### inPorts:\n- n_workers: The number of worker threads to use for executing the body in parallel.\n\n##### outPorts:\n- None",
-                        "lineNo": [
-                            {
-                                "lineno": 712,
-                                "end_lineno": 740
-                            }
-                        ],
-                        "sourceBranchId": "3a2bfac2-940a-4632-b3a2-844cbaf3b867",
-                        "portId": "7441a1e4-70d6-402b-b853-6c52363a3261",
-                        "finishNodeId": "None",
-                        "isBranchNode": true,
-                        "borderColor": "rgb(0,192,255)"
-                    },
-                    "x": -68,
-                    "y": 293,
-                    "ports": [
-                        {
-                            "id": "a9fdf23e-c9f5-4eb9-8a00-1034d605a551",
-                            "type": "default",
-                            "extras": {},
-                            "x": -67,
-                            "y": 317,
-                            "name": "in-0",
-                            "alignment": "left",
-                            "parentNode": "beebace6-f1cb-452d-abde-60ee16b04095",
-                            "links": [
-                                "e1541fe3-04a7-40e0-9ef6-21872a678171"
-                            ],
-                            "in": true,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "9fb71913-6605-4b85-bb2c-70a163cdb62d",
-                            "type": "default",
-                            "extras": {},
-                            "x": -67,
-                            "y": 339,
-                            "name": "parameter-int-n_workers",
-                            "alignment": "left",
-                            "parentNode": "beebace6-f1cb-452d-abde-60ee16b04095",
-                            "links": [
-                                "6accbdf3-6c10-42c0-b737-c5196433ea0d"
-                            ],
-                            "in": true,
-                            "label": "n_workers",
-                            "varName": "n_workers",
-                            "portType": "",
-                            "dataType": "int"
-                        },
-                        {
-                            "id": "4d8a364c-3c71-45f0-af48-f6ae816a5b17",
-                            "type": "default",
-                            "extras": {},
-                            "x": 58.609375,
-                            "y": 317,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "beebace6-f1cb-452d-abde-60ee16b04095",
-                            "links": [],
-                            "in": false,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "2e41e9b8-418e-4380-9de5-7c4695355d21",
-                            "type": "default",
-                            "extras": {},
-                            "x": 58.609375,
-                            "y": 339,
-                            "name": "out-flow-body",
-                            "alignment": "right",
-                            "parentNode": "beebace6-f1cb-452d-abde-60ee16b04095",
-                            "links": [
-                                "1e10c79c-bc3f-48a4-b29b-973c96304a86"
-                            ],
-                            "in": false,
-                            "label": "body ▶",
-                            "varName": "body ▶",
-                            "portType": "",
-                            "dataType": ""
-                        }
-                    ],
-                    "name": "RunParallelThread",
-                    "color": "blue",
-                    "portsInOrder": [
-                        "a9fdf23e-c9f5-4eb9-8a00-1034d605a551",
-                        "9fb71913-6605-4b85-bb2c-70a163cdb62d"
-                    ],
-                    "portsOutOrder": [
-                        "4d8a364c-3c71-45f0-af48-f6ae816a5b17",
-                        "2e41e9b8-418e-4380-9de5-7c4695355d21"
-                    ]
-                },
-                "3a2bfac2-940a-4632-b3a2-844cbaf3b867": {
-                    "id": "3a2bfac2-940a-4632-b3a2-844cbaf3b867",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "debug",
-                        "path": "xai_components/xai_controlflow/branches.py",
-                        "description": null,
-                        "lineNo": [
-                            {
-                                "lineno": 60,
-                                "end_lineno": 77
-                            }
-                        ],
-                        "finishNodeId": "0686fd47-a5aa-4d27-a626-96f400d50738",
-                        "isBranchNode": true,
-                        "borderColor": "rgb(0,192,255)"
-                    },
-                    "x": -399,
-                    "y": 250,
-                    "ports": [
-                        {
-                            "id": "db805666-c087-466e-8bad-71dcb6768e75",
-                            "type": "default",
-                            "extras": {},
-                            "x": -398,
-                            "y": 274,
-                            "name": "in-0",
-                            "alignment": "left",
-                            "parentNode": "3a2bfac2-940a-4632-b3a2-844cbaf3b867",
-                            "links": [
-                                "c88a483e-09ec-435d-9f79-086dde8ff320"
-                            ],
-                            "in": true,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "c6d1f8d7-d8bb-41eb-b4c6-9dbcf6ca5c6c",
-                            "type": "default",
-                            "extras": {},
-                            "x": -398,
-                            "y": 296,
-                            "name": "parameter-list-items",
-                            "alignment": "left",
-                            "parentNode": "3a2bfac2-940a-4632-b3a2-844cbaf3b867",
-                            "links": [
-                                "98df1557-ba17-487a-b7f8-111f0a45a564"
-                            ],
-                            "in": true,
-                            "label": "★items",
-                            "varName": "★items",
-                            "portType": "",
-                            "dataType": "list"
-                        },
-                        {
-                            "id": "bf97b78d-8c9d-4267-8815-8c8ba47b87c5",
-                            "type": "default",
-                            "extras": {},
-                            "x": -244.890625,
-                            "y": 274,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "3a2bfac2-940a-4632-b3a2-844cbaf3b867",
-                            "links": [
-                                "f47664d6-47c4-4463-8ed0-b791f7b6b14a"
-                            ],
-                            "in": false,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "7441a1e4-70d6-402b-b853-6c52363a3261",
-                            "type": "default",
-                            "extras": {},
-                            "x": -244.890625,
-                            "y": 296,
-                            "name": "out-flow-body",
-                            "alignment": "right",
-                            "parentNode": "3a2bfac2-940a-4632-b3a2-844cbaf3b867",
-                            "links": [
-                                "e1541fe3-04a7-40e0-9ef6-21872a678171"
-                            ],
-                            "in": false,
-                            "label": "body ▶",
-                            "varName": "body ▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "196f6065-c117-4062-b3d0-bbbed121b146",
-                            "type": "default",
-                            "extras": {},
-                            "x": -244.890625,
-                            "y": 318,
-                            "name": "parameter-out-any-current_item",
-                            "alignment": "right",
-                            "parentNode": "3a2bfac2-940a-4632-b3a2-844cbaf3b867",
-                            "links": [
-                                "2a2711c9-f8d9-4fe3-b068-6b562d62972a"
-                            ],
-                            "in": false,
-                            "label": "current_item",
-                            "varName": "current_item",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "45f451e6-e8a0-486a-a98d-b5a8600b06e9",
-                            "type": "default",
-                            "extras": {},
-                            "x": -244.890625,
-                            "y": 340,
-                            "name": "parameter-out-int-current_index",
-                            "alignment": "right",
-                            "parentNode": "3a2bfac2-940a-4632-b3a2-844cbaf3b867",
-                            "links": [],
-                            "in": false,
-                            "label": "current_index",
-                            "varName": "current_index",
-                            "portType": "",
-                            "dataType": ""
-                        }
-                    ],
-                    "name": "ForEach",
-                    "color": "rgb(0,102,204)",
-                    "portsInOrder": [
-                        "db805666-c087-466e-8bad-71dcb6768e75",
-                        "c6d1f8d7-d8bb-41eb-b4c6-9dbcf6ca5c6c"
-                    ],
-                    "portsOutOrder": [
-                        "bf97b78d-8c9d-4267-8815-8c8ba47b87c5",
-                        "7441a1e4-70d6-402b-b853-6c52363a3261",
-                        "196f6065-c117-4062-b3d0-bbbed121b146",
-                        "45f451e6-e8a0-486a-a98d-b5a8600b06e9"
-                    ]
-                },
                 "73115ab7-a0ac-47bb-a0a0-d299ad3d1579": {
                     "id": "73115ab7-a0ac-47bb-a0a0-d299ad3d1579",
                     "type": "custom-node",
@@ -728,8 +502,8 @@
                             "id": "a0e0c926-b7a0-4f46-95ee-db4826658d12",
                             "type": "default",
                             "extras": {},
-                            "x": -440.71875,
-                            "y": 338,
+                            "x": -440.7187144812133,
+                            "y": 337.99998121995196,
                             "name": "out-0",
                             "alignment": "right",
                             "parentNode": "73115ab7-a0ac-47bb-a0a0-d299ad3d1579",
@@ -750,297 +524,6 @@
                         "a0e0c926-b7a0-4f46-95ee-db4826658d12"
                     ]
                 },
-                "b7b82f31-c069-4268-9ed4-e3f299a5ca41": {
-                    "id": "b7b82f31-c069-4268-9ed4-e3f299a5ca41",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "debug",
-                        "path": "xai_components/xai_utils/utils.py",
-                        "description": "Generates a random number between the specified bounds.\n\n##### inPorts:\n- greater_than: The lower bound for the random number (inclusive).\n- less_than: The upper bound for the random number (exclusive).\n\n##### outPorts:\n- value: The generated random number.",
-                        "lineNo": [
-                            {
-                                "lineno": 691,
-                                "end_lineno": 708
-                            }
-                        ],
-                        "borderColor": "rgb(0,192,255)",
-                        "sourceBranchId": "beebace6-f1cb-452d-abde-60ee16b04095",
-                        "portId": "2e41e9b8-418e-4380-9de5-7c4695355d21"
-                    },
-                    "x": 144,
-                    "y": 315,
-                    "ports": [
-                        {
-                            "id": "29b8fd51-14b7-4f62-9ea1-0670af194c6c",
-                            "type": "default",
-                            "extras": {},
-                            "x": 145,
-                            "y": 339,
-                            "name": "in-0",
-                            "alignment": "left",
-                            "parentNode": "b7b82f31-c069-4268-9ed4-e3f299a5ca41",
-                            "links": [
-                                "1e10c79c-bc3f-48a4-b29b-973c96304a86"
-                            ],
-                            "in": true,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "01f70577-452f-48e5-8a0f-6ba2c1aed1e8",
-                            "type": "default",
-                            "extras": {},
-                            "x": 145,
-                            "y": 361,
-                            "name": "parameter-int-greater_than",
-                            "alignment": "left",
-                            "parentNode": "b7b82f31-c069-4268-9ed4-e3f299a5ca41",
-                            "links": [
-                                "46d4ae56-8fec-4ae1-be63-0ca5041bc088"
-                            ],
-                            "in": true,
-                            "label": "★greater_than",
-                            "varName": "★greater_than",
-                            "portType": "",
-                            "dataType": "int"
-                        },
-                        {
-                            "id": "b321db1b-97bd-48ea-b46d-38f97f6e3d10",
-                            "type": "default",
-                            "extras": {},
-                            "x": 145,
-                            "y": 383,
-                            "name": "parameter-int-less_than",
-                            "alignment": "left",
-                            "parentNode": "b7b82f31-c069-4268-9ed4-e3f299a5ca41",
-                            "links": [
-                                "e29e880d-6963-4c5b-8f36-9629df6411c6"
-                            ],
-                            "in": true,
-                            "label": "★less_than",
-                            "varName": "★less_than",
-                            "portType": "",
-                            "dataType": "int"
-                        },
-                        {
-                            "id": "a9128b9f-05bf-4fff-a977-d90261fae650",
-                            "type": "default",
-                            "extras": {},
-                            "x": 293.84375,
-                            "y": 339,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "b7b82f31-c069-4268-9ed4-e3f299a5ca41",
-                            "links": [
-                                "8541f82e-3faf-41c6-83e9-2efb635d590d"
-                            ],
-                            "in": false,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "5429e217-4f24-4f30-867b-3c081f1622da",
-                            "type": "default",
-                            "extras": {},
-                            "x": 293.84375,
-                            "y": 361,
-                            "name": "parameter-out-int-value",
-                            "alignment": "right",
-                            "parentNode": "b7b82f31-c069-4268-9ed4-e3f299a5ca41",
-                            "links": [
-                                "961d8378-bcef-4be3-aa8e-bc92025f789d"
-                            ],
-                            "in": false,
-                            "label": "value",
-                            "varName": "value",
-                            "portType": "",
-                            "dataType": ""
-                        }
-                    ],
-                    "name": "GetRandomNumber",
-                    "color": "rgb(0,102,204)",
-                    "portsInOrder": [
-                        "29b8fd51-14b7-4f62-9ea1-0670af194c6c",
-                        "01f70577-452f-48e5-8a0f-6ba2c1aed1e8",
-                        "b321db1b-97bd-48ea-b46d-38f97f6e3d10"
-                    ],
-                    "portsOutOrder": [
-                        "a9128b9f-05bf-4fff-a977-d90261fae650",
-                        "5429e217-4f24-4f30-867b-3c081f1622da"
-                    ]
-                },
-                "4ec75bdd-22cc-4f21-8779-4ef0b85f30a9": {
-                    "id": "4ec75bdd-22cc-4f21-8779-4ef0b85f30a9",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "debug",
-                        "path": "xai_components/xai_utils/utils.py",
-                        "description": "Pauses the python process.\n\n##### inPorts:\n- sleep_timer: the number of seconds to pause.\n    Default `5.0` seconds.",
-                        "lineNo": [
-                            {
-                                "lineno": 335,
-                                "end_lineno": 348
-                            }
-                        ],
-                        "borderColor": "rgb(0,192,255)"
-                    },
-                    "x": 343,
-                    "y": 315,
-                    "ports": [
-                        {
-                            "id": "b0517ec3-eec7-4fc2-b602-d3605facd266",
-                            "type": "default",
-                            "extras": {},
-                            "x": 344,
-                            "y": 339,
-                            "name": "in-0",
-                            "alignment": "left",
-                            "parentNode": "4ec75bdd-22cc-4f21-8779-4ef0b85f30a9",
-                            "links": [
-                                "8541f82e-3faf-41c6-83e9-2efb635d590d"
-                            ],
-                            "in": true,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "c627ddb5-fc9d-45e1-baba-defbba793117",
-                            "type": "default",
-                            "extras": {},
-                            "x": 344,
-                            "y": 361,
-                            "name": "parameter-float-sleep_timer",
-                            "alignment": "left",
-                            "parentNode": "4ec75bdd-22cc-4f21-8779-4ef0b85f30a9",
-                            "links": [
-                                "961d8378-bcef-4be3-aa8e-bc92025f789d"
-                            ],
-                            "in": true,
-                            "label": "sleep_timer",
-                            "varName": "sleep_timer",
-                            "portType": "",
-                            "dataType": "float"
-                        },
-                        {
-                            "id": "4fe24f48-d11a-4ef2-8363-f56cda03314a",
-                            "type": "default",
-                            "extras": {},
-                            "x": 452.015625,
-                            "y": 339,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "4ec75bdd-22cc-4f21-8779-4ef0b85f30a9",
-                            "links": [
-                                "1644436e-4c3d-45d6-a975-1fc79bc0703e"
-                            ],
-                            "in": false,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        }
-                    ],
-                    "name": "SleepComponent",
-                    "color": "green",
-                    "portsInOrder": [
-                        "b0517ec3-eec7-4fc2-b602-d3605facd266",
-                        "c627ddb5-fc9d-45e1-baba-defbba793117"
-                    ],
-                    "portsOutOrder": [
-                        "4fe24f48-d11a-4ef2-8363-f56cda03314a"
-                    ]
-                },
-                "4109f066-62e2-4c2c-83cc-f857608f1014": {
-                    "id": "4109f066-62e2-4c2c-83cc-f857608f1014",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "debug",
-                        "path": "xai_components/xai_utils/utils.py",
-                        "description": "Prints a message to the console.\n\n##### inPorts:\n- msg: The message to be printed.",
-                        "lineNo": [
-                            {
-                                "lineno": 57,
-                                "end_lineno": 66
-                            }
-                        ],
-                        "borderColor": "rgb(0,192,255)",
-                        "nextNode": "None"
-                    },
-                    "x": 510,
-                    "y": 316,
-                    "ports": [
-                        {
-                            "id": "14d0ef6d-2104-4133-976f-e7fd434fa01a",
-                            "type": "default",
-                            "extras": {},
-                            "x": 511,
-                            "y": 340,
-                            "name": "in-0",
-                            "alignment": "left",
-                            "parentNode": "4109f066-62e2-4c2c-83cc-f857608f1014",
-                            "links": [
-                                "1644436e-4c3d-45d6-a975-1fc79bc0703e"
-                            ],
-                            "in": true,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "f1ff06cc-66b7-4225-b9b5-35d07fd4ed0a",
-                            "type": "default",
-                            "extras": {},
-                            "x": 511,
-                            "y": 362,
-                            "name": "parameter-any-msg",
-                            "alignment": "left",
-                            "parentNode": "4109f066-62e2-4c2c-83cc-f857608f1014",
-                            "links": [
-                                "2a2711c9-f8d9-4fe3-b068-6b562d62972a"
-                            ],
-                            "in": true,
-                            "label": "msg",
-                            "varName": "msg",
-                            "portType": "",
-                            "dataType": "any"
-                        },
-                        {
-                            "id": "9c26ca12-7980-4bed-9a9a-1f896cd5c1e9",
-                            "type": "default",
-                            "extras": {},
-                            "x": 582.78125,
-                            "y": 340,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "4109f066-62e2-4c2c-83cc-f857608f1014",
-                            "links": [],
-                            "in": false,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        }
-                    ],
-                    "name": "Print",
-                    "color": "rgb(255,204,0)",
-                    "portsInOrder": [
-                        "14d0ef6d-2104-4133-976f-e7fd434fa01a",
-                        "f1ff06cc-66b7-4225-b9b5-35d07fd4ed0a"
-                    ],
-                    "portsOutOrder": [
-                        "9c26ca12-7980-4bed-9a9a-1f896cd5c1e9"
-                    ]
-                },
                 "0ad4befa-2216-4019-82b1-7b5c94640241": {
                     "id": "0ad4befa-2216-4019-82b1-7b5c94640241",
                     "type": "custom-node",
@@ -1055,8 +538,8 @@
                             "id": "36d144cf-c9d3-4740-8bc1-22892b751219",
                             "type": "default",
                             "extras": {},
-                            "x": 80.28125,
-                            "y": 452,
+                            "x": 80.28127612876247,
+                            "y": 451.99999060997595,
                             "name": "out-0",
                             "alignment": "right",
                             "parentNode": "0ad4befa-2216-4019-82b1-7b5c94640241",
@@ -1091,8 +574,8 @@
                             "id": "0673aa39-2a54-4011-b722-f2fc6dd4e0f8",
                             "type": "default",
                             "extras": {},
-                            "x": 79.28125,
-                            "y": 402,
+                            "x": 79.28123856866632,
+                            "y": 401.99999060997595,
                             "name": "out-0",
                             "alignment": "right",
                             "parentNode": "0d68b66a-d1a9-46dc-b078-22c397062ef8",
@@ -1118,17 +601,18 @@
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
-                        "type": "int"
+                        "type": "int",
+                        "borderColor": "rgb(0,192,255)"
                     },
-                    "x": -164,
-                    "y": 324,
+                    "x": -199.1538461538462,
+                    "y": 217.15384615384616,
                     "ports": [
                         {
                             "id": "ed277422-befe-49c7-ac54-6f552ab97ef4",
                             "type": "default",
                             "extras": {},
-                            "x": -106.71875,
-                            "y": 348,
+                            "x": -141.8593676512855,
+                            "y": 241.14061560997607,
                             "name": "out-0",
                             "alignment": "right",
                             "parentNode": "e7ef03fc-2499-4cae-b2cd-19b58a542853",
@@ -1147,6 +631,856 @@
                     "portsInOrder": [],
                     "portsOutOrder": [
                         "ed277422-befe-49c7-ac54-6f552ab97ef4"
+                    ]
+                },
+                "c2251c90-1e68-424c-b046-bbdca8b12c4c": {
+                    "id": "c2251c90-1e68-424c-b046-bbdca8b12c4c",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "Finish",
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": 643,
+                    "y": 87,
+                    "ports": [
+                        {
+                            "id": "4c53720d-272d-48cb-bba8-00995c39bf07",
+                            "type": "default",
+                            "extras": {},
+                            "x": 643.9999134484738,
+                            "y": 110.9999882624701,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "c2251c90-1e68-424c-b046-bbdca8b12c4c",
+                            "links": [
+                                "f6048c4e-6740-41d1-90d2-11b7a7b31106"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "84b3ed83-1965-4bfe-b211-4396cd99725f",
+                            "type": "default",
+                            "extras": {},
+                            "x": 643.9999134484738,
+                            "y": 132.99998121995205,
+                            "name": "parameter-dynalist-outputs",
+                            "alignment": "left",
+                            "parentNode": "c2251c90-1e68-424c-b046-bbdca8b12c4c",
+                            "links": [],
+                            "in": true,
+                            "label": "outputs",
+                            "varName": "outputs",
+                            "portType": "",
+                            "dataType": "dynalist",
+                            "dynaPortOrder": 0,
+                            "dynaPortRef": {
+                                "previous": null,
+                                "next": "37d83fb3-7df1-448c-abb9-0ba34dcf0a32"
+                            }
+                        }
+                    ],
+                    "name": "Finish",
+                    "color": "rgb(255,102,102)",
+                    "portsInOrder": [
+                        "4c53720d-272d-48cb-bba8-00995c39bf07",
+                        "84b3ed83-1965-4bfe-b211-4396cd99725f"
+                    ],
+                    "portsOutOrder": []
+                },
+                "2b131fe6-efc7-4d4f-867f-927fbb1a5884": {
+                    "id": "2b131fe6-efc7-4d4f-867f-927fbb1a5884",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "debug",
+                        "path": "xai_components/xai_utils/utils.py",
+                        "description": "Executes a given body in a separate thread using a thread pool executor.\n\n**Important Note**: Context changes done in the body are not propagated! \nThis includes things like setting variable values.\n\n\n##### inPorts:\n- n_workers: The number of worker threads to use for executing the body in parallel.\n\n##### outPorts:\n- None",
+                        "lineNo": [
+                            {
+                                "lineno": 712,
+                                "end_lineno": 751
+                            }
+                        ],
+                        "sourceBranchId": "5141d7b0-c5f1-47e7-b208-6a44418cd420",
+                        "portId": "5c0591da-0dfc-4aca-924e-50a20fb28983",
+                        "finishNodeId": "None",
+                        "isBranchNode": true,
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": -86.53846153846156,
+                    "y": 187.46153846153845,
+                    "ports": [
+                        {
+                            "id": "340bd492-b03f-4aea-bfc2-e35de417dff4",
+                            "type": "default",
+                            "extras": {},
+                            "x": -85.53124265128554,
+                            "y": 211.45311560997607,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "2b131fe6-efc7-4d4f-867f-927fbb1a5884",
+                            "links": [
+                                "e1541fe3-04a7-40e0-9ef6-21872a678171"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "e39ed6ef-364b-478f-a00e-f4ffee4e9499",
+                            "type": "default",
+                            "extras": {},
+                            "x": -85.53124265128554,
+                            "y": 233.4531203049881,
+                            "name": "parameter-int-n_workers",
+                            "alignment": "left",
+                            "parentNode": "2b131fe6-efc7-4d4f-867f-927fbb1a5884",
+                            "links": [
+                                "6accbdf3-6c10-42c0-b737-c5196433ea0d"
+                            ],
+                            "in": true,
+                            "label": "n_workers",
+                            "varName": "n_workers",
+                            "portType": "",
+                            "dataType": "int"
+                        },
+                        {
+                            "id": "bb4c5b3f-f285-45c6-89cb-8f4c9d67604a",
+                            "type": "default",
+                            "extras": {},
+                            "x": 49.859382348714405,
+                            "y": 211.45311560997607,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "2b131fe6-efc7-4d4f-867f-927fbb1a5884",
+                            "links": [],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "d19d4f99-86f0-4b58-b5cd-d3a2ebe5fbd1",
+                            "type": "default",
+                            "extras": {},
+                            "x": 49.859382348714405,
+                            "y": 233.4531203049881,
+                            "name": "parameter-out-list-futures",
+                            "alignment": "right",
+                            "parentNode": "2b131fe6-efc7-4d4f-867f-927fbb1a5884",
+                            "links": [
+                                "d0a41651-90a3-4827-91ac-29d8a00859dd"
+                            ],
+                            "in": false,
+                            "label": "futures",
+                            "varName": "futures",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "eb0e2108-7efe-437b-badd-8e6bedf1affd",
+                            "type": "default",
+                            "extras": {},
+                            "x": 49.859382348714405,
+                            "y": 255.45312500000009,
+                            "name": "parameter-out-any-future",
+                            "alignment": "right",
+                            "parentNode": "2b131fe6-efc7-4d4f-867f-927fbb1a5884",
+                            "links": [],
+                            "in": false,
+                            "label": "future",
+                            "varName": "future",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "6be808ba-bcef-4731-ab99-2274172d0cb2",
+                            "type": "default",
+                            "extras": {},
+                            "x": 49.859382348714405,
+                            "y": 277.4531296950121,
+                            "name": "out-flow-body",
+                            "alignment": "right",
+                            "parentNode": "2b131fe6-efc7-4d4f-867f-927fbb1a5884",
+                            "links": [
+                                "999a094e-42c4-4d97-9925-13698b0dd975"
+                            ],
+                            "in": false,
+                            "label": "body ▶",
+                            "varName": "body ▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "RunParallelThread",
+                    "color": "blue",
+                    "portsInOrder": [
+                        "340bd492-b03f-4aea-bfc2-e35de417dff4",
+                        "e39ed6ef-364b-478f-a00e-f4ffee4e9499"
+                    ],
+                    "portsOutOrder": [
+                        "bb4c5b3f-f285-45c6-89cb-8f4c9d67604a",
+                        "d19d4f99-86f0-4b58-b5cd-d3a2ebe5fbd1",
+                        "eb0e2108-7efe-437b-badd-8e6bedf1affd",
+                        "6be808ba-bcef-4731-ab99-2274172d0cb2"
+                    ]
+                },
+                "5141d7b0-c5f1-47e7-b208-6a44418cd420": {
+                    "id": "5141d7b0-c5f1-47e7-b208-6a44418cd420",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "debug",
+                        "path": "xai_components/xai_controlflow/branches.py",
+                        "description": null,
+                        "lineNo": [
+                            {
+                                "lineno": 60,
+                                "end_lineno": 77
+                            }
+                        ],
+                        "finishNodeId": "ef83a274-010a-4510-bc09-7e50adb6b62b",
+                        "isBranchNode": true,
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": -380,
+                    "y": 93,
+                    "ports": [
+                        {
+                            "id": "cc627738-2656-4e0f-919e-20b935810e74",
+                            "type": "default",
+                            "extras": {},
+                            "x": -378.9999879562734,
+                            "y": 116.9999906099761,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "5141d7b0-c5f1-47e7-b208-6a44418cd420",
+                            "links": [
+                                "c88a483e-09ec-435d-9f79-086dde8ff320"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "c7851ee5-c162-4394-9e4c-7df28e2e86f6",
+                            "type": "default",
+                            "extras": {},
+                            "x": -378.9999879562734,
+                            "y": 138.99999530498812,
+                            "name": "parameter-list-items",
+                            "alignment": "left",
+                            "parentNode": "5141d7b0-c5f1-47e7-b208-6a44418cd420",
+                            "links": [
+                                "98df1557-ba17-487a-b7f8-111f0a45a564"
+                            ],
+                            "in": true,
+                            "label": "★items",
+                            "varName": "★items",
+                            "portType": "",
+                            "dataType": "list"
+                        },
+                        {
+                            "id": "60162b1d-d213-4d05-b8c6-4f1e19d9b3b8",
+                            "type": "default",
+                            "extras": {},
+                            "x": -225.8906223462975,
+                            "y": 116.9999906099761,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "5141d7b0-c5f1-47e7-b208-6a44418cd420",
+                            "links": [
+                                "8e7a4a5a-3d49-44f9-a6ad-40924f3f59d6"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "5c0591da-0dfc-4aca-924e-50a20fb28983",
+                            "type": "default",
+                            "extras": {},
+                            "x": -225.8906223462975,
+                            "y": 138.99999530498812,
+                            "name": "out-flow-body",
+                            "alignment": "right",
+                            "parentNode": "5141d7b0-c5f1-47e7-b208-6a44418cd420",
+                            "links": [
+                                "e1541fe3-04a7-40e0-9ef6-21872a678171"
+                            ],
+                            "in": false,
+                            "label": "body ▶",
+                            "varName": "body ▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "84abd6b7-b88d-491a-9e36-35b5485b4315",
+                            "type": "default",
+                            "extras": {},
+                            "x": -225.8906223462975,
+                            "y": 161.0000000000001,
+                            "name": "parameter-out-any-current_item",
+                            "alignment": "right",
+                            "parentNode": "5141d7b0-c5f1-47e7-b208-6a44418cd420",
+                            "links": [
+                                "2a2711c9-f8d9-4fe3-b068-6b562d62972a"
+                            ],
+                            "in": false,
+                            "label": "current_item",
+                            "varName": "current_item",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "c30fab1a-60b7-4701-8241-c2fa6cb23684",
+                            "type": "default",
+                            "extras": {},
+                            "x": -225.8906223462975,
+                            "y": 182.99998121995205,
+                            "name": "parameter-out-int-current_index",
+                            "alignment": "right",
+                            "parentNode": "5141d7b0-c5f1-47e7-b208-6a44418cd420",
+                            "links": [],
+                            "in": false,
+                            "label": "current_index",
+                            "varName": "current_index",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "ForEach",
+                    "color": "rgb(0,102,204)",
+                    "portsInOrder": [
+                        "cc627738-2656-4e0f-919e-20b935810e74",
+                        "c7851ee5-c162-4394-9e4c-7df28e2e86f6"
+                    ],
+                    "portsOutOrder": [
+                        "60162b1d-d213-4d05-b8c6-4f1e19d9b3b8",
+                        "5c0591da-0dfc-4aca-924e-50a20fb28983",
+                        "84abd6b7-b88d-491a-9e36-35b5485b4315",
+                        "c30fab1a-60b7-4701-8241-c2fa6cb23684"
+                    ]
+                },
+                "129162da-8768-41cf-938c-3fe3fd73f07f": {
+                    "id": "129162da-8768-41cf-938c-3fe3fd73f07f",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "debug",
+                        "path": "xai_components/xai_utils/utils.py",
+                        "description": "Generates a random number between the specified bounds.\n\n##### inPorts:\n- greater_than: The lower bound for the random number (inclusive).\n- less_than: The upper bound for the random number (exclusive).\n\n##### outPorts:\n- value: The generated random number.",
+                        "lineNo": [
+                            {
+                                "lineno": 691,
+                                "end_lineno": 708
+                            }
+                        ],
+                        "sourceBranchId": "2b131fe6-efc7-4d4f-867f-927fbb1a5884",
+                        "portId": "6be808ba-bcef-4731-ab99-2274172d0cb2"
+                    },
+                    "x": 160,
+                    "y": 357,
+                    "ports": [
+                        {
+                            "id": "16d06106-81e6-4d63-ac1f-071980af9582",
+                            "type": "default",
+                            "extras": {},
+                            "x": 160.99998856866628,
+                            "y": 381.00000000000006,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "129162da-8768-41cf-938c-3fe3fd73f07f",
+                            "links": [
+                                "999a094e-42c4-4d97-9925-13698b0dd975"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "1bfd0b11-543c-4e30-b8de-ab609456b5d4",
+                            "type": "default",
+                            "extras": {},
+                            "x": 160.99998856866628,
+                            "y": 402.9999812199519,
+                            "name": "parameter-int-greater_than",
+                            "alignment": "left",
+                            "parentNode": "129162da-8768-41cf-938c-3fe3fd73f07f",
+                            "links": [
+                                "46d4ae56-8fec-4ae1-be63-0ca5041bc088"
+                            ],
+                            "in": true,
+                            "label": "★greater_than",
+                            "varName": "★greater_than",
+                            "portType": "",
+                            "dataType": "int"
+                        },
+                        {
+                            "id": "eda07ee2-c588-4cfe-8955-17f7e0775980",
+                            "type": "default",
+                            "extras": {},
+                            "x": 160.99998856866628,
+                            "y": 425.000009390024,
+                            "name": "parameter-int-less_than",
+                            "alignment": "left",
+                            "parentNode": "129162da-8768-41cf-938c-3fe3fd73f07f",
+                            "links": [
+                                "e29e880d-6963-4c5b-8f36-9629df6411c6"
+                            ],
+                            "in": true,
+                            "label": "★less_than",
+                            "varName": "★less_than",
+                            "portType": "",
+                            "dataType": "int"
+                        },
+                        {
+                            "id": "4f197b8c-c35b-4d8f-9815-06f682c5dc47",
+                            "type": "default",
+                            "extras": {},
+                            "x": 309.84374795869024,
+                            "y": 381.00000000000006,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "129162da-8768-41cf-938c-3fe3fd73f07f",
+                            "links": [
+                                "8541f82e-3faf-41c6-83e9-2efb635d590d"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "257a9118-1d57-4051-8857-547b8459bcbe",
+                            "type": "default",
+                            "extras": {},
+                            "x": 309.84374795869024,
+                            "y": 402.9999812199519,
+                            "name": "parameter-out-int-value",
+                            "alignment": "right",
+                            "parentNode": "129162da-8768-41cf-938c-3fe3fd73f07f",
+                            "links": [
+                                "961d8378-bcef-4be3-aa8e-bc92025f789d"
+                            ],
+                            "in": false,
+                            "label": "value",
+                            "varName": "value",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "GetRandomNumber",
+                    "color": "rgb(255,153,102)",
+                    "portsInOrder": [
+                        "16d06106-81e6-4d63-ac1f-071980af9582",
+                        "1bfd0b11-543c-4e30-b8de-ab609456b5d4",
+                        "eda07ee2-c588-4cfe-8955-17f7e0775980"
+                    ],
+                    "portsOutOrder": [
+                        "4f197b8c-c35b-4d8f-9815-06f682c5dc47",
+                        "257a9118-1d57-4051-8857-547b8459bcbe"
+                    ]
+                },
+                "c5e10350-41b7-4f15-b571-371fa1e0fbd2": {
+                    "id": "c5e10350-41b7-4f15-b571-371fa1e0fbd2",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "debug",
+                        "path": "xai_components/xai_utils/utils.py",
+                        "description": "Pauses the python process.\n\n##### inPorts:\n- sleep_timer: the number of seconds to pause.\n    Default `5.0` seconds.",
+                        "lineNo": [
+                            {
+                                "lineno": 335,
+                                "end_lineno": 348
+                            }
+                        ]
+                    },
+                    "x": 355.15384615384613,
+                    "y": 357.07692307692304,
+                    "ports": [
+                        {
+                            "id": "2359e786-e909-443d-b2f3-9811937c5178",
+                            "type": "default",
+                            "extras": {},
+                            "x": 356.14060417864215,
+                            "y": 381.062490609976,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "c5e10350-41b7-4f15-b571-371fa1e0fbd2",
+                            "links": [
+                                "8541f82e-3faf-41c6-83e9-2efb635d590d"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "26c5f968-ac72-4047-ac13-62f9a9549b07",
+                            "type": "default",
+                            "extras": {},
+                            "x": 356.14060417864215,
+                            "y": 403.06247182992786,
+                            "name": "parameter-float-sleep_timer",
+                            "alignment": "left",
+                            "parentNode": "c5e10350-41b7-4f15-b571-371fa1e0fbd2",
+                            "links": [
+                                "961d8378-bcef-4be3-aa8e-bc92025f789d"
+                            ],
+                            "in": true,
+                            "label": "sleep_timer",
+                            "varName": "sleep_timer",
+                            "portType": "",
+                            "dataType": "float"
+                        },
+                        {
+                            "id": "52b70132-5963-4dab-bf95-68f6ab52bd9c",
+                            "type": "default",
+                            "extras": {},
+                            "x": 464.1561634484739,
+                            "y": 381.062490609976,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "c5e10350-41b7-4f15-b571-371fa1e0fbd2",
+                            "links": [
+                                "0c54e7aa-1dfa-473d-ac04-ca3e40512c85"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "SleepComponent",
+                    "color": "green",
+                    "portsInOrder": [
+                        "2359e786-e909-443d-b2f3-9811937c5178",
+                        "26c5f968-ac72-4047-ac13-62f9a9549b07"
+                    ],
+                    "portsOutOrder": [
+                        "52b70132-5963-4dab-bf95-68f6ab52bd9c"
+                    ]
+                },
+                "67f85ef9-0410-4067-b9b1-b5c54b46a0ed": {
+                    "id": "67f85ef9-0410-4067-b9b1-b5c54b46a0ed",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "debug",
+                        "path": "xai_components/xai_utils/utils.py",
+                        "description": "Prints a message to the console.\n\n##### inPorts:\n- msg: The message to be printed.",
+                        "lineNo": [
+                            {
+                                "lineno": 57,
+                                "end_lineno": 66
+                            }
+                        ],
+                        "sourceBranchId": "eb60672f-42e3-4d7b-bb64-d03aa0f44c1a",
+                        "portId": "5f5d0880-a10e-4bae-9c1f-acfb0bd40990",
+                        "nextNode": "None"
+                    },
+                    "x": 714.8461538461538,
+                    "y": 400.9230769230769,
+                    "ports": [
+                        {
+                            "id": "0c8ddacc-0227-4bb2-ba0e-66e0402ce3f0",
+                            "type": "default",
+                            "extras": {},
+                            "x": 715.843738568666,
+                            "y": 424.921884390024,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "67f85ef9-0410-4067-b9b1-b5c54b46a0ed",
+                            "links": [
+                                "1c9336d9-3799-4aa9-9112-7ca9e92b8ad1"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "b2d0bb34-e798-41ad-8900-cac09e8614fc",
+                            "type": "default",
+                            "extras": {},
+                            "x": 715.843738568666,
+                            "y": 446.92186560997595,
+                            "name": "parameter-any-msg",
+                            "alignment": "left",
+                            "parentNode": "67f85ef9-0410-4067-b9b1-b5c54b46a0ed",
+                            "links": [
+                                "2a2711c9-f8d9-4fe3-b068-6b562d62972a"
+                            ],
+                            "in": true,
+                            "label": "msg",
+                            "varName": "msg",
+                            "portType": "",
+                            "dataType": "any"
+                        },
+                        {
+                            "id": "7abbbd25-23ee-41eb-85c7-0c0e0e3a89af",
+                            "type": "default",
+                            "extras": {},
+                            "x": 787.6250261287622,
+                            "y": 424.921884390024,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "67f85ef9-0410-4067-b9b1-b5c54b46a0ed",
+                            "links": [],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "Print",
+                    "color": "rgb(204,204,204)",
+                    "portsInOrder": [
+                        "0c8ddacc-0227-4bb2-ba0e-66e0402ce3f0",
+                        "b2d0bb34-e798-41ad-8900-cac09e8614fc"
+                    ],
+                    "portsOutOrder": [
+                        "7abbbd25-23ee-41eb-85c7-0c0e0e3a89af"
+                    ]
+                },
+                "eb60672f-42e3-4d7b-bb64-d03aa0f44c1a": {
+                    "id": "eb60672f-42e3-4d7b-bb64-d03aa0f44c1a",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "debug",
+                        "path": "xai_components/xai_utils/utils.py",
+                        "description": "Executes a given body in a separate thread using a thread pool executor.\n\n**Important Note**: Context changes done in the body are not propagated! \nThis includes things like setting variable values.\n\n\n##### inPorts:\n- n_workers: The number of worker threads to use for executing the body in parallel.\n\n##### outPorts:\n- None",
+                        "lineNo": [
+                            {
+                                "lineno": 712,
+                                "end_lineno": 751
+                            }
+                        ],
+                        "finishNodeId": "None",
+                        "isBranchNode": true,
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": 507.30769230769226,
+                    "y": 357.15384615384613,
+                    "ports": [
+                        {
+                            "id": "bbca24e7-4b98-4c30-8307-3773062305b2",
+                            "type": "default",
+                            "extras": {},
+                            "x": 508.2967884484739,
+                            "y": 381.140615609976,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "eb60672f-42e3-4d7b-bb64-d03aa0f44c1a",
+                            "links": [
+                                "0c54e7aa-1dfa-473d-ac04-ca3e40512c85"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "48c83e44-a8d6-4709-9f47-d31fd9586e3d",
+                            "type": "default",
+                            "extras": {},
+                            "x": 508.2967884484739,
+                            "y": 403.14059682992786,
+                            "name": "parameter-int-n_workers",
+                            "alignment": "left",
+                            "parentNode": "eb60672f-42e3-4d7b-bb64-d03aa0f44c1a",
+                            "links": [],
+                            "in": true,
+                            "label": "n_workers",
+                            "varName": "n_workers",
+                            "portType": "",
+                            "dataType": "int"
+                        },
+                        {
+                            "id": "ad52a90c-0095-420d-9dc7-7e09769a9e89",
+                            "type": "default",
+                            "extras": {},
+                            "x": 643.6874134484738,
+                            "y": 381.140615609976,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "eb60672f-42e3-4d7b-bb64-d03aa0f44c1a",
+                            "links": [],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "52f81c6e-16e9-47d7-abad-9733f05fd802",
+                            "type": "default",
+                            "extras": {},
+                            "x": 643.6874134484738,
+                            "y": 403.14059682992786,
+                            "name": "parameter-out-list-futures",
+                            "alignment": "right",
+                            "parentNode": "eb60672f-42e3-4d7b-bb64-d03aa0f44c1a",
+                            "links": [],
+                            "in": false,
+                            "label": "futures",
+                            "varName": "futures",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "4f60ea1d-9eee-4a61-859b-9a66e7369fb5",
+                            "type": "default",
+                            "extras": {},
+                            "x": 643.6874134484738,
+                            "y": 425.140625,
+                            "name": "parameter-out-any-future",
+                            "alignment": "right",
+                            "parentNode": "eb60672f-42e3-4d7b-bb64-d03aa0f44c1a",
+                            "links": [],
+                            "in": false,
+                            "label": "future",
+                            "varName": "future",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "5f5d0880-a10e-4bae-9c1f-acfb0bd40990",
+                            "type": "default",
+                            "extras": {},
+                            "x": 643.6874134484738,
+                            "y": 447.1406062199519,
+                            "name": "out-flow-body",
+                            "alignment": "right",
+                            "parentNode": "eb60672f-42e3-4d7b-bb64-d03aa0f44c1a",
+                            "links": [
+                                "1c9336d9-3799-4aa9-9112-7ca9e92b8ad1"
+                            ],
+                            "in": false,
+                            "label": "body ▶",
+                            "varName": "body ▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "RunParallelThread",
+                    "color": "blue",
+                    "portsInOrder": [
+                        "bbca24e7-4b98-4c30-8307-3773062305b2",
+                        "48c83e44-a8d6-4709-9f47-d31fd9586e3d"
+                    ],
+                    "portsOutOrder": [
+                        "ad52a90c-0095-420d-9dc7-7e09769a9e89",
+                        "52f81c6e-16e9-47d7-abad-9733f05fd802",
+                        "4f60ea1d-9eee-4a61-859b-9a66e7369fb5",
+                        "5f5d0880-a10e-4bae-9c1f-acfb0bd40990"
+                    ]
+                },
+                "ef83a274-010a-4510-bc09-7e50adb6b62b": {
+                    "id": "ef83a274-010a-4510-bc09-7e50adb6b62b",
+                    "type": "custom-node",
+                    "selected": true,
+                    "extras": {
+                        "type": "debug",
+                        "path": "xai_components/xai_utils/utils.py",
+                        "description": null,
+                        "lineNo": [
+                            {
+                                "lineno": 755,
+                                "end_lineno": 760
+                            }
+                        ],
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": 101.05351170568554,
+                    "y": 82.53846153846169,
+                    "ports": [
+                        {
+                            "id": "868fa100-aecd-4178-baae-8080545f5bc0",
+                            "type": "default",
+                            "extras": {},
+                            "x": 102.04688234871439,
+                            "y": 106.53124060997611,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "ef83a274-010a-4510-bc09-7e50adb6b62b",
+                            "links": [
+                                "8e7a4a5a-3d49-44f9-a6ad-40924f3f59d6"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "e3f6a117-a842-48ec-b8b1-1dc1f0e58dd9",
+                            "type": "default",
+                            "extras": {},
+                            "x": 102.04688234871439,
+                            "y": 128.53124530498812,
+                            "name": "parameter-list-futures",
+                            "alignment": "left",
+                            "parentNode": "ef83a274-010a-4510-bc09-7e50adb6b62b",
+                            "links": [
+                                "d0a41651-90a3-4827-91ac-29d8a00859dd"
+                            ],
+                            "in": true,
+                            "label": "★futures",
+                            "varName": "★futures",
+                            "portType": "",
+                            "dataType": "list"
+                        },
+                        {
+                            "id": "64cb8e81-506f-4b03-8d50-7a0099d29830",
+                            "type": "default",
+                            "extras": {},
+                            "x": 195.84373856866628,
+                            "y": 106.53124060997611,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "ef83a274-010a-4510-bc09-7e50adb6b62b",
+                            "links": [
+                                "f6048c4e-6740-41d1-90d2-11b7a7b31106"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "AwaitFutures",
+                    "color": "blue",
+                    "portsInOrder": [
+                        "868fa100-aecd-4178-baae-8080545f5bc0",
+                        "e3f6a117-a842-48ec-b8b1-1dc1f0e58dd9"
+                    ],
+                    "portsOutOrder": [
+                        "64cb8e81-506f-4b03-8d50-7a0099d29830"
                     ]
                 }
             }


### PR DESCRIPTION
# Description

In #332 we added a `RunParallelThread` Component. If within its body another thread is started, we can run into the situation where the interpreter wants to shutdown but there are still futures that need to be executed that in turn want to create more futures. 

That fails with `RuntimeError: cannot schedule new futures after interpreter shutdown`. 

We didn't run into the issue at first, because a Jupyter kernel keeps running until the output panel is closed. But, when we directly run the compiled file from the terminal we can reproduce the exception. 

The solution to the issue is to await the futures before finishing the main thread. We therefore introduce an `AwaitFutures` Component that will wait for a list of futures, and extend `RunParallelThread` to expose both the future it has just created as well as a list of all the futures that particular instance of the component has created. 

To showcase the change, the example has also been updated:
![image](https://github.com/XpressAI/xircuits/assets/509379/4545341a-f1b9-4497-b7b2-9f2486300302)


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [x] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Run the example with AwaitFutures and without it.**


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
