### PR TITLE
🐛 Fix Argument Inputs not appearing in unsaved / uncompiled Run Dialogues

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -252,16 +252,13 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       }
     }
 
-    async function compileXircuitsFile(path: string, pythonPaths: any = {}, showOutput: boolean = false) {
+    async function compileXircuitsFile(path: string, pythonPaths: any = {}) {
       try {
         const request = await requestToGenerateCompileFile(path, pythonPaths);
         if (request["message"] == "completed") {
           const modelPath = path.split(".xircuits")[0] + ".py";
           docmanager.closeFile(modelPath);
-   
-          if (showOutput) {
-            alert(`${modelPath} successfully compiled!`);
-          }
+
           if (modelPath.startsWith("xai_components/")) {
             console.info(`File ${modelPath} changed. Reloading components...`);
             await app.commands.execute(commandIDs.refreshComponentList);
@@ -279,14 +276,13 @@ const xircuits: JupyterFrontEndPlugin<void> = {
     app.commands.addCommand(commandIDs.compileFile, {
       execute: async args => {
         const path = tracker.currentWidget.context.path;
-        const showOutput = args['showOutput'] !== undefined ? (args['showOutput'] as boolean) : false;
    
         const pythonPaths = {};
         (args['componentList'] === undefined ? [] : args['componentList'] as []).filter(it => it['python_path']).forEach(it => {
           pythonPaths[it['name']] = it['python_path']
         });
    
-        await compileXircuitsFile(path, pythonPaths, showOutput);
+        await compileXircuitsFile(path, pythonPaths);
       }
     });
    


### PR DESCRIPTION
# Description

Fixed an issue where the arguments dialog would show empty arrays when triggering compile-run directly on a dirty (unsaved) model. This was happening because the state variables that feed the args dialog were only being updated when the initialize flag was true.

The fix adds a helper function `getArgumentNodes()` that recalculates the current argument nodes just before opening the dialog, ensuring the dialog always has up-to-date values regardless of model state. This was implemented in both `handleLocalRunDialog` and `handleRemoteRunDialog`.

This PR also removes the alert after compiling. 

## References

N/A

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Test Compile-Run on Dirty Model**
1. Open a Xircuits workflow
2. Add some argument nodes
3. Make changes without saving
4. Click compile-run
5. Verify that arguments appear correctly in dialog

**2. Test Compile-Run on Saved Model**
1. Open a Xircuits workflow
2. Add some argument nodes
3. Save changes
4. Click compile-run
5. Verify that arguments appear correctly in dialog

## Tested on?

- [ ] Windows
- [x] Linux 
- [ ] Centos 
- [ ] Mac  
- [ ] Others
