### PR TITLE
✨ Add Run Xircuits Workflow on Terminal Option

### DIFF
--- a/src/commands/CommandIDs.tsx
+++ b/src/commands/CommandIDs.tsx
@@ -35,6 +35,7 @@ export const commandIDs = {
   nextNode: "Xircuit-editor:next-node",
   outputMsg: "Xircuit-log:logOutputMessage",
   executeToOutputPanel: "Xircuit-output-panel:execute",
+  executeToTerminal: "Xircuit-terminal:execute",
   createNewComponentLibrary: "Xircuit-editor:new-component-library",
   refreshComponentList: "xircuits-sidebar:refresh-component-list",
   toggleDisplayNodesInLibrary: "xircuits-sidebar:toggle-display-nodes-in-library",

--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -615,19 +615,30 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			if (runType == 'run') {
 				result = await handleLocalRunDialog();
 				if (result.status === 'ok') {
-					code += "%run " + model_path + result.args;
+				code += "%run " + model_path + result.args;
+				commands.execute(commandIDs.executeToOutputPanel, { code });
 				}
-			} else if (runType == 'remote-run') {
-				result = await handleRemoteRunDialog();
-				if (result.status === 'ok') {
-					code += buildRemoteRunCommand(model_path, result.args);
+				else if (result.status === 'cancelled') {
+				console.log("Run operation cancelled by user.");
 				}
 			}
-	
-			if (result.status === 'ok') {
+			
+			else if (runType == 'remote-run') {
+				result = await handleRemoteRunDialog();
+				if (result.status === 'ok') {
+				code += buildRemoteRunCommand(model_path, result.args);
 				commands.execute(commandIDs.executeToOutputPanel, { code });
-			} else if (result.status === 'cancelled') {
-				console.log("Run operation cancelled by user.");
+				}
+			}
+			
+			else if (runType === 'terminal-run') {
+				commands.execute(commandIDs.executeToTerminal, {
+				python_path: model_path
+				});
+			}
+			
+			else {
+				console.log("Unknown runType or user cancelled.");
 			}
 		})
 	}

--- a/src/components/runner/RunSwitcher.tsx
+++ b/src/components/runner/RunSwitcher.tsx
@@ -42,6 +42,7 @@ export class RunSwitcher extends ReactWidget {
                                 <option value="run" >Local Run</option>
                                 <option value="run-dont-compile">Local Run w/o Compile</option>
                                 <option value="remote-run">Remote Run</option>
+                                <option value="terminal-run">Terminal Run</option>
                             </HTMLSelect>
                         );
                     }
@@ -54,8 +55,9 @@ export class RunSwitcher extends ReactWidget {
                             title={'Select the run type'}
                         >
                             <option value="run" >Local Run</option>
-                            <option value="run-dont-compile">Run w/o Compile</option>
+                            <option value="run-dont-compile">Local Run w/o Compile</option>
                             <option value="remote-run">Remote Run</option>
+                            <option value="terminal-run">Terminal Run</option>
                         </HTMLSelect>
                     );
                 }}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -364,7 +364,7 @@ const xircuits: JupyterFrontEndPlugin<void> = {
         const terminalSession = terminalWidget.content.session;
     
         terminalSession.send({ type: 'stdin', content: [`cd $JUPYTER_SERVER_ROOT\n`] });
-        terminalSession.send({ type: 'stdin', content: [`export PYTHONPATH=$JUPYTER_SERVER_ROOT\n`] });
+        terminalSession.send({ type: 'stdin', content: [`export PYTHONPATH=$JUPYTER_SERVER_ROOT:$PYTHONPATH\n`] });
         terminalSession.send({ type: 'stdin', content: ['python ' + python_path + '\n'] });
       }
     });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -354,6 +354,21 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       },
     });
 
+    app.commands.addCommand(commandIDs.executeToTerminal, {
+      label: 'Run in Terminal',
+      execute: async args => {
+
+        const python_path = (args['python_path'] as string);
+        const terminalWidget = await app.commands.execute('terminal:create-new');
+        app.shell.add(terminalWidget, 'main', { mode: 'split-bottom' });
+        const terminalSession = terminalWidget.content.session;
+    
+        terminalSession.send({ type: 'stdin', content: [`cd $JUPYTER_SERVER_ROOT\n`] });
+        terminalSession.send({ type: 'stdin', content: [`export PYTHONPATH=$JUPYTER_SERVER_ROOT\n`] });
+        terminalSession.send({ type: 'stdin', content: ['python ' + python_path + '\n'] });
+      }
+    });
+    
     // Add a command for compiling a xircuits file from the file browser context menu.
     app.commands.addCommand(commandIDs.compileWorkflowFromFileBrowser, {
       label: 'Compile Xircuits',


### PR DESCRIPTION
# Description

This PR allows users to automatically run a compiled xircuits workflow on the terminal. It will spawn a terminal, cd to the jupyterlab base working dir, export the python path, and run the compiled python workflow there. Useful for workflows that can't run properly on the a single threaded python kernel or workflows with interactivity.

https://github.com/user-attachments/assets/f889a045-ddb0-4cd9-946c-9100edd38707

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Compile a Xircuits workflow. Select the `Run from Terminal` option. Run it.
2. Verify that it works as expected.


## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

