### PR TITLE
✨ Add Compile Xircuits to Context Menu

### DIFF
--- a/src/commands/CommandIDs.tsx
+++ b/src/commands/CommandIDs.tsx
@@ -30,6 +30,7 @@ export const commandIDs = {
   connectLinkToObviousPorts: "Xircuit-editor:connect-obvious-link",
   addCommentNode: "Xircuit-editor:add-comment-node",
   compileFile: "Xircuit-editor:compile-file",
+  compileWorkflowFromFileBrowser: "Xircuit-editor:compile-workflow-from-file-browser",
   nextNode: "Xircuit-editor:next-node",
   outputMsg: "Xircuit-log:logOutputMessage",
   executeToOutputPanel: "Xircuit-output-panel:execute",


### PR DESCRIPTION
# Description

This PR allows users to compile a workflow / multiple workflows from the Jupyterlab context menu. Under the hood it calls the xircuits compile backend endpoint. It also pushes the xircuits related context menu to the top.

![Screenshot_20241003_001755](https://github.com/user-attachments/assets/7ceb60d5-e96c-4d57-bbd3-feb924cf8970)

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

### 1: Single Workflow Compilation
1. Boot up **Xircuits**.
2. Right-click any workflow from the file browser to open the context menu.
3. Select **Compile**.
4. Verify the following:
   - **a.** The workflow compiles properly.
   - **b.** The workflow runs as expected.

### 2: Multiple Workflow Compilation
1. Boot up **Xircuits**.
2. Select multiple workflows from the file browser.
3. Right-click to open the context menu.
4. Select **Compile**.
5. Verify the following:
   - **a.** All selected workflows compile properly.
   - **b.** All selected workflows run as expected.


## Tested on?

- [ ] Windows  
- [x] Linux Fedora 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
