### PR TITLE
🐛 Fix CLI Component Library Install when using Github URL

### DIFF
--- a/xircuits/handlers/request_folder.py
+++ b/xircuits/handlers/request_folder.py
@@ -60,7 +60,7 @@ def extract_library_details_from_url(github_url):
         raise ValueError("Invalid GitHub URL format.")
 
     org_name = match.group(1)
-    repo_name = match.group(2).replace('-', '_')
+    repo_name = match.group(2)
     return org_name, repo_name
 
 def clone_repo(github_url, target_path):
@@ -78,7 +78,8 @@ def clone_from_github_url(github_url: str) -> str:
     g = Github()
 
     org_name, repo_name = extract_library_details_from_url(github_url)
-    target_path = f"xai_components/xai_{repo_name}"
+    local_lib_path = repo_name.replace('-', '_')
+    target_path = f"xai_components/xai_{local_lib_path}"
 
     # Retrieve the repository
     try:


### PR DESCRIPTION
# Description

This PR fixes the CLI bug that incorrectly parses component library github URLs that are **not** in our recognized library list, when running
```
xircuits install https://github.com/your-orgs/the-xai-lib-name
```

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [x] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Run xircuits install <github-url> from a url. Confirm that it correctly installs the library. 

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  