### PR TITLE
🐛 Handle Boolean Arg Parsing in Compiler

### DIFF
--- a/xai_components/base.py
+++ b/xai_components/base.py
@@ -242,3 +242,11 @@ class dynatuple(tuple):
             else:
                 return item
         return tuple(resolve(item) for item in x)
+
+def parse_bool(value):
+    if value is None:
+        return None
+    if value.lower() in ('true', 't', 'yes', 'y', '1'):
+        return True
+    elif value.lower() in ('false', 'f', 'no', 'n', '0'):
+        return False

--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -87,7 +87,7 @@ import sys
     def _generate_fixed_imports(self):
         fixed_imports = """
 from argparse import ArgumentParser
-from xai_components.base import SubGraphExecutor, InArg, OutArg, Component, xai_component
+from xai_components.base import SubGraphExecutor, InArg, OutArg, Component, xai_component, parse_bool
 
 """
         return ast.parse(fixed_imports).body
@@ -377,7 +377,6 @@ if __name__ == '__main__':
         type_mapping = {
             "int": "int",
             "string": "str",
-            "boolean": "bool",
             "float": "float",
             "any": "any"
         }
@@ -392,7 +391,10 @@ parser = ArgumentParser()
         for arg in argument_nodes:
             m = pattern.match(arg.name)
             arg_name = m.group(1)
-            tpl = "parser.add_argument('--%s', type=%s)" % (arg_name, type_mapping[arg.type])
+            if arg.type == "boolean":
+                tpl = "parser.add_argument('--%s', type=parse_bool, default=None, nargs='?', const=True)" % arg_name
+            else:
+                tpl = "parser.add_argument('--%s', type=%s)" % (arg_name, type_mapping[arg.type])
             body.extend(ast.parse(tpl).body)
 
         return body


### PR DESCRIPTION
# Description

The current way the compiler handles boolean arguments looks like this:
```python
parser.add_argument('--testArgs', type=bool)
```

Unfortunately, this means that regardless of what is passed to `--testArgs`, whether it's False or 0, it's first converted to a string and then passed to the `bool()` function, hence always evaluating to True.

This PR adds `parse_bool` to `base.py` to handle this issue. The new implementation looks like this:

```python
parser.add_argument('--testArgs', type=parse_bool, default=None, nargs='?', const=True)
```

What this does:
- It will return False if provided with 'false', 'f', 'no', 'n', or '0' (not case-sensitive).
- If the argument is not provided at all, it will be None.
- If the flag is provided without a value (like just `--testArgs`), it will be True.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [x] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Create a workflow that accepts a boolean argument and prints it, eg

![image](https://github.com/user-attachments/assets/3db77063-9b89-493d-a367-c2a553bc9edb)

Test that:
- It will return False if provided with 'false', 'f', 'no', 'n', or '0' (not case-sensitive).
- If the argument is not provided at all, it will be None.
- If the flag is provided without a value (like just `--testArgs`), it will be True.

Test for both CLI and in Xircuits execute runner interface.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
