### PR TITLE
✨ / ♻️  Add Workflow Component CSS + Refactor Node Widget Code  

### DIFF
--- a/src/components/node/CustomNodeWidget.tsx
+++ b/src/components/node/CustomNodeWidget.tsx
@@ -3,14 +3,14 @@ import * as _ from 'lodash';
 import { DiagramEngine } from '@projectstorm/react-diagrams-core';
 import { DefaultNodeModel } from '@projectstorm/react-diagrams';
 import styled from '@emotion/styled';
-import Toggle from 'react-toggle'
+import Toggle from 'react-toggle';
 import { ILabShell, JupyterFrontEnd } from '@jupyterlab/application';
 import { CustomPortLabel } from '../port/CustomPortLabel';
 import { Dialog } from '@jupyterlab/apputils';
 import { formDialogWidget } from '../../dialog/formDialogwidget';
 import { showFormDialog } from '../../dialog/FormDialog';
 import { CommentDialog } from '../../dialog/CommentDialog';
-import ReactTooltip from "react-tooltip"
+import ReactTooltip from "react-tooltip";
 import { marked } from 'marked';
 import Color from 'colorjs.io';
 import { commandIDs } from "../../commands/CommandIDs";
@@ -18,41 +18,41 @@ import { commandIDs } from "../../commands/CommandIDs";
 var S;
 (function (S) {
     S.Node = styled.div<{ borderColor: string, background: string; selected: boolean; }>`
-		background-color: ${(p) => {
-        const color = new Color(p.background);
-        color.alpha = 0.75;
-        color.oklch.c *= 1.2;
-        return color.to('oklch').toString();
-    }};
-    box-shadow: 1px 1px 10px ${(p) => p.selected ? '3px rgb(0 192 255 / 0.5)' : '0px rgb(0 0 0 / 0.5)'};
-		border-radius: 5px;
-		font-family: sans-serif;
-		color: white;
-		overflow: visible;
-		font-size: 11px;
-		border: solid 1px ${(p) => (p.selected ? (p.borderColor == undefined ? 'rgb(0,192,255)' : p.borderColor) : 'black')};
-	`;
+        background-color: ${(p) => {
+            const color = new Color(p.background);
+            color.alpha = 0.75;
+            color.oklch.c *= 1.2;
+            return color.to('oklch').toString();
+        }};
+        box-shadow: 1px 1px 10px ${(p) => p.selected ? '3px rgb(0 192 255 / 0.5)' : '0px rgb(0 0 0 / 0.5)'};
+        border-radius: 5px;
+        font-family: sans-serif;
+        color: white;
+        overflow: visible;
+        font-size: 11px;
+        border: solid 1px ${(p) => (p.selected ? (p.borderColor == undefined ? 'rgb(0,192,255)' : p.borderColor) : 'black')};
+    `;
 
     S.Title = styled.div`
-		background: rgba(0, 0, 0, 0.3);
-		display: flex;
-		white-space: nowrap;
-		justify-items: center;
-    box-shadow: inset 0 -2px 4px 0 rgb(0 0 0 / 0.05);  
-	`;
+        background: rgba(0, 0, 0, 0.3);
+        display: flex;
+        white-space: nowrap;
+        justify-items: center;
+        box-shadow: inset 0 -2px 4px 0 rgb(0 0 0 / 0.05);
+    `;
 
     S.TitleName = styled.div`
-		flex-grow: 1;
-		padding: 5px 5px;
-	`;
+        flex-grow: 1;
+        padding: 5px 5px;
+    `;
 
     S.CommentContainer = styled.div<{ selected: boolean; }>`
         background: rgba(0, 0, 0, 0.3);
         border-radius: 5px;
-		font-family: sans-serif;
-		color: rgb(255, 255, 255);
-		border: solid 2px black;
-		font-size: 12px;
+        font-family: sans-serif;
+        color: rgb(255, 255, 255);
+        border: solid 2px black;
+        font-size: 12px;
         border: solid 2px ${(p) => p.selected ? 'rgb(0,192,255)' : 'black'};
         padding: 5px;
     `;
@@ -63,34 +63,34 @@ var S;
         font-family: 'Roboto', sans-serif;
         font-weight: 700;
         font-size: 13px;
-	`;
+    `;
 
     S.Ports = styled.div`
-		display: flex;
-		background-image: linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2));
-	`;
+        display: flex;
+        background-image: linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2));
+    `;
 
     S.PortsContainer = styled.div`
         max-width: 640px;
         white-space: pre;
-		flex-grow: 1;
-		display: flex;
-		flex-direction: column;
+        flex-grow: 1;
+        display: flex;
+        flex-direction: column;
 
-		&:first-of-type {
-			margin-right: 10px;
-		}
+        &:first-of-type {
+            margin-right: 10px;
+        }
 
-		&:only-child {
-			margin-right: 0px;
-		}
-	`;
+        &:only-child {
+            margin-right: 0px;
+        }
+    `;
     S.WorkflowNode = styled(S.Node)`
