### PR TITLE
🐛 Fix Argument CamelCap Handling + Remote Run Input 

### DIFF
--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -715,16 +715,18 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		} else {
 			setRunConfigs("")
 		}
+		
+		const setterByType = {
+			'string': setStringNodes,
+			'int': setIntNodes,
+			'float': setFloatNodes,
+			'boolean': setBoolNodes,
+			'any': setAnyNodes
+		}
+
+		Object.values(setterByType).forEach(set => set([]));
 
 		context.ready.then(() => {
-			const setterByType = {
-				'string': setStringNodes,
-				'int': setIntNodes,
-				'float': setFloatNodes,
-				'boolean': setBoolNodes,
-				'any': setAnyNodes
-			}
-
 
 			if (initialize) {
 				let allNodes = xircuitsApp.getDiagramEngine().getModel().getNodes();
@@ -739,9 +741,6 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 						setterByType[result[1]](nodes => ([...nodes, nodeText[nodeText.length -1]].sort()));
 					}
 				}
-			}
-			else {
-				Object.values(setterByType).forEach(set => set([]));
 			}
 		})
 	}, [initialize, runType]);

--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -797,7 +797,6 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 				.reduce((cmd, param) => {
 					xircuitLogger.info(param + ": " + dialogResult.value[param]);
 					let filteredParam = param.replace(/\s+/g, "_");
-					filteredParam = filteredParam.toLowerCase();
 					return `${cmd} --${filteredParam} ${dialogResult.value[param]}`;
 				}, s);
 		}, "");

