### PR TITLE
Align inputs on the left and outputs on the right.

### DIFF
--- a/src/components/port/CustomPortLabel.tsx
+++ b/src/components/port/CustomPortLabel.tsx
@@ -120,7 +120,7 @@ const PortLabel = ({nodeType, port}) => {
 	}
 
 	return (
-			<S.Label style={{ textAlign: (!port.getOptions().in && port.getOptions().label === '▶') ? 'right' : 'left', cursor: attached ? 'pointer' : 'inherit' }}>
+			<S.Label style={{ textAlign: port.getOptions().in ? 'left' : 'right', cursor: attached ? 'pointer' : 'inherit' }}>
 				{nodeType === LITERAL_SECRET ? "*****" : labelText}
 			</S.Label>
 	);


### PR DESCRIPTION
# Description
This is a simple graphical bug fix.

Before:
![image](https://github.com/user-attachments/assets/5db1ceb5-7384-4bb7-a6fd-d0ceed74701e)

After;
![image](https://github.com/user-attachments/assets/aa916dca-03fe-482a-99a5-28ea89500ef9)

It isn't a huge change, but makes things look the same in the component preview and the canvas. Also start components without any inputs now look a bit less awkward.


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
