### PR TITLE
✨/🐛  Add xircuits Run CLI Command +  Fix Recursive Compile

### DIFF
--- a/src/commands/CommandIDs.tsx
+++ b/src/commands/CommandIDs.tsx
@@ -31,17 +31,18 @@ export const commandIDs = {
   connectLinkToObviousPorts: "Xircuit-editor:connect-obvious-link",
   addCommentNode: "Xircuit-editor:add-comment-node",
   compileFile: "Xircuit-editor:compile-file",
-  compileWorkflowFromFileBrowser: "Xircuit-editor:compile-workflow-from-file-browser",
   nextNode: "Xircuit-editor:next-node",
+  toggleLightMode: "xircuits-editor:toggle-light-mode",
   outputMsg: "Xircuit-log:logOutputMessage",
   executeToOutputPanel: "Xircuit-output-panel:execute",
   executeToTerminal: "Xircuit-terminal:execute",
   createNewComponentLibrary: "Xircuit-editor:new-component-library",
   refreshComponentList: "xircuits-sidebar:refresh-component-list",
   toggleDisplayNodesInLibrary: "xircuits-sidebar:toggle-display-nodes-in-library",
+  compileWorkflowFromFileBrowser: "Xircuit-filebrowser:compile-workflow-from-file-browser",
+  runXircuitsFileFromFileBrowser: "Xircuit-filebrowser:run-workflow-from-file-browser",
   createNewXircuitInCurrentDir: "Xircuit-filebrowser:create-new-in-current-dir",
   helpOpenResource: "xircuits-help:open-resource",
   openXircuitsConfiguration: "xircuits-config:open-config",
-  fetchRemoteRunConfig: "xircuits-config:fetch-remote-config",
-  toggleLightMode: "xircuits-editor:toggle-light-mode"
+  fetchRemoteRunConfig: "xircuits-config:fetch-remote-config"
 };

