### PR TITLE
✨ Add component example template when creating from sidebar interface

### DIFF
--- a/src/commands/LibraryActionCommands.tsx
+++ b/src/commands/LibraryActionCommands.tsx
@@ -51,7 +51,7 @@ export function addLibraryActionCommands(
     })
 
     commands.addCommand(commandIDs.createNewComponentLibrary, {
-        label: "Create new Component Library",
+        label: "Create New Component",
         icon: addIcon,
         execute: async (args) => {
 

--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -205,7 +205,10 @@ export default function Sidebar(props: SidebarProps) {
     const menu = new MenuSvg({ commands: app.commands });
     // Add commands to the menu
     menu.addItem({ command: commandIDs.refreshComponentList });
-    menu.addItem({ command: commandIDs.createNewComponentLibrary });
+    menu.addItem({
+        command: commandIDs.createNewComponentLibrary,
+        args: { componentCode: exampleComponent }
+    });
     menu.addItem({ type: "separator" });
     menu.addItem({ command: commandIDs.toggleDisplayNodesInLibrary });
 
@@ -406,3 +409,25 @@ export default function Sidebar(props: SidebarProps) {
       </Body>
     )
 };
+
+const exampleComponent = `from xai_components.base import InArg, OutArg, InCompArg, Component, BaseComponent, xai_component, dynalist
+
+@xai_component(color='blue')
+class ExampleComponent(Component):
+    """Brief description of the component.
+    
+    ##### inPorts:
+    - input_port (type): Description of input_port.
+
+    ##### outPorts:
+    - output_port (type): Description of output_port.
+
+    """
+    input_port: InArg[type]
+    output_port: OutArg[type]
+    
+    def execute(self, ctx) -> None:
+        input_port = self.input_port.value
+        print(f'The input_port value is {input_port}.')
+        self.output_port.value = input_port
+`


### PR DESCRIPTION
# Description

This PR adds ExampleComponent when creating a new component from the tray sidebar interface.

```
from xai_components.base import InArg, OutArg, InCompArg, Component, BaseComponent, xai_component, dynalist

@xai_component(color='blue')
class ExampleComponent(Component):
    """Brief description of the component.
    
    ##### inPorts:
    - input_port (type): Description of input_port.

    ##### outPorts:
    - output_port (type): Description of output_port.

    """
    input_port: InArg[type]
    output_port: OutArg[type]
    
    def execute(self, ctx) -> None:
        input_port = self.input_port.value
        print(f'The input_port value is {input_port}.')
        self.output_port.value = input_port
```

## References

https://github.com/XpressAI/xircuits/pull/343

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Create a new component. Ensure that the template appears on the text editor. 
2. Drag it in. Ensure that it works.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

