### PR TITLE
fix recursive compile not accepting output file paths

### DIFF
--- a/xircuits/compiler/compiler.py
+++ b/xircuits/compiler/compiler.py
@@ -13,7 +13,7 @@ def compile(input_file_path, output_file_path, component_python_paths=None):
     with open(output_file_path, 'w', encoding='utf-8') as out_f:
         generator.generate(out_f)
 
-def recursive_compile(input_file_path, component_python_paths=None, visited_files=None):
+def recursive_compile(input_file_path, output_file_path=None, component_python_paths=None, visited_files=None):
     if component_python_paths is None:
         component_python_paths = {}
     if visited_files is None:
@@ -48,12 +48,16 @@ def recursive_compile(input_file_path, component_python_paths=None, visited_file
                             nested_xircuits_path = py_path.replace('.py', '.xircuits')
                             # Resolve relative paths
                             nested_xircuits_path = os.path.join(os.path.dirname(input_file_path), nested_xircuits_path)
-                            # Recursively compile the nested workflow
-                            recursive_compile(nested_xircuits_path, component_python_paths, visited_files)
+                            # For nested workflows, pass None to keep default .xircuits->.py
+                            recursive_compile(nested_xircuits_path, output_file_path=None, component_python_paths=component_python_paths, visited_files=visited_files)
 
     # Compile the current workflow
-    py_output_path = input_file_path.replace('.xircuits', '.py')
-    # print(f"Compiling {input_file_path} to {py_output_path}")
+    # If 'output_file_path' was provided (top-level file), use it; otherwise default to <filename>.py
+    py_output_path = (
+        output_file_path 
+        if output_file_path 
+        else input_file_path.replace('.xircuits', '.py')
+    )
 
     try:
         compile(input_file_path, py_output_path, component_python_paths=component_python_paths)

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -50,7 +50,12 @@ def cmd_compile(args, extra_args=[]):
         component_paths = json.load(args.python_paths_file)
     
     if args.recursive:
-        recursive_compile(args.source_file, component_python_paths=component_paths)
+        # Pass the user-specified out_file (if any) to recursive_compile
+        recursive_compile(
+            input_file_path=args.source_file,
+            output_file_path=args.out_file,
+            component_python_paths=component_paths
+        )
     else:
         # Single file compilation
         if args.out_file:


### PR DESCRIPTION
## Description

This PR fixes a bug in the recursive compilation process of `.xircuits` files. The bug caused the top-level output file path to be ignored when provided. This fix ensures that the specified top-level output file is respected while nested `.xircuits` files still compile to their default `.py` outputs.

## References

https://github.com/XpressAI/xircuits/commit/6f214150e2296c14e828d07303e52a3c0ff200e4#diff-7c7c35a35c81a91158b78c81534f996f1879c5bf1b737ea70911f77fa816a32cL60-L71

---

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [x] Others - Xircuits CLI

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Tests

    1. Compile a top-level `.xircuits` file with an explicit output file path.
    2. Verify that nested `.xircuits` files compiled to their default `.py` outputs.

## Tested on?

- [x] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

