### PR TITLE
🐛 Smart Link Fixes

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -452,19 +452,29 @@ export function addNodeActionCommands(
                 // When node got no outputPort, just return
                 return;
             }
-
+    
+            // Helper function to parse Union types
+            const parseUnionType = (type: string): string[] => {
+                const unionMatch = type.match(/^Union\[(.*)\]$/);
+                if (unionMatch) {
+                    return unionMatch[1].split('|').map(t => t.trim());
+                }
+                return [type];
+            };
+    
             for (let outPortIndex in outPorts) {
                 const outPort = outPorts[outPortIndex];
                 const outPortName = outPort.getOptions()['name'];
                 const outPortLabel = outPort.getOptions()['label'];
                 const outPortType = outPort.getOptions()['dataType'];
                 const outPortLabelArr: string[] = outPortLabel.split('_');
+                const outPortTypes = parseUnionType(outPortType);
     
                 if (outPort.getOptions()['label'] == '▶') {
                     // Skip ▶ outPort
                     continue;
                 }
-
+    
                 // Check if there are existing links from the target port
                 if (Object.keys(outPort.getLinks()).length > 0) {
                     continue;
@@ -476,21 +486,25 @@ export function addNodeActionCommands(
                     const inPortLabel = inPort.getOptions()['label'];
                     const inPortType = inPort.getOptions()['dataType'];
                     const inPortLabelArr: string[] = inPortLabel.split('_');
+                    const inPortTypes = parseUnionType(inPortType);
                     // Compare if there is similarity for each word
                     const intersection = outPortLabelArr.filter(element => inPortLabelArr.includes(element));
-
+    
                     // Check if there are existing links from the source port
                     if (Object.keys(inPort.getLinks()).length > 0) {
                         continue;
                     }
     
                     // Check datatype compatibility
-                    if (outPortType !== inPortType && inPortType !== 'any') {
+                    const typesCompatible = outPortTypes.some(outType => 
+                        inPortTypes.includes(outType) || inPortTypes.includes('any')
+                    );
+                    if (!typesCompatible) {
                         continue;
                     }
     
                     // Check label compatibility or intersection
-                    if ((outPortLabel === inPortLabel && outPortType === inPortType) || intersection.length >= 1) {
+                    if ((outPortLabel === inPortLabel && typesCompatible) || intersection.length >= 1) {
                         const newLink = new DefaultLinkModel();
                         const sourcePort = sourceNode.getPorts()[outPortName];
                         newLink.setSourcePort(sourcePort);

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -457,29 +457,43 @@ export function addNodeActionCommands(
                 const outPort = outPorts[outPortIndex];
                 const outPortName = outPort.getOptions()['name'];
                 const outPortLabel = outPort.getOptions()['label'];
-                const outPortType = outPort.getOptions()['type'];
+                const outPortType = outPort.getOptions()['dataType'];
                 const outPortLabelArr: string[] = outPortLabel.split('_');
+    
                 if (outPort.getOptions()['label'] == '▶') {
                     // Skip ▶ outPort
-                    continue
-                };
+                    continue;
+                }
 
+                // Check if there are existing links from the target port
+                if (Object.keys(outPort.getLinks()).length > 0) {
+                    continue;
+                }
+    
                 for (let inPortIndex in inPorts) {
                     const inPort = inPorts[inPortIndex];
                     const inPortName = inPort.getOptions()['name'];
                     const inPortLabel = inPort.getOptions()['label'];
-                    const inPortType = inPort.getOptions()['type'];
+                    const inPortType = inPort.getOptions()['dataType'];
                     const inPortLabelArr: string[] = inPortLabel.split('_');
                     // Compare if there is similarity for each word
                     const intersection = outPortLabelArr.filter(element => inPortLabelArr.includes(element));
 
-                    if (outPortLabel == inPortLabel && outPortType == inPortType || intersection.length >= 1) {
-                        // Create new link
+                    // Check if there are existing links from the source port
+                    if (Object.keys(inPort.getLinks()).length > 0) {
+                        continue;
+                    }
+    
+                    // Check datatype compatibility
+                    if (outPortType !== inPortType) {
+                        continue;
+                    }
+    
+                    // Check label compatibility or intersection
+                    if ((outPortLabel === inPortLabel && outPortType === inPortType) || intersection.length >= 1) {
                         const newLink = new DefaultLinkModel();
-                        // Set sourcePort
                         const sourcePort = sourceNode.getPorts()[outPortName];
                         newLink.setSourcePort(sourcePort);
-                        // Set targetPort
                         const targetPort = targetNode.getPorts()[inPortName];
                         newLink.setTargetPort(targetPort);
 

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -485,7 +485,7 @@ export function addNodeActionCommands(
                     }
     
                     // Check datatype compatibility
-                    if (outPortType !== inPortType) {
+                    if (outPortType !== inPortType && inPortType !== 'any') {
                         continue;
                     }
     


### PR DESCRIPTION
# Description

The smart link action happens when a flow link is created between two nodes. It autoconnects the two nodes' parameter ports that have a shared string, eg: out_sparksession -> in_sparksession.

This PR updates it so that:
- when a flow link is created, it will check if the port type matches, eg `str`-> `str`, `any` -> `any`
- it will allow port linking if an arbitrary datatype is connected to an `any` type, ie `str` -> `any`. Vice versa does not apply, ie `any` -> x `str`. 

A link should not be created if:
- the port type does not match (with the exception of `any`) 
- the source OR the target port already has a link (previously it would overlay an additional link)

## References

https://github.com/XpressAI/xircuits/pull/153

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Verify the smart link logic:
- type checks
- type checks with `any`
- port connect if already existing link

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
