### PR TITLE
🐛 Add compatibility between secret <-> string, int, float

### DIFF
--- a/src/components/port/CustomPortModel.ts
+++ b/src/components/port/CustomPortModel.ts
@@ -160,8 +160,12 @@ export  class CustomPortModel extends DefaultPortModel  {
     }
 
     static typeCompatibilityMap = {
-        "chat": ["list"],
-        "secret": ["string", "int", "float"],
+        secret: ["string", "integer", "float"],
+        string: ["secret"],
+        integer: ["secret"],
+        float: ["secret"],
+        chat: ["list"],
+        list: ["chat"],
     };
     
     // Helper function to parse Union types


### PR DESCRIPTION
# Description

This PR updates the type compatibility mapping for ports to include bidirectional compatibility between secret types and Literal String/Integer/Float, as well as between chat and list types.

## References

N/A

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Port Connection Testing**

    1. Create nodes with ports of different types
    2. Verify secret ports can connect to/from string/integer/float ports
    3. Verify chat ports can connect to/from list ports
    4. Verify incompatible port types cannot connect

## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  