### PR TITLE
Copy & Paste support for Attached Literals

### DIFF
--- a/src/dialog/FormDialog.tsx
+++ b/src/dialog/FormDialog.tsx
@@ -106,9 +106,9 @@ const preventDefaultDialogHandler = (
         event.stopPropagation();
         event.preventDefault();
       }
-      // When 'Enter' key is pressed while on input dialog and the input isn't Literal Chat, force focus to submit button
+      // When 'Enter' key is pressed while on input dialog and the input isn't Literal Chat or the attached checkbox, force focus to submit button
       const dialogInput = dialog.node.getElementsByTagName('input')[0];
-      if (dialogInput && dialogInput.name !== 'messages') {
+      if (dialogInput && !['messages', 'attachNode'].includes(dialogInput.name)) {
         await defaultButton.focus();
       }
     } else {

--- a/src/dialog/LiteralInputDialog.tsx
+++ b/src/dialog/LiteralInputDialog.tsx
@@ -63,7 +63,6 @@ export const LiteralInputDialog = ({ title, oldValue, type, inputType, attached,
 	const InputValueDialog = () => {
 		const [attach, setAttach] = useState(attached || false)
 		const InputComponent = inputComponents[inputType === 'textarea' ? inputType.toLowerCase() : type.toLowerCase()];
-		console.log("me seeks", InputComponent, showAttachOption);
 
 		// The `type` prop is now passed to all components
 		const extraProps = { type, inputType };

--- a/src/tray_library/GeneralComponentLib.tsx
+++ b/src/tray_library/GeneralComponentLib.tsx
@@ -24,8 +24,6 @@ export async function handleLiteralInput(nodeName, nodeData, inputValue = "", ty
     let attached = false;
 
     do {
-        console.log("valuexxx", nodeConnections);
-
         const isCreatingNewNode = nodeConnections === 0;
         let dialogOptions = inputDialog({ title, oldValue: inputValue, type, attached: (nodeData.extras?.attached || false ), showAttachOption: !isCreatingNewNode});
         let dialogResult = await showFormDialog(dialogOptions);


### PR DESCRIPTION
# Description

In https://github.com/XpressAI/xircuits/pull/340 we have added support for attached literals. 

However, as @MFA-X-AI has pointed out, we didn't properly support copy & paste on them. Attached literals didn't get copied with the node they were attached to. 

This PR adds this functionality.

## References

- https://github.com/XpressAI/xircuits/pull/340 

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  