### PR TITLE
🐛 Prevent Event Propagation to Other Widgets

### DIFF
--- a/src/commands/CustomActionEvent.tsx
+++ b/src/commands/CustomActionEvent.tsx
@@ -10,23 +10,25 @@ interface CustomActionEventOptions {
 
 export class CustomActionEvent extends Action {
     constructor(options: CustomActionEventOptions) {
-        
         super({
             type: InputType.KEY_DOWN,
             fire: (event: ActionEvent<React.KeyboardEvent>) => {
                 const app = options.app;
                 // @ts-ignore
-                if(app.shell._tracker._activeWidget && options.getWidgetId() === app.shell._tracker._activeWidget.id){
+                if (app.shell._tracker._activeWidget && options.getWidgetId() === app.shell._tracker._activeWidget.id) {
                     const keyCode = event.event.key;
                     const ctrlKey = event.event.ctrlKey;
 
                     const executeIf = (condition, command) => {
-                        if(condition){
-                            // @ts-ignore
-                            event.event.stopImmediatePropagation();
-                            app.commands.execute(command)
+                        if (condition) {
+                            event.event.preventDefault();
+                            event.event.stopPropagation();
+                            if (event.event.nativeEvent) {
+                                event.event.nativeEvent.stopImmediatePropagation();
+                            }
+                            app.commands.execute(command);
                         }
-                    }
+                    };
 
                     executeIf(ctrlKey && keyCode === 'z', commandIDs.undo);
                     executeIf(ctrlKey && keyCode === 'y', commandIDs.redo);


### PR DESCRIPTION
# Description

This PR adds event handling logic to fully stop keyboard event propagation (`preventDefault()`, `stopPropagation()`, `stopImmediatePropagation()`) in `CustomActionEvent`. This ensures key commands like `Ctrl+Z` only affect the active xircuits canvas and do not interfere with other JupyterLab widgets like text editors when they are not active.

## References

https://github.com/XpressAI/xircuits/pull/254

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

   1. Verify that `Ctrl+Z`, `Ctrl+Y`, etc., only impact the active Xircuits canvas.
   2. Confirm that no other JupyterLab widgets, such as the text editor, are affected by key commands while the Xircuits widget is focused.


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