--- a/src/dialog/RunDialog.tsx
+++ b/src/dialog/RunDialog.tsx
@@ -69,9 +69,9 @@ export const RunDialog = ({
 
 	return (
 		<form>
-			{childStringNodes.length > 0 ? <h3 style={{ marginTop: 0, marginBottom: 5 }}>Arguments:</h3> : null}
+			{childStringNodes.length > 0 ? <h3 style={runDialogStyle.form.subheader}>Arguments:</h3> : null}
 			<div>{runConfigs.length != 0 ?
-				<><h4 style={{ marginTop: 2, marginBottom: 0 }}>Remote Execution</h4>
+				<><h4 style={runDialogStyle.form.header}>Remote Execution</h4>
 					<div>Available Run Type:
 						<HTMLSelect
 							onChange={(e) => handleTypeChange(e)}
@@ -109,7 +109,7 @@ export const RunDialog = ({
 							value={command}
 							minRows={10}
 							name='command'
-							style={{ width: 350, fontSize: 12 }}
+							style={runDialogStyle.form.textarea}
 							readOnly />
 					</div></>
 				: null}
@@ -127,7 +127,7 @@ export const RunDialog = ({
 			<div>
 				{
 					childBoolNodes.length != 0 ?
-						<><br /><h4 style={{ marginTop: 2, marginBottom: 0 }}>Boolean</h4></> : null
+						<><br /><h4 style={runDialogStyle.form.header}>Boolean</h4></> : null
 				}
 			</div>
 			{childBoolNodes.map((boolNode, i) =>
@@ -146,7 +146,7 @@ export const RunDialog = ({
 			<div>
 				{
 					childIntNodes.length != 0 ?
-						<><br /><h4 style={{ marginTop: 2, marginBottom: 0 }}>Integer</h4></> : null
+						<><br /><h4 style={runDialogStyle.form.header}>Integer</h4></> : null
 				}
 			</div>
 			{childIntNodes.map((intNode, i) =>
@@ -160,43 +160,14 @@ export const RunDialog = ({
 							step={1}
 							precision={0}
 							mobile={true}
-							style={{
-								wrap: {
-									boxShadow: '0 0 1px 1px #fff inset, 1px 1px 5px -1px #000',
-									padding: '2px 2.26ex 2px 2px',
-									borderRadius: '6px 3px 3px 6px',
-									fontSize: 20,
-									width: '60%'
-								},
-								input: {
-									borderRadius: '6px 3px 3px 6px',
-									padding: '0.1ex 1ex',
-									border: '#ccc',
-									marginRight: 4,
-									display: 'block',
-									fontWeight: 100,
-									width: '100%'
-								},
-								plus: {
-									background: 'rgba(255, 255, 255, 100)'
-								},
-								minus: {
-									background: 'rgba(255, 255, 255, 100)'
-								},
-								btnDown: {
-									background: 'rgba(0, 0, 0)'
-								},
-								btnUp: {
-									background: 'rgba(0, 0, 0)'
-								}
-							}}
+							style={runDialogStyle.form}
 						/>
 					</div>
 				</div>)}
 			<div>
 				{
 					childFloatNodes.length != 0 ?
-						<><br /><h4 style={{ marginTop: 2, marginBottom: 0 }}>Float</h4></> : null
+						<><br /><h4 style={runDialogStyle.form.header}>Float</h4></> : null
 				}
 			</div>
 			{childFloatNodes.map((floatNode, i) =>
@@ -210,39 +181,55 @@ export const RunDialog = ({
 							step={0.1}
 							precision={2}
 							mobile={true}
-							style={{
-								wrap: {
-									boxShadow: '0 0 1px 1px #fff inset, 1px 1px 5px -1px #000',
-									padding: '2px 2.26ex 2px 2px',
-									borderRadius: '6px 3px 3px 6px',
-									fontSize: 20,
-									width: '60%'
-								},
-								input: {
-									borderRadius: '6px 3px 3px 6px',
-									padding: '0.1ex 1ex',
-									border: '#ccc',
-									marginRight: 4,
-									display: 'block',
-									fontWeight: 100,
-									width: '100%'
-								},
-								plus: {
-									background: 'rgba(255, 255, 255, 100)'
-								},
-								minus: {
-									background: 'rgba(255, 255, 255, 100)'
-								},
-								btnDown: {
-									background: 'rgba(0, 0, 0)'
-								},
-								btnUp: {
-									background: 'rgba(0, 0, 0)'
-								}
-							}}
+							style={runDialogStyle.form}
 						/>
 					</div>
 				</div>)}
 		</form>
 	);
 }
+
+const runDialogStyle = {
+	form: {
+		wrap: {
+			boxShadow: '0 0 1px 1px #fff inset, 1px 1px 5px -1px #000',
+			padding: '2px 2.26ex 2px 2px',
+			borderRadius: '6px 3px 3px 6px',
+			fontSize: 20,
+			width: '60%'
+		},
+		input: {
+			borderRadius: '6px 3px 3px 6px',
+			padding: '0.1ex 1ex',
+			border: '#ccc',
+			marginRight: 4,
+			display: 'block',
+			fontWeight: 100,
+			width: '100%'
+		},
+		plus: {
+			background: 'rgba(255, 255, 255, 100)'
+		},
+		minus: {
+			background: 'rgba(255, 255, 255, 100)'
+		},
+		btnDown: {
+			background: 'rgba(0, 0, 0)'
+		},
+		btnUp: {
+			background: 'rgba(0, 0, 0)'
+		},
+		textarea: {
+			width: 350,
+			fontSize: 12
+		},
+		header: {
+			marginTop: 2,
+			marginBottom: 0
+		},
+		subheader: {
+			marginTop: 0,
+			marginBottom: 5
+		}
+	}
+};


### PR DESCRIPTION
# Description

This PR fixes:

- duplicate form inputs spawning when toggling remote run dropdown
- camel caps in arguments not handled properly 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

- Drag in an argument component.  Save, compile, run it to see the number of input forms. Toggle the run type. Run it again. Ensure that the number of form inputs are the sam
- Drag in an argument component. Use camelcaps. Compile and run. Verify that the output contains the input provided.


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

This PR is a WIP of a bigger update of updating the remote run feature. 
