### PR TITLE
🐛 Union Type Fixes + More Smart Link Fixes

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -483,7 +483,8 @@ export function addNodeActionCommands(
                 for (let inPortIndex in inPorts) {
                     const inPort = inPorts[inPortIndex];
                     const inPortName = inPort.getOptions()['name'];
-                    const inPortLabel = inPort.getOptions()['label'];
+                    // handler for compulsory [★] ports
+                    const inPortLabel = inPort.getOptions()['label'].replace(/★/g, '');
                     const inPortType = inPort.getOptions()['dataType'];
                     const inPortLabelArr: string[] = inPortLabel.split('_');
                     const inPortTypes = parseUnionType(inPortType);

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -485,7 +485,7 @@ export function addNodeActionCommands(
                     const inPortName = inPort.getOptions()['name'];
                     // handler for compulsory [★] ports
                     const inPortLabel = inPort.getOptions()['label'].replace(/★/g, '');
-                    const inPortType = inPort.getOptions()['dataType'];
+                    const inPortType = inPort.getOptions()['dataType'] ?? '';
                     const inPortLabelArr: string[] = inPortLabel.split('_');
                     const inPortTypes = parseUnionType(inPortType);
                     // Compare if there is similarity for each word

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -457,7 +457,7 @@ export function addNodeActionCommands(
             const parseUnionType = (type: string): string[] => {
                 const unionMatch = type.match(/^Union\[(.*)\]$/);
                 if (unionMatch) {
-                    return unionMatch[1].split('|').map(t => t.trim());
+                    return unionMatch[1].split(/[\|,]/).map(t => t.trim());
                 }
                 return [type];
             };

--- a/src/components/port/CustomPortLabel.tsx
+++ b/src/components/port/CustomPortLabel.tsx
@@ -157,7 +157,7 @@ export class CustomPortLabel extends React.Component<CustomPortLabelProps> {
 		} else {
 			portType = portName.split("-")[1];
 		}
-		if (portType.includes(',')) {
+		if (portType.includes('Union')) {
 			portType = 'union';
 		}
 		

--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -76,23 +76,21 @@ export  class CustomPortModel extends DefaultPortModel  {
         if (!port.canLinkToLinkedPort()) {
             return false;
         }
-
-        let canTriangleLinkToTriangle = this.canTriangleLinkToTriangle(this, port);
-
-        if (canTriangleLinkToTriangle == false){
-            port.getNode().getOptions().extras["borderColor"]="red";
-            port.getNode().getOptions().extras["tip"]="Triangle must be linked to triangle.";
-            port.getNode().setSelected(true);
-            console.log("triangle to triangle failed.");
-            //tested
-            return false;
-        }
-
-        let canParameterLinkToPort = this.canParameterLinkToPort(this, port);
-
-        if(canParameterLinkToPort == false){
-            console.log("Parameter Link To Port failed.");
-            return false;
+    
+        // Check if it's a triangle-to-triangle link
+        if (this.options.label.includes('▶') || port.getOptions().label.includes('▶')) {
+            if (!this.canTriangleLinkToTriangle(this, port)) {
+                port.getNode().getOptions().extras["borderColor"]="red";
+                port.getNode().getOptions().extras["tip"]="Triangle must be linked to triangle.";
+                port.getNode().setSelected(true);
+                console.log("triangle to triangle failed.");
+                return false;
+            }
+        } else {
+            // Then check if it's a parameter link
+            if (!this.canParameterLinkToPort(this, port)) {
+                return false;
+            }
         }
 
         let checkLinkDirection = this.checkLinkDirection(this, port);
@@ -132,7 +130,7 @@ export  class CustomPortModel extends DefaultPortModel  {
 
             if (!thisName.startsWith("parameter")){
                 targetPort.getNode().getOptions().extras["borderColor"] = "red";
-                targetPort.getNode().getOptions().extras["tip"] = `Port ${thisLabel} linked is not a parameter, please link a non-parameter node to it.`;
+                targetPort.getNode().getOptions().extras["tip"] = `Port ${thisLabel} linked is not a parameter, please link a ${thisLabel} node to it.`;
                 targetPort.getNode().setSelected(true);
                 return false;
             }

--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -77,13 +77,6 @@ export  class CustomPortModel extends DefaultPortModel  {
             return false;
         }
 
-        let canParameterLinkToPort = this.canParameterLinkToPort(this, port);
-
-        if(canParameterLinkToPort == false){
-            console.log("Parameter Link To Port failed.");
-            return false;
-        }
-
         let canTriangleLinkToTriangle = this.canTriangleLinkToTriangle(this, port);
 
         if (canTriangleLinkToTriangle == false){
@@ -92,6 +85,13 @@ export  class CustomPortModel extends DefaultPortModel  {
             port.getNode().setSelected(true);
             console.log("triangle to triangle failed.");
             //tested
+            return false;
+        }
+
+        let canParameterLinkToPort = this.canParameterLinkToPort(this, port);
+
+        if(canParameterLinkToPort == false){
+            console.log("Parameter Link To Port failed.");
             return false;
         }
 
@@ -137,8 +137,9 @@ export  class CustomPortModel extends DefaultPortModel  {
                 return false;
             }
         }
-
-        let sourceDataType = thisPort.dataType;
+        
+        // Use thisNodeModelType if sourceDataType is an empty string due to old workflow
+        let sourceDataType = thisPort.dataType || thisNodeModelType;
         let targetDataType = targetPort.dataType;
 
         if(!targetPort.isTypeCompatible(sourceDataType, targetDataType)) {

--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -144,8 +144,8 @@ export  class CustomPortModel extends DefaultPortModel  {
 
         if(!targetPort.isTypeCompatible(sourceDataType, targetDataType)) {
             // if a list of types is provided for the port, parse it a bit to display it nicer
-            if (targetDataType.includes(',')) {
-                targetDataType = this.parsePortType(targetDataType);
+            if (targetDataType.includes('Union')) {
+                targetDataType = this.parseUnionPortType(targetDataType);
             }
             targetPort.getNode().getOptions().extras["borderColor"] = "red";
             targetPort.getNode().getOptions().extras["tip"] = `Incorrect data type. Port ${thisLabel} is of type *\`${targetDataType}\`*. You have provided type *\`${sourceDataType}\`*.`;
@@ -170,7 +170,7 @@ export  class CustomPortModel extends DefaultPortModel  {
     parseUnionType = (type: string): string[] => {
         const unionMatch = type.match(/^Union\[(.*)\]$/);
         if (unionMatch) {
-            return unionMatch[1].split('|').map(t => t.trim());
+            return unionMatch[1].split(/[\|,]/).map(t => t.trim());
         }
         return [type];
     }
@@ -378,11 +378,11 @@ export  class CustomPortModel extends DefaultPortModel  {
      * Parsed type looks like: type1 or type2
      * @param portType - unparsed port type (looks like: "Union[type1, type2]")
      */
-    parsePortType = (portType: string) => {
+    parseUnionPortType = (portType: string) => {
         // port type is of form: Union[type1, type2]
         portType = portType.replace('Union', '');    // remove Union word
         portType = portType.replace(/[\[\]]/g, '');  // remove square brackets
-        portType = portType.replace(',', ' or ');
+        portType = portType.replace(/[,|]/g, ' or ');   // replace all commas and pipes with ' or '
         return portType;
     }
 


### PR DESCRIPTION
# Description

This PR fixes the following:

- fix union link logic if passed from non-literal: as node to node parameter linking is now fixed in https://github.com/XpressAI/xircuits/pull/348 , the handling for Union needs to be addressed. This PR now properly parses each type in the Union (ie InArg[Union[str|int]]) and allows linking if one datatype mathces.
- fix smart link not considering compulsory symbol: previously the compulsory [★] affects the smartlinking. Now this PR strips the ★ before matching. 
- fix smart link if using chain linking: as flow ports do not have data types, this PR properly handles it.
- fix union symbol from not appearing in ports: previously Union type was internally set if there's a `.`. This PR properly recognizes it if type `Union` is passed.

## References

https://github.com/XpressAI/xircuits/pull/348

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

- ensure that the union link between nodes work as expected
- ensure taht smart link properly works even with compulsory ports
- ensure that smart link works if using chain linking
- ensure that the union symbol appears on union types

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

