### PR TITLE
🐛 Raise Exception in Compile Failure

### DIFF
--- a/xircuits/compiler/compiler.py
+++ b/xircuits/compiler/compiler.py
@@ -60,3 +60,4 @@ def recursive_compile(input_file_path, component_python_paths=None, visited_file
         print(f"Compiled {input_file_path} to {py_output_path}")
     except Exception as e:
         print(f"Failed to compile {input_file_path}: {e}")
+        raise ValueError(f"Compilation failed for {input_file_path}. Check your inputs and try again.")


### PR DESCRIPTION
# Description

This PR raises an exception for errors during compilation. Previously, any exceptions that occurred during the compilation process were caught and printed, but the compilation would continue, which could cause issues downstream if the compilation did not complete as expected. The code has been updated to raise a `ValueError` after catching an exception, which will rightfully terminate the process and notify the error.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

To verify this change, the following tests were conducted:

**1. Compilation Test via CLI**

    1. Attempt to compile an uncompleted diagram using the CLI.
    2. Ensure that compilation fails and raises a `ValueError` with the correct message.

**2. Compilation Test via Xircuits Canvas**

    1. Attempt to compile an uncompleted diagram from the Xircuits Canvas.
    2. Verify that the process stops and a `ValueError` is raised, preventing any downstream processes from occurring.

These tests ensure that the compile function now properly halts on exceptions, providing users with clear feedback on compilation issues.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  