--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -636,7 +636,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			
 			else if (runType === 'terminal-run') {
 				commands.execute(commandIDs.executeToTerminal, {
-					command: `python ${model_path}`
+					command: `xircuits run ${model_path}`
 				});
 			}
 			

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -416,7 +416,11 @@ const xircuits: JupyterFrontEndPlugin<void> = {
 
     app.commands.addCommand(commandIDs.copyXircuitsToRoot, {
       label: 'Copy To Root Directory',
-      isVisible: () => [...browserFactory.tracker.currentWidget.selectedItems()].length > 0,
+      isVisible: () => {
+        const selectedItems = [...browserFactory.tracker.currentWidget.selectedItems()];
+        // Only show if at least one file's path contains a slash (i.e. not in root)
+        return selectedItems.some(item => item.path.indexOf('/') !== -1);
+      },
       icon: xircuitsIcon,
       execute: async () => {
         const selectedItems = Array.from(browserFactory.tracker.currentWidget.selectedItems());

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -447,9 +447,35 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       }
     });
 
-    // Add the compile command to the context menu of the file browser
+    app.commands.addCommand(commandIDs.runXircuitsFileFromFileBrowser, {
+      label: 'Run Xircuits',
+      icon: xircuitsIcon,
+      isVisible: () => {
+        return [...browserFactory.tracker.currentWidget.selectedItems()]
+          .filter(item => item.type === 'file' && item.path.endsWith('.xircuits'))
+          .length > 0;
+      },
+      execute: async () => {
+        const selectedItems = Array.from(browserFactory.tracker.currentWidget.selectedItems());
+        for (const xircuitsFile of selectedItems) {
+          if (xircuitsFile.path.endsWith('.xircuits')) {
+            await app.commands.execute(commandIDs.executeToTerminal, {
+              command: `xircuits run ${xircuitsFile.path}`
+            });
+          }
+        }
+      }
+    });
+
+    // Add the commands to the context menu of the file browser
     app.contextMenu.addItem({
       command: commandIDs.compileWorkflowFromFileBrowser,
+      selector: '.jp-DirListing-item[data-file-type="xircuits"]',
+      rank: 0
+    });
+
+    app.contextMenu.addItem({
+      command: commandIDs.runXircuitsFileFromFileBrowser,
       selector: '.jp-DirListing-item[data-file-type="xircuits"]',
       rank: 0
     });

--- a/xircuits/compiler/compiler.py
+++ b/xircuits/compiler/compiler.py
@@ -13,21 +13,22 @@ def compile(input_file_path, output_file_path, component_python_paths=None):
     with open(output_file_path, 'w', encoding='utf-8') as out_f:
         generator.generate(out_f)
 
-def recursive_compile(input_file_path, output_file_path=None, component_python_paths=None, visited_files=None):
+def recursive_compile(input_file_path, output_file_path=None, component_python_paths=None, visited_files=None, base_dir=None):
     if component_python_paths is None:
         component_python_paths = {}
     if visited_files is None:
         visited_files = set()
-
-    # Normalize file path
+        
     input_file_path = os.path.abspath(input_file_path)
+    
+    if base_dir is None:
+        base_dir = os.path.dirname(input_file_path)
 
     if input_file_path in visited_files:
         return
 
     visited_files.add(input_file_path)
 
-    # Read the Xircuits workflow file
     try:
         with open(input_file_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
@@ -35,33 +36,35 @@ def recursive_compile(input_file_path, output_file_path=None, component_python_p
         print(f"Error reading {input_file_path}: {e}")
         return
 
-    # Traverse layers to find nested workflows
     if 'layers' in data:
         for layer in data['layers']:
             if 'models' in layer and isinstance(layer['models'], dict):
-                for model in layer['models'].values():
+                for model_key, model in layer['models'].items():
                     extras = model.get('extras', {})
                     if extras.get('type') == "xircuits_workflow":
-                        # Extract and transform the path from .py to .xircuits
                         py_path = extras.get('path')
                         if py_path:
-                            nested_xircuits_path = py_path.replace('.py', '.xircuits')
-                            # Resolve relative paths
-                            nested_xircuits_path = os.path.join(os.path.dirname(input_file_path), nested_xircuits_path)
-                            # For nested workflows, pass None to keep default .xircuits->.py
-                            recursive_compile(nested_xircuits_path, output_file_path=None, component_python_paths=component_python_paths, visited_files=visited_files)
-
-    # Compile the current workflow
-    # If 'output_file_path' was provided (top-level file), use it; otherwise default to <filename>.py
-    py_output_path = (
-        output_file_path 
-        if output_file_path 
-        else input_file_path.replace('.xircuits', '.py')
-    )
-
+                            candidate_py = os.path.normpath(os.path.join(os.path.dirname(input_file_path), py_path))
+                            candidate = candidate_py.replace('.py', '.xircuits')
+                            
+                            if not os.path.exists(candidate):
+                                candidate_py = os.path.normpath(os.path.join(base_dir, py_path))
+                                candidate = candidate_py.replace('.py', '.xircuits')
+                                if not os.path.exists(candidate):
+                                    candidate_py = os.path.normpath(os.path.join(os.path.dirname(input_file_path), os.path.basename(py_path)))
+                                    candidate = candidate_py.replace('.py', '.xircuits')
+                                    if not os.path.exists(candidate):
+                                        candidate = None
+                            
+                            if candidate:
+                                recursive_compile(candidate, output_file_path=None, 
+                                                  component_python_paths=component_python_paths, 
+                                                  visited_files=visited_files, base_dir=base_dir)
+    py_output_path = output_file_path if output_file_path else input_file_path.replace('.xircuits', '.py')
     try:
         compile(input_file_path, py_output_path, component_python_paths=component_python_paths)
         print(f"Compiled {input_file_path} to {py_output_path}")
+
     except Exception as e:
         print(f"Failed to compile {input_file_path}: {e}")
         raise ValueError(f"Compilation failed for {input_file_path}. Check your inputs and try again.")

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -120,8 +120,16 @@ def cmd_compile(args, extra_args=[]):
 def cmd_list_libraries(args, extra_args=[]):
     list_component_library()
 
+def cmd_run(args, extra_args=[]):
+
+    cmd_compile(args, extra_args)
+    
+    output_filename = args.out_file if args.out_file else args.source_file.replace('.xircuits', '.py')
+    
+    run_command = f"python {output_filename} {' '.join(extra_args)}"
+    os.system(run_command)
+
 def main():
-    # Print banner only when executing as a CLI command.
     print(
     '''
     ======================================
@@ -176,6 +184,16 @@ def main():
     list_parser = subparsers.add_parser('list', help='List available component libraries for Xircuits.')
     list_parser.set_defaults(func=cmd_list_libraries)
 
+    # 'run' command.
+    run_parser = subparsers.add_parser('run', help='Compile and run a Xircuits workflow file.')
+    run_parser.add_argument('source_file', type=str, help='Source Xircuits file to compile and run.')
+    run_parser.add_argument('out_file', nargs='?', type=str, help='Optional output Python file.')
+    run_parser.add_argument("--python-paths-file", default=None, type=argparse.FileType('r'),
+                            help="JSON file mapping component names to python paths. e.g. {'MyComponent': '/some/path'}")
+    run_parser.add_argument('--non-recursive', action='store_false', dest='recursive', default=True,
+                            help='Do not recursively compile Xircuits workflow files.')
+    run_parser.set_defaults(func=cmd_run)
+
     args, unknown_args = parser.parse_known_args()
 
     # For any command other than 'init' and 'compile', switch to the xircuits working directory.
@@ -183,7 +201,7 @@ def main():
         working_dir = ensure_xircuits_initialized()
         if working_dir:
             os.chdir(working_dir)
-            print(f"Operating in Xircuits working directory: {working_dir}")
+            print(f"Xircuits computing from: {working_dir}")
 
     if hasattr(args, 'func'):
         args.func(args, unknown_args)

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -44,7 +44,6 @@ def ensure_xircuits_initialized():
     if working_dir is not None:
         # Found xai_components. Now check for .xircuits.
         if not (working_dir / ".xircuits").exists():
-            # print(f"Found 'xai_components' in {working_dir} but missing '.xircuits'. Auto-initializing .xircuits.")
             # Switch to the working directory to initialize .xircuits there.
             os.chdir(working_dir)
             init_xircuits()
@@ -179,8 +178,8 @@ def main():
 
     args, unknown_args = parser.parse_known_args()
 
-    # For any command other than 'init', switch to the xircuits working directory.
-    if args.command != "init":
+    # For any command other than 'init' and 'compile', switch to the xircuits working directory.
+    if args.command not in ("init", "compile"):
         working_dir = ensure_xircuits_initialized()
         if working_dir:
             os.chdir(working_dir)

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -122,9 +122,11 @@ def cmd_list_libraries(args, extra_args=[]):
 
 def cmd_run(args, extra_args=[]):
 
-    cmd_compile(args, extra_args)
-    
-    output_filename = args.out_file if args.out_file else args.source_file.replace('.xircuits', '.py')
+    if args.source_file.endswith('.py'):
+        output_filename = args.source_file
+    else:
+        cmd_compile(args, extra_args)
+        output_filename = args.out_file if args.out_file else args.source_file.replace('.xircuits', '.py')
     
     run_command = f"python {output_filename} {' '.join(extra_args)}"
     os.system(run_command)
@@ -186,7 +188,7 @@ def main():
 
     # 'run' command.
     run_parser = subparsers.add_parser('run', help='Compile and run a Xircuits workflow file.')
-    run_parser.add_argument('source_file', type=str, help='Source Xircuits file to compile and run.')
+    run_parser.add_argument('source_file', type=str, help='Source Xircuits file to compile and run (or a Python file to run directly).')
     run_parser.add_argument('out_file', nargs='?', type=str, help='Optional output Python file.')
     run_parser.add_argument("--python-paths-file", default=None, type=argparse.FileType('r'),
                             help="JSON file mapping component names to python paths. e.g. {'MyComponent': '/some/path'}")


### PR DESCRIPTION
# Description

This PR introduces several improvements to Xircuits workflow execution and compilation:

1. Added a new `xircuits run` CLI command for direct workflow execution. You can pass `xircuits run workflow.xircuits` or `workflow.py`. If the former, it will compile it first.
2. Enhanced FileBrowser integration with new "Run Xircuits" context menu option
3. Made "Copy to Root" option only visible for non-root workflows
4. Fix recursive compilation to better handle working directories (previously it it was run from a non-base working dir, it wouldn't work as expected)
5. Modified working directory detection to use xai_components as the main reference
6. Updated terminal execution to use the new `xircuits run` command

These changes make workflow execution more streamlined and intuitive while fixing some path-related issues in compilation.

## References

N/A

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change
- [ ] This change requires a documentation update

# Tests

**1. Test CLI Command**
1. Run `xircuits run workflow.xircuits`
2. Verify compilation and execution succeed
3. Check output matches expected results

**2. Test FileBrowser Integration**
1. Right-click a .xircuits file in FileBrowser
2. Verify "Run Xircuits" option appears
3. Click and confirm workflow executes

**3. Test Copy to Root Functionality**
1. Navigate to subdirectory with .xircuits file
2. Verify "Copy to Root" option appears
3. Navigate to root directory
4. Verify "Copy to Root" option is hidden

## Tested on?

- [x] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others

# Notes