-    outline: 2px solid rgba(255, 255, 255, 0.5);
-    outline-offset: 8px; // Space between the main node and the outline
+        outline: 2px solid rgba(255, 255, 255, 0.5);
+        outline-offset: 8px; // Space between the main node and the outline
 
-    ${(p) => p.selected && `
-        outline: 2px solid rgba(0, 192, 255, 0.5); // blue
+        ${(p) => p.selected && `
+            outline: 2px solid rgba(0, 192, 255, 0.5); // blue
         `}
     `;
 })(S || (S = {}));
@@ -102,33 +102,61 @@ export interface DefaultNodeProps {
     shell: ILabShell;
 }
 
-const CommentNode = ({ node, handleEditComment }) => (
-    <S.CommentContainer onDoubleClick={handleEditComment} selected={node.isSelected()}>
-        <S.TitleName><b>{node.getOptions().name}</b></S.TitleName>
-        <div className='comment-component-content'>
-            {node['extras']['commentInput']}
-        </div>
-    </S.CommentContainer>
-);
+const CommentNode = ({ node }) => {
+    const [commentInput, setCommentInput] = React.useState(node['extras']['commentInput']);
 
-const ParameterNode = ({ node, engine, handleEditLiteral }) => (
-    <S.Node
-        borderColor={node.getOptions().extras["borderColor"]}
-        data-default-node-name={node.getOptions().name}
-        selected={node.isSelected()}
-        background={node.getOptions().color}
-        onDoubleClick={handleEditLiteral}
-    >
-        <S.Title>
-            <S.TitleName>{node.getOptions().name}</S.TitleName>
-        </S.Title>
-        <S.Ports>
-            <S.PortsContainer>{_.map(node.getInPorts(), port => <CustomPortLabel engine={engine} port={port} key={port.getID()} node={node} />)}</S.PortsContainer>
-            <S.PortsContainer>{_.map(node.getOutPorts(), port => <CustomPortLabel engine={engine} port={port} key={port.getID()} node={node} />)}</S.PortsContainer>
-        </S.Ports>
-    </S.Node>
+    const handleEditComment = async () => {
+        let dialogResult = await showFormDialog({
+            body: formDialogWidget(<CommentDialog commentInput={commentInput} />),
+            buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'Submit' })],
+            focusNodeSelector: 'textarea'
+        });
 
