### PR TITLE
✨ Add Create New Xircuits to Jupyterlab Filebrowser Context Menu

### DIFF
--- a/src/commands/CommandIDs.tsx
+++ b/src/commands/CommandIDs.tsx
@@ -38,6 +38,7 @@ export const commandIDs = {
   createNewComponentLibrary: "Xircuit-editor:new-component-library",
   refreshComponentList: "xircuits-sidebar:refresh-component-list",
   toggleDisplayNodesInLibrary: "xircuits-sidebar:toggle-display-nodes-in-library",
+  createNewXircuitInCurrentDir: "Xircuit-filebrowser:create-new-in-current-dir",
   helpOpenResource: "xircuits-help:open-resource",
   openXircuitsConfiguration: "xircuits-config:open-config",
   fetchRemoteRunConfig: "xircuits-config:fetch-remote-config"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -431,6 +431,50 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       rank: 0
     });
 
+    // Add a command for creating a new Xircuits file when nothing is selected
+    app.commands.addCommand(commandIDs.createNewXircuitInCurrentDir, {
+      label: 'New Xircuits File',
+      icon: xircuitsIcon,
+      caption: 'Create a new Xircuits file in the current directory',
+      execute: async () => {
+        const currentBrowser = browserFactory.tracker.currentWidget;
+        if (!currentBrowser) {
+          console.error("No active file browser found.");
+          return;
+        }
+
+        // Use the docmanager command to generate a new file with an incremented name
+        const model = await app.commands.execute(commandIDs.newDocManager, {
+          path: currentBrowser.model.path,
+          type: "file",
+          ext: ".xircuits"
+        });
+
+        // Create the default Xircuits graph (SRD JSON)
+        const fileContent = createInitXircuits(app, app.shell);
+
+        // Save the new file with Xircuits default content
+        await app.serviceManager.contents.save(model.path, {
+          type: 'file',
+          format: 'text',
+          content: fileContent
+        });
+
+        // Open the newly created Xircuits file in the editor
+        await app.commands.execute(commandIDs.openDocManager, {
+          path: model.path,
+          factory: FACTORY
+        });
+      }
+    });
+
+    // Add the command to the file browser context menu when nothing is selected
+    app.contextMenu.addItem({
+      command: commandIDs.createNewXircuitInCurrentDir,
+      selector: '.jp-DirListing-content',
+      rank: 0
+    });
+
     app.commands.addCommand(commandIDs.openXircuitsConfiguration, {
       label: 'Open Xircuits Configurations',
       icon: xircuitsIcon,


### PR DESCRIPTION
# Description

This PR allows user to create a new Xircuits from the Jupyterlab filebrowser context menu.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Right click on the Jupyterlab file browser. Verify that the Create New Xircuits option is there.
2. Create a new Xircuits using that option. Verify that it works as expected.


## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

