### PR TITLE
Only handle events for the correct widget

### DIFF
--- a/src/XircuitsWidget.tsx
+++ b/src/XircuitsWidget.tsx
@@ -46,7 +46,7 @@ export class XircuitsPanel extends ReactWidget {
     this.triggerLoadingAnimationSignal = options.triggerLoadingAnimationSignal;
     this.reloadAllNodesSignal = options.reloadAllNodesSignal;
     this.toggleAllLinkAnimationSignal = options.toggleAllLinkAnimationSignal;
-    this.xircuitsApp = new XircuitsApplication(this.app, this.shell);
+    this.xircuitsApp = new XircuitsApplication(this.app, this.shell, () => this.parent?.id);
   }
 
   handleEvent(event: Event): void {

--- a/src/commands/CustomActionEvent.tsx
+++ b/src/commands/CustomActionEvent.tsx
@@ -5,6 +5,7 @@ import { commandIDs } from "./CommandIDs";
 
 interface CustomActionEventOptions {
     app: JupyterFrontEnd;
+    getWidgetId: () => string;
 }
 
 export class CustomActionEvent extends Action {
@@ -14,19 +15,19 @@ export class CustomActionEvent extends Action {
             type: InputType.KEY_DOWN,
             fire: (event: ActionEvent<React.KeyboardEvent>) => {
                 const app = options.app;
-                const keyCode = event.event.key;
-                const ctrlKey = event.event.ctrlKey;
-                
-                const executeIf = (condition, command) => {
-                    if(condition){
-                        // @ts-ignore
-                        event.event.stopImmediatePropagation();
-                        app.commands.execute(command)
-                    }
-                }
-
                 // @ts-ignore
-                if (app.shell._tracker._activeWidget && app.shell._tracker._activeWidget.node.contains(event.event.target)){
+                if(app.shell._tracker._activeWidget && options.getWidgetId() === app.shell._tracker._activeWidget.id){
+                    const keyCode = event.event.key;
+                    const ctrlKey = event.event.ctrlKey;
+
+                    const executeIf = (condition, command) => {
+                        if(condition){
+                            // @ts-ignore
+                            event.event.stopImmediatePropagation();
+                            app.commands.execute(command)
+                        }
+                    }
+
                     executeIf(ctrlKey && keyCode === 'z', commandIDs.undo);
                     executeIf(ctrlKey && keyCode === 'y', commandIDs.redo);
                     executeIf(ctrlKey && keyCode === 's', commandIDs.saveXircuit);
@@ -36,7 +37,6 @@ export class CustomActionEvent extends Action {
                     executeIf(keyCode == 'Delete' || keyCode == 'Backspace', commandIDs.deleteEntity);
                 }
             }
-
         });
     }
 }

--- a/src/components/XircuitsApp.ts
+++ b/src/components/XircuitsApp.ts
@@ -23,7 +23,7 @@ export class XircuitsApplication {
 
         protected diagramEngine: SRD.DiagramEngine;
 
-        constructor(app: JupyterFrontEnd, shell: ILabShell) {
+        constructor(app: JupyterFrontEnd, shell: ILabShell, getWidgetId: () => string) {
                 this.diagramEngine = new SRD.DiagramEngine({ registerDefaultZoomCanvasAction: false, registerDefaultDeleteItemsAction: false });
 
                 // Default Factories
@@ -39,7 +39,7 @@ export class XircuitsApplication {
                 this.diagramEngine.getLinkFactories().registerFactory(new ParameterLinkFactory());
                 this.diagramEngine.getLinkFactories().registerFactory(new TriangleLinkFactory());
                 this.diagramEngine.getActionEventBus().registerAction(new CustomPanAndZoomCanvasAction())
-                this.diagramEngine.getActionEventBus().registerAction(new CustomActionEvent({ app }));
+                this.diagramEngine.getActionEventBus().registerAction(new CustomActionEvent({ app, getWidgetId }));
                 this.diagramEngine.getStateMachine().pushState(new CustomDiagramState());
 
 


### PR DESCRIPTION
# Description

We've run into the issue that the xircuits widget would handle event's that aren't meant for it (e.g. copy & paste in a text editor would result in the widget pasting things that may have been copied previously). 

At the core of the issue lies the event handler being attached to document, but as that is being done by the underlying diagram engine, we can't change that as easily. 

As a workaround, we're passing a way to acquire the widget id down to the event handler, so it can check if it is supposed to handle the event. 

We must pass on a function instead of giving it the id directly, because the id isn't yet available during construction.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Manual Test**

    1. Open a Xircuits Diagram, create a node and copy it (no need to paste yet)
    2. Open a Text editor and press CTRL + V
    3. Switch back to the xircuits diagram. Before: you see a pasted node; After: No pasted node. 


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