-);
+        if (dialogResult["button"]["label"] === 'Cancel') {
+            return false;
+        }
+
+        const newVal = dialogResult["value"][''];
+        setCommentInput(newVal);
+        node['extras']['commentInput'] = newVal;
+    };
+
+    return (
+        <S.CommentContainer onDoubleClick={handleEditComment} selected={node.isSelected()}>
+            <S.TitleName><b>{node.getOptions().name}</b></S.TitleName>
+            <div className='comment-component-content'>
+                {commentInput}
+            </div>
+        </S.CommentContainer>
+    );
+};
+
+const ParameterNode = ({ node, engine, app }) => {
+    const handleEditLiteral = () => {
+        if (!node.getOptions()["name"].startsWith("Literal")) {
+            return;
+        }
+        app.commands.execute(commandIDs.editNode);
+    };
+
+    return (
+        <S.Node
+            borderColor={node.getOptions().extras["borderColor"]}
+            data-default-node-name={node.getOptions().name}
+            selected={node.isSelected()}
+            background={node.getOptions().color}
+            onDoubleClick={handleEditLiteral}
+        >
+            <S.Title>
+                <S.TitleName>{node.getOptions().name}</S.TitleName>
+            </S.Title>
+            <S.Ports>
+                <S.PortsContainer>{_.map(node.getInPorts(), port => <CustomPortLabel engine={engine} port={port} key={port.getID()} node={node} />)}</S.PortsContainer>
+                <S.PortsContainer>{_.map(node.getOutPorts(), port => <CustomPortLabel engine={engine} port={port} key={port.getID()} node={node} />)}</S.PortsContainer>
+            </S.Ports>
+        </S.Node>
+    );
+};
 
 const StartFinishNode = ({ node, engine, handleDeletableNode }) => (
     <S.Node
@@ -150,7 +178,7 @@ const StartFinishNode = ({ node, engine, handleDeletableNode }) => (
     </S.Node>
 );
 
-const WorkflowNode = ({ node, engine, handleEditLiteral, handleDeletableNode }) => {
+const WorkflowNode = ({ node, engine, handleDeletableNode }) => {
     const elementRef = React.useRef<HTMLElement>(null);
 
     return (
@@ -162,7 +190,6 @@ const WorkflowNode = ({ node, engine, handleEditLiteral, handleDeletableNode }) 
                 data-default-node-name={node.getOptions().name}
                 selected={node.isSelected()}
                 background={node.getOptions().color}
-                onDoubleClick={handleEditLiteral}
             >
                 <S.Title>
                     <S.TitleName>{node.getOptions().name}</S.TitleName>
@@ -179,8 +206,28 @@ const WorkflowNode = ({ node, engine, handleEditLiteral, handleDeletableNode }) 
     );
 };
 
-const ComponentLibraryNode = ({ node, engine, shell, handleEditLiteral, handleDescription, showDescription, descriptionStr, handleDeletableNode, hideErrorTooltip }) => {
+const ComponentLibraryNode = ({ node, engine, shell, handleDeletableNode }) => {
+    const [showDescription, setShowDescription] = React.useState(false);
+    const [descriptionStr, setDescriptionStr] = React.useState("");
     const elementRef = React.useRef<HTMLElement>(null);
+
+    const handleDescription = async () => {
+        setShowDescription(!showDescription);
+        getDescriptionStr();
+        if (elementRef.current) {
+            ReactTooltip.show(elementRef.current);
+        }
+    };
+
+    const getDescriptionStr = () => {
+        let dscrptStr = node['extras']['description'] ?? '***No description provided***';
+        setDescriptionStr(dscrptStr);
+    };
+
+    const hideErrorTooltip = () => {
+        delete node.getOptions().extras["tip"];
+        node.getOptions().extras["borderColor"] = "rgb(0,192,255)";
+    };
 
     return (
         <div style={{ position: "relative" }}>
@@ -205,13 +252,12 @@ const ComponentLibraryNode = ({ node, engine, shell, handleEditLiteral, handleDe
                 data-default-node-name={node.getOptions().name}
                 selected={node.isSelected()}
                 background={node.getOptions().color}
-                onDoubleClick={handleEditLiteral}
             >
                 <S.Title>
                     <S.TitleName>{node.getOptions().name}</S.TitleName>
                     <label data-no-drag>
                         <Toggle className='lock' checked={node.isLocked() ?? false} onChange={event => handleDeletableNode('nodeDeletable', event)} />
-                        <Toggle className='description' name='Description' checked={showDescription ?? false} onChange={event => handleDescription('description', event)} />
+                        <Toggle className='description' name='Description' checked={showDescription ?? false} onChange={handleDescription} />
                     </label>
                 </S.Title>
                 <S.Ports>
@@ -266,19 +312,6 @@ const ComponentLibraryNode = ({ node, engine, shell, handleEditLiteral, handleDe
 };
 
 export class CustomNodeWidget extends React.Component<DefaultNodeProps> {
-    element: React.RefObject<HTMLElement>;
-    state = {
-        nodeDeletable: false,
-        commentInput: this.props.node['extras']['commentInput'],
-        showDescription: false,
-        descriptionStr: "",
-    };
-
-    constructor(props: DefaultNodeProps) {
-        super(props);
-        this.element = React.createRef();
-    }
-
     handleDeletableNode = (key, event) => {
         this.setState({
             [key]: event.target.checked ? this.props.node.setLocked(true) : this.props.node.setLocked(false),
@@ -289,87 +322,38 @@ export class CustomNodeWidget extends React.Component<DefaultNodeProps> {
         this.props.engine.fireEvent({}, 'onChange');
     };
 
-    handleEditLiteral = () => {
-        if (!this.props.node.getOptions()["name"].startsWith("Literal")) {
-            return;
-        }
-        this.props.app.commands.execute(commandIDs.editNode);
-    };
-
-    handleEditComment = async () => {
-        let dialogResult = await showFormDialog({
-            body: formDialogWidget(<CommentDialog commentInput={this.state.commentInput} />),
-            buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'Submit' })],
-            focusNodeSelector: 'textarea'
-        });
-
-        if (dialogResult["button"]["label"] === 'Cancel') {
-            return false;
-        }
-
-        const newVal = dialogResult["value"][''];
-        this.setState({ commentInput: newVal });
-        this.props.node['extras']['commentInput'] = newVal;
-        this.handleOnChangeCanvas();
-    };
-
-    handleDescription = async () => {
-        await this.setState({ showDescription: !this.state.showDescription });
-        this.getDescriptionStr();
-        if (this.element.current) {
-            ReactTooltip.show(this.element.current);
-        }
-    };
-
-    getDescriptionStr = () => {
-        let dscrptStr = this.props.node['extras']['description'] ?? '***No description provided***';
-        this.setState({ descriptionStr: dscrptStr });
-    };
-
-    hideErrorTooltip = () => {
-        delete this.props.node.getOptions().extras["tip"];
-        this.props.node.getOptions().extras["borderColor"] = "rgb(0,192,255)";
-    };
-
     render() {
-        const { node, engine, shell } = this.props;
-        const { showDescription, descriptionStr } = this.state;
+        const { node, engine, app, shell } = this.props;
 
         if (node['extras']['type'] === 'comment') {
-            return <CommentNode node={node} handleEditComment={this.handleEditComment} />;
+            return <CommentNode node={node} />;
         }
 
         if (node.getOptions()["name"].startsWith('Literal') || node.getOptions()["name"].startsWith('Argument')) {
-            return <ParameterNode node={node} engine={engine} handleEditLiteral={this.handleEditLiteral} />;
+            return <ParameterNode node={node} engine={engine} app={app} />;
         }
 
         if (node['extras']['type'] === 'xircuits_workflow') {
-            return <WorkflowNode 
-                node={node} 
-                engine={engine} 
-                handleEditLiteral={this.handleEditLiteral} 
-                handleDeletableNode={this.handleDeletableNode} 
+            return <WorkflowNode
+                node={node}
+                engine={engine}
+                handleDeletableNode={this.handleDeletableNode}
             />;
         }
 
         if (node.getOptions()["name"] === 'Start' || node.getOptions()["name"] === 'Finish') {
-            return <StartFinishNode 
-                node={node} 
-                engine={engine} 
-                handleDeletableNode={this.handleDeletableNode} 
+            return <StartFinishNode
+                node={node}
+                engine={engine}
+                handleDeletableNode={this.handleDeletableNode}
             />;
         }
-        
-        return <ComponentLibraryNode 
-            node={node} 
-            engine={engine} 
-            shell={shell} 
-            handleEditLiteral={this.handleEditLiteral} 
-            handleDescription={this.handleDescription} 
-            showDescription={showDescription} 
-            descriptionStr={descriptionStr} 
-            handleDeletableNode={this.handleDeletableNode} 
-            hideErrorTooltip={this.hideErrorTooltip} 
+
+        return <ComponentLibraryNode
+            node={node}
+            engine={engine}
+            shell={shell}
+            handleDeletableNode={this.handleDeletableNode}
         />;
     }
 }

--- a/src/components/node/CustomNodeWidget.tsx
+++ b/src/components/node/CustomNodeWidget.tsx
@@ -17,20 +17,20 @@ import { commandIDs } from "../../commands/CommandIDs";
 
 var S;
 (function (S) {
-    S.Node = styled.div<{ borderColor:string,background: string; selected: boolean;  }>`
+    S.Node = styled.div<{ borderColor: string, background: string; selected: boolean; }>`
 		background-color: ${(p) => {
         const color = new Color(p.background);
         color.alpha = 0.75;
         color.oklch.c *= 1.2;
         return color.to('oklch').toString();
     }};
-    box-shadow: 1px 1px 10px ${(p) => p.selected ? '3px rgb(0 192 255 / 0.5)' : '0px rgb(0 0 0 / 0.5)'};    
+    box-shadow: 1px 1px 10px ${(p) => p.selected ? '3px rgb(0 192 255 / 0.5)' : '0px rgb(0 0 0 / 0.5)'};
 		border-radius: 5px;
 		font-family: sans-serif;
 		color: white;
 		overflow: visible;
 		font-size: 11px;
-		border: solid 1px ${(p) => (p.selected ? (p.borderColor==undefined? 'rgb(0,192,255)': p.borderColor ):'black')};
+		border: solid 1px ${(p) => (p.selected ? (p.borderColor == undefined ? 'rgb(0,192,255)' : p.borderColor) : 'black')};
 	`;
 
     S.Title = styled.div`
@@ -46,18 +46,18 @@ var S;
 		padding: 5px 5px;
 	`;
 
-    S.CommentContainer = styled.div<{ selected: boolean;  }>`
+    S.CommentContainer = styled.div<{ selected: boolean; }>`
         background: rgba(0, 0, 0, 0.3);
         border-radius: 5px;
 		font-family: sans-serif;
 		color: rgb(255, 255, 255);
 		border: solid 2px black;
 		font-size: 12px;
-        border: solid 2px ${(p) => p.selected ? 'rgb(0,192,255)':'black'};
+        border: solid 2px ${(p) => p.selected ? 'rgb(0,192,255)' : 'black'};
         padding: 5px;
     `;
 
-    S.DescriptionName = styled.div<{ color:string }>`
+    S.DescriptionName = styled.div<{ color: string }>`
         color: ${(p) => p.color ?? 'rgb(0, 0, 0)'};
         text-align: justify;
         font-family: 'Roboto', sans-serif;
@@ -85,282 +85,257 @@ var S;
 			margin-right: 0px;
 		}
 	`;
+    S.WorkflowNode = styled(S.Node)`
+    outline: 2px solid rgba(255, 255, 255, 0.5);
+    outline-offset: 8px; // Space between the main node and the outline
 
+    ${(p) => p.selected && `
+        outline: 2px solid rgba(0, 192, 255, 0.5); // blue
+        `}
+    `;
 })(S || (S = {}));
 
 export interface DefaultNodeProps {
     node: DefaultNodeModel;
     engine: DiagramEngine;
     app: JupyterFrontEnd;
-    shell : ILabShell;
+    shell: ILabShell;
 }
 
-/**
- * Default node that models the DefaultNodeModel. It creates two columns
- * for both all the input ports on the left, and the output ports on the right.
- */
-export class CustomNodeWidget extends React.Component<DefaultNodeProps> {
+const CommentNode = ({ node, handleEditComment }) => (
+    <S.CommentContainer onDoubleClick={handleEditComment} selected={node.isSelected()}>
+        <S.TitleName><b>{node.getOptions().name}</b></S.TitleName>
+        <div className='comment-component-content'>
+            {node['extras']['commentInput']}
+        </div>
+    </S.CommentContainer>
+);
 
-    generatePort = (port) => {
-        return <CustomPortLabel engine={this.props.engine} port={port} key={port.getID()} node={this.props.node} />;
-    };
-    element:Object;
+const ParameterNode = ({ node, engine, handleEditLiteral }) => (
+    <S.Node
+        borderColor={node.getOptions().extras["borderColor"]}
+        data-default-node-name={node.getOptions().name}
+        selected={node.isSelected()}
+        background={node.getOptions().color}
+        onDoubleClick={handleEditLiteral}
+    >
+        <S.Title>
+            <S.TitleName>{node.getOptions().name}</S.TitleName>
+        </S.Title>
+        <S.Ports>
+            <S.PortsContainer>{_.map(node.getInPorts(), port => <CustomPortLabel engine={engine} port={port} key={port.getID()} node={node} />)}</S.PortsContainer>
+            <S.PortsContainer>{_.map(node.getOutPorts(), port => <CustomPortLabel engine={engine} port={port} key={port.getID()} node={node} />)}</S.PortsContainer>
+        </S.Ports>
+    </S.Node>
+
+);
+
+const WorkflowNode = ({ node, engine, handleEditLiteral, handleDescription, showDescription, descriptionStr }) => (
+    <div style={{ position: "relative" }}>
+        {showDescription && <div className="description-tooltip">
+            <div data-no-drag style={{ cursor: "default" }}>
+                <button type="button" className="close" data-dismiss="modal" aria-label="Close" onClick={handleDescription}>
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <S.DescriptionName color={node.getOptions().color}>{node.getOptions().name}</S.DescriptionName>
+                <div className="scrollable" onWheel={(e) => { e.stopPropagation(); e.currentTarget.scrollBy(e.deltaX, e.deltaY); }}>
+                    <p className="description-title">Description:</p>
+                    <div className="description-container">
+                        <div className="markdown-body" dangerouslySetInnerHTML={{ __html: marked(descriptionStr ?? '') }} />
+                    </div>
+                </div>
+            </div>
+        </div>}
+        <S.WorkflowNode
+            borderColor={node.getOptions().extras["borderColor"]}
+            data-default-node-name={node.getOptions().name}
+            selected={node.isSelected()}
+            background={node.getOptions().color}
+            onDoubleClick={handleEditLiteral}
+        >
+            <S.Title>
+                <S.TitleName>{node.getOptions().name}</S.TitleName>
+                <label data-no-drag>
+                    <Toggle className='lock' checked={node.isLocked()} onChange={() => handleDescription('nodeDeletable')} />
+                    <Toggle className='description' name='Description' checked={showDescription} onChange={handleDescription} />
+                </label>
+            </S.Title>
+            <S.Ports>
+                <S.PortsContainer>{_.map(node.getInPorts(), port => <CustomPortLabel engine={engine} port={port} key={port.getID()} node={node} />)}</S.PortsContainer>
+                <S.PortsContainer>{_.map(node.getOutPorts(), port => <CustomPortLabel engine={engine} port={port} key={port.getID()} node={node} />)}</S.PortsContainer>
+            </S.Ports>
+        </S.WorkflowNode>
+    </div>
+);
+
+const ComponentLibraryNode = ({ node, engine, shell, handleEditLiteral, handleDescription, showDescription, descriptionStr, handleDeletableNode, hideErrorTooltip }) => {
+    const elementRef = React.useRef<HTMLElement>(null);
+
+    return (
+        <div style={{ position: "relative" }}>
+            {showDescription && <div className="description-tooltip">
+                <div data-no-drag style={{ cursor: "default" }}>
+                    <button type="button" className="close" data-dismiss="modal" aria-label="Close" onClick={handleDescription}>
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                    <S.DescriptionName color={node.getOptions().color}>{node.getOptions().name}</S.DescriptionName>
+                    <div className="scrollable" onWheel={(e) => { e.stopPropagation(); e.currentTarget.scrollBy(e.deltaX, e.deltaY); }}>
+                        <p className="description-title">Description:</p>
+                        <div className="description-container">
+                            <div className="markdown-body" dangerouslySetInnerHTML={{ __html: marked(descriptionStr ?? '') }} />
+                        </div>
+                    </div>
+                </div>
+            </div>}
+            <S.Node
+                ref={elementRef}
+                data-tip data-for={node.getOptions().id}
+                borderColor={node.getOptions().extras["borderColor"]}
+                data-default-node-name={node.getOptions().name}
+                selected={node.isSelected()}
+                background={node.getOptions().color}
+                onDoubleClick={handleEditLiteral}
+            >
+                <S.Title>
+                    <S.TitleName>{node.getOptions().name}</S.TitleName>
+                    <label data-no-drag>
+                        <Toggle className='lock' checked={node.isLocked()} onChange={handleDeletableNode} />
+                        <Toggle className='description' name='Description' checked={showDescription} onChange={handleDescription} />
+                    </label>
+                </S.Title>
+                <S.Ports>
+                    <S.PortsContainer>{_.map(node.getInPorts(), port => <CustomPortLabel engine={engine} port={port} key={port.getID()} node={node} />)}</S.PortsContainer>
+                    <S.PortsContainer>{_.map(node.getOutPorts(), port => <CustomPortLabel engine={engine} port={port} key={port.getID()} node={node} />)}</S.PortsContainer>
+                </S.Ports>
+            </S.Node>
+            {(node.getOptions().extras["tip"] != undefined && node.getOptions().extras["tip"] != "") ?
+                <ReactTooltip
+                    id={node.getOptions().id}
+                    clickable
+                    place="bottom"
+                    className="error-tooltip"
+                    arrowColor="rgba(255, 0, 0, .9)"
+                    delayHide={100}
+                    delayUpdate={50}
+                    getContent={() =>
+                        <div data-no-drag className="error-container">
+                            <p className="error-title">Error</p>
+                            <div className="markdown-body" dangerouslySetInnerHTML={{ __html: marked(node.getOptions().extras["tip"] ?? '') }} />
+                            <button type="button" className="close" data-dismiss="modal" aria-label="Close" onClick={hideErrorTooltip}>
+                                <span aria-hidden="true">&times;</span>
+                            </button>
+                        </div>
+                    }
+                    overridePosition={({ left, top }) => {
+                        const currentNode = node;
+                        const nodeDimension = { x: currentNode.width, y: currentNode.height };
+                        const nodePosition = { x: currentNode.getX(), y: currentNode.getY() };
+                        let newPositionX = nodePosition.x;
+                        let newPositionY = nodePosition.y;
+                        let offset = 0;
+
+                        if (!shell.leftCollapsed) {
+                            let leftSidebar = document.getElementById('jp-left-stack');
+                            offset = leftSidebar.clientWidth + 2;
+                        }
+
+                        newPositionX = newPositionX - 184 + offset + (nodeDimension.x / 2);
+                        newPositionY = newPositionY + 90 + nodeDimension.y;
+
+                        const tooltipPosition = engine.getRelativePoint(newPositionX, newPositionY);
+
+                        left = tooltipPosition.x;
+                        top = tooltipPosition.y;
+                        return { top, left };
+                    }}
+                />
+                : null}
+        </div>
+    );
+};
+
+export class CustomNodeWidget extends React.Component<DefaultNodeProps> {
+    element: React.RefObject<HTMLElement>;
     state = {
         nodeDeletable: false,
         commentInput: this.props.node['extras']['commentInput'],
         showDescription: false,
         descriptionStr: "",
-
     };
 
-    handleDeletableNode(key, event) {
+    constructor(props: DefaultNodeProps) {
+        super(props);
+        this.element = React.createRef();
+    }
+
+    handleDeletableNode = (key, event) => {
         this.setState({
-            [key]: event.target.checked
-                ? this.props.node.setLocked(true)
-                : this.props.node.setLocked(false),
-        })
-    }
+            [key]: event.target.checked ? this.props.node.setLocked(true) : this.props.node.setLocked(false),
+        });
+    };
 
-    handleOnChangeCanvas(){
+    handleOnChangeCanvas = () => {
         this.props.engine.fireEvent({}, 'onChange');
-    }
+    };
 
-    /**
-     * Allow to edit Literal Component
-     */
-    handleEditLiteral() {
+    handleEditLiteral = () => {
         if (!this.props.node.getOptions()["name"].startsWith("Literal")) {
             return;
         }
-        this.props.app.commands.execute(commandIDs.editNode)
-    }
+        this.props.app.commands.execute(commandIDs.editNode);
+    };
 
-    /**
-     * Allow to edit Comment Component
-     */
-    async handleEditComment(){
+    handleEditComment = async () => {
         let dialogResult = await showFormDialog({
-            body: formDialogWidget(
-                    <CommentDialog commentInput={this.state.commentInput}/>
-            ),
-            buttons: [Dialog.cancelButton(), Dialog.okButton({ label: ('Submit') })],
+            body: formDialogWidget(<CommentDialog commentInput={this.state.commentInput} />),
+            buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'Submit' })],
             focusNodeSelector: 'textarea'
-        })
+        });
 
-        if (dialogResult["button"]["label"] == 'Cancel') {
-          // When Cancel is clicked on the dialog, just return
-          return false;
-		    }
+        if (dialogResult["button"]["label"] === 'Cancel') {
+            return false;
+        }
 
-        const newVal = dialogResult["value"]['']
-        //  update value both in internal component state
+        const newVal = dialogResult["value"][''];
         this.setState({ commentInput: newVal });
-        // and in model object
         this.props.node['extras']['commentInput'] = newVal;
         this.handleOnChangeCanvas();
-    }
+    };
 
-    /**
-     * Show/Hide Component's Description Tooltip
-     */
-    async handleDescription() {
+    handleDescription = async () => {
         await this.setState({ showDescription: !this.state.showDescription });
         this.getDescriptionStr();
-        ReactTooltip.show(this.element as Element);
-    }
+        if (this.element.current) {
+            ReactTooltip.show(this.element.current);
+        }
+    };
 
-    renderText = text => {
-        var renderer = new marked.Renderer();
-        renderer.link = function(href, title, text) {
-            var link = marked.Renderer.prototype.link.apply(this, arguments);
-            return link.replace("<a","<a target='_blank'");
-        };
-        marked.setOptions({
-            renderer: renderer
-        });
-        const __html = marked(text ?? '')
-        return { __html }
-    }
-
-    getDescriptionStr() {
+    getDescriptionStr = () => {
         let dscrptStr = this.props.node['extras']['description'] ?? '***No description provided***';
         this.setState({ descriptionStr: dscrptStr });
-    }
+    };
 
-    // Hide Error Tooltip
-    hideErrorTooltip(){
+    hideErrorTooltip = () => {
         delete this.props.node.getOptions().extras["tip"];
-        this.props.node.getOptions().extras["borderColor"]="rgb(0,192,255)";
-    }
-    
+        this.props.node.getOptions().extras["borderColor"] = "rgb(0,192,255)";
+    };
+
     render() {
+        const { node, engine, shell } = this.props;
+        const { showDescription, descriptionStr } = this.state;
 
-        const isCommentNode = this.props.node['extras']['type'] == 'comment';
-        const isLiteralNode = this.props.node.getOptions()["name"].startsWith('Literal');
-        const isArgumentNode = this.props.node.getOptions()["name"].startsWith('Argument');
-
-        if (isCommentNode) {
-            return (
-                <S.CommentContainer
-                    onDoubleClick={this.handleEditComment.bind(this)}
-                    selected={this.props.node.isSelected()}>
-                    <S.TitleName><b>{this.props.node.getOptions().name}</b></S.TitleName>
-                    <div className='comment-component-content'>
-                        {this.state.commentInput}
-                    </div>
-                </S.CommentContainer>
-            );
-        } 
-        else if (isLiteralNode) {
-            return (
-                <S.Node
-                    borderColor={this.props.node.getOptions().extras["borderColor"]}
-                    data-default-node-name={this.props.node.getOptions().name}
-                    selected={this.props.node.isSelected()}
-                    background={this.props.node.getOptions().color}
-                    onDoubleClick={this.handleEditLiteral.bind(this)}>
-                    <S.Title>
-                        <S.TitleName>{this.props.node.getOptions().name}</S.TitleName>
-                    </S.Title>
-                    <S.Ports>
-                        <S.PortsContainer>{_.map(this.props.node.getInPorts(), this.generatePort)}</S.PortsContainer>
-                        <S.PortsContainer>{_.map(this.props.node.getOutPorts(), this.generatePort)}</S.PortsContainer>
-                    </S.Ports>
-                </S.Node>
-            );
+        if (node['extras']['type'] === 'comment') {
+            return <CommentNode node={node} handleEditComment={this.handleEditComment} />;
         }
-        else if (this.props.node.getOptions()["name"] !== 'Start' && this.props.node.getOptions()["name"] !== 'Finish') {
-            return (
-                <div style={{position: "relative"}}>
-                    {/** Description Tooltip */}
-                    {this.state.showDescription && <div className="description-tooltip">
-                        <div data-no-drag style={{ cursor: "default" }}>
-                            <button
-                              type="button"
-                              className="close"
-                              data-dismiss="modal"
-                              aria-label="Close"
-                              onClick={() => {
-                                  this.setState({ showDescription: false });
-                              }}>
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                            <S.DescriptionName color={this.props.node.getOptions().color}>{this.props.node.getOptions()["name"]}</S.DescriptionName>
-                            <div className="scrollable"
-                                 onWheel={(e) => {
-                                  e.stopPropagation();
-                                  e.currentTarget.scrollBy(e.deltaX, e.deltaY);
-                                }}
-                            >
-                                <p className="description-title">Description:</p>
-                                <div
-                                  className="description-container">
-                                    <div className="markdown-body"
-                                         dangerouslySetInnerHTML={this.renderText(this.state.descriptionStr)} />
-                                </div>
-                            </div>
-                        </div>
-                    </div>}
-                    <S.Node
-                      ref={(element) => {
-                          this.element = element;
-                      }}
-                      data-tip data-for={this.props.node.getOptions().id} // Data for tooltip
-                        borderColor={this.props.node.getOptions().extras["borderColor"]}
-                        data-default-node-name={this.props.node.getOptions().name}
-                        selected={this.props.node.isSelected()}
-                        background={this.props.node.getOptions().color}
-                        onDoubleClick={this.handleEditLiteral.bind(this)}>
-                        <S.Title>
-                            <S.TitleName>{this.props.node.getOptions().name}</S.TitleName>
-                            <label data-no-drag>
-                                <Toggle
-                                    className='lock'
-                                    checked={this.props.node.isLocked()}
-                                    onChange={this.handleDeletableNode.bind(this, 'nodeDeletable')}
-                                />
-                                {!isArgumentNode && (
-                                    <Toggle
-                                        className='description'
-                                        name='Description'
-                                        checked={this.state.showDescription}
-                                        onChange={this.handleDescription.bind(this)}
-                                    />
-                                )}
-                            </label>
-                        </S.Title>
-                        <S.Ports>
-                            <S.PortsContainer>{_.map(this.props.node.getInPorts(), this.generatePort)}</S.PortsContainer>
-                            <S.PortsContainer>{_.map(this.props.node.getOutPorts(), this.generatePort)}</S.PortsContainer>
-                        </S.Ports>
-                    </S.Node>
-                    {/** Error Tooltip */}
-                    {(this.props.node.getOptions().extras["tip"] != undefined && this.props.node.getOptions().extras["tip"] != "") ?
-                      <ReactTooltip
-                        id={this.props.node.getOptions().id}
-                        clickable
-                        place="bottom"
-                        className="error-tooltip"
-                        arrowColor="rgba(255, 0, 0, .9)"
-                        delayHide={100}
-                        delayUpdate={50}
-                        getContent={() =>
-                          <div data-no-drag className="error-container">
-                              <p className="error-title">Error</p>
-                              <div className="markdown-body"
-                                   dangerouslySetInnerHTML={this.renderText(this.props.node.getOptions().extras["tip"])} />
-                              <button
-                                type="button"
-                                className="close"
-                                data-dismiss="modal"
-                                aria-label="Close"
-                                        onClick={this.hideErrorTooltip.bind(this)}>
-                                        <span aria-hidden="true">&times;</span>
-                                    </button>
-                                </div>
-                            }
-                            overridePosition={({ left, top }) => {
-                                const currentNode = this.props.node;
-                                const nodeDimension = { x: currentNode.width, y: currentNode.height };
-                                const nodePosition = { x: currentNode.getX(), y: currentNode.getY() };
-                                let newPositionX = nodePosition.x;
-                                let newPositionY = nodePosition.y;
-                                let offset = 0;
 
-                                if (!this.props.shell.leftCollapsed) {
-                                    // Some weird offset happened when left sidebar opened, need to add this
-                                    let leftSidebar = document.getElementById('jp-left-stack');
-                                    offset = leftSidebar.clientWidth + 2;
-                                }
-
-                                newPositionX = newPositionX - 184 + offset + (nodeDimension.x / 2);
-                                newPositionY = newPositionY + 90 + nodeDimension.y;
-
-                                const tooltipPosition = this.props.engine.getRelativePoint(newPositionX, newPositionY);
-
-                                left = tooltipPosition.x;
-                                top = tooltipPosition.y;
-                                return { top, left }
-                            }}
-                        />
-                        : null}
-                </div>
-            );
+        if (node.getOptions()["name"].startsWith('Literal') || node.getOptions()["name"].startsWith('Argument')) {
+            return <ParameterNode node={node} engine={engine} handleEditLiteral={this.handleEditLiteral} />;
         }
-        return (
-            <S.Node
-                borderColor={this.props.node.getOptions().extras["borderColor"]}
-                data-default-node-name={this.props.node.getOptions().name}
-                selected={this.props.node.isSelected()}
-                background={this.props.node.getOptions().color}>
-                <S.Title>
-                    <S.TitleName>{this.props.node.getOptions().name}</S.TitleName>
-                </S.Title>
-                <S.Ports>
-                    <S.PortsContainer>{_.map(this.props.node.getInPorts(), this.generatePort)}</S.PortsContainer>
-                    <S.PortsContainer>{_.map(this.props.node.getOutPorts(), this.generatePort)}</S.PortsContainer>
-                </S.Ports>
-            </S.Node>
-        );
+
+        if (node['extras']['type'] === 'xircuits_workflow') {
+            return <WorkflowNode node={node} engine={engine} handleEditLiteral={this.handleEditLiteral} handleDescription={this.handleDescription} showDescription={showDescription} descriptionStr={descriptionStr} />;
+        }
+
+        return <ComponentLibraryNode node={node} engine={engine} shell={shell} handleEditLiteral={this.handleEditLiteral} handleDescription={this.handleDescription} showDescription={showDescription} descriptionStr={descriptionStr} handleDeletableNode={this.handleDeletableNode} hideErrorTooltip={this.hideErrorTooltip} />;
     }
 }


### PR DESCRIPTION
# Description

As workflow components are unique and integral parts of the system, they require a distinct appearance to differentiate them from other components. 

![0 5 white default blue on select single](https://github.com/XpressAI/xircuits/assets/68586800/91e59593-e071-4604-ad2e-0def50c225a7)

In the process, the node widget code has been significantly refactored. The previous implementation in `CustomNodeWidget` was a monolithic ball of mud, making it difficult to manage and extend. The refactoring process involved breaking down the `CustomNodeWidget` into smaller, more manageable functional components, `CommentNode`, `ParameterNode`, `StartFinishNode`, `WorkflowNode`, and `ComponentLibraryNode`.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Verify that workflow components now have a distinct appearance compared to other nodes.
2.  Verify that the previous functions of nodes are still intact, which includes:
- `CommentNode`: double clicking will update
- `ParameterNode`: double clicking on a Literal will update 
- `StartFinishNode`: does not have a description icon but can be locked (new)
- `WorkflowNode`:  can be locked, does not have description icon.
- `ComponentLibraryNode`: has component description icon, can be locked

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Add if any.
