### PR TITLE
🐛 Fix Library Components + Argument Any Type Checking

### DIFF
--- a/src/components/XircuitsApp.ts
+++ b/src/components/XircuitsApp.ts
@@ -94,7 +94,7 @@ export class XircuitsApplication {
                         for (let portID of node.portsOutOrder) {
                                 const port = node.ports.find(p => p.id === portID);
                                 const position = new Point(port.x, port.y);
-                                newNode.addOutPortEnhance({label: port.label, name: port.name, id: port.id, position});
+                                newNode.addOutPortEnhance({label: port.label, name: port.name, id: port.id, position, dataType: port.dataType});
                         }
                         tempModel.addNode(newNode);
                 }

--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -132,20 +132,22 @@ export  class CustomPortModel extends DefaultPortModel  {
                 targetPort.getNode().setSelected(true);
                 return false;
             }
-
-            let dataType = targetPort.dataType;
-
-            if(!targetPort.isTypeCompatible(thisNodeModelType, dataType)) {
-                // if a list of types is provided for the port, parse it a bit to display it nicer
-                if (dataType.includes(',')) {
-                    dataType = this.parsePortType(dataType);
-                }
-                targetPort.getNode().getOptions().extras["borderColor"] = "red";
-                targetPort.getNode().getOptions().extras["tip"] = `Incorrect data type. Port ${thisLabel} is of type ` + "*`" + dataType + "`*.";
-                targetPort.getNode().setSelected(true);
-                return false;
-            }
         }
+
+        let sourceDataType = thisPort.dataType;
+        let targetDataType = targetPort.dataType;
+
+        if(!targetPort.isTypeCompatible(sourceDataType, targetDataType)) {
+            // if a list of types is provided for the port, parse it a bit to display it nicer
+            if (targetDataType.includes(',')) {
+                targetDataType = this.parsePortType(targetDataType);
+            }
+            targetPort.getNode().getOptions().extras["borderColor"] = "red";
+            targetPort.getNode().getOptions().extras["tip"] = `Incorrect data type. Port ${thisLabel} is of type *\`${targetDataType}\`*. You have provided type *\`${sourceDataType}\`*.`;
+            targetPort.getNode().setSelected(true);
+            return false;
+        }
+        
         this.removeErrorTooltip(this, targetPort);
         return true;
     }
@@ -159,25 +161,25 @@ export  class CustomPortModel extends DefaultPortModel  {
         "secret": ["string", "int", "float"],
     };
 
-    isTypeCompatible(thisNodeModelType, dataType) {
+    isTypeCompatible(sourceDataType, targetDataType) {
         // Check for direct compatibility or 'any' type
-        if (thisNodeModelType === dataType || thisNodeModelType === 'any' || dataType === 'any') {
+        if (sourceDataType === targetDataType || sourceDataType === 'any' || targetDataType === 'any') {
             return true;
         }
 
-        // Check if the thisNodeModelType exists in the compatibility map
-        if (CustomPortModel.typeCompatibilityMap.hasOwnProperty(thisNodeModelType)) {
-            // Get the array of compatible data types for thisNodeModelType
-            const compatibleDataTypes = CustomPortModel.typeCompatibilityMap[thisNodeModelType];
+        // Check if the sourceDataType exists in the compatibility map
+        if (CustomPortModel.typeCompatibilityMap.hasOwnProperty(sourceDataType)) {
+            // Get the array of compatible data types for sourceDataType
+            const compatibleDataTypes = CustomPortModel.typeCompatibilityMap[sourceDataType];
 
-            // Check if dataType is in the array of compatible types
-            if (compatibleDataTypes.includes(dataType)) {
+            // Check if targetDataType is in the array of compatible types
+            if (compatibleDataTypes.includes(targetDataType)) {
                 return true;
             }
         }
 
         // If multiple types are accepted by target node port, check if source port type is among them
-        if (dataType.includes(thisNodeModelType)) {
+        if (targetDataType.includes(sourceDataType)) {
             return true;
         }
 

--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -161,7 +161,7 @@ export  class CustomPortModel extends DefaultPortModel  {
 
     isTypeCompatible(thisNodeModelType, dataType) {
         // Check for direct compatibility or 'any' type
-        if (thisNodeModelType === dataType || dataType === 'any') {
+        if (thisNodeModelType === dataType || thisNodeModelType === 'any' || dataType === 'any') {
             return true;
         }
 


### PR DESCRIPTION
# Description

This PR allows `Argument Any` to be connected to any ports, as it should. It also fixes the port type checks for normal library components. 

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Verify that you can connect `Argument Any` to any port types.
2. Verify that type checks between library components work again. The timer component has a unique port type for testing.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

