### PR TITLE
PoC for Structured Debug Logging

### DIFF
--- a/xai_components/base.py
+++ b/xai_components/base.py
@@ -308,7 +308,7 @@ class StructuredDebugLogger:
             self.target = open(self.target_file, 'w')
 
     def write(self, value):
-        json.dump(value, self.target)
+        json.dump(value, self.target, default=repr)
         self.target.write("\n")
         self.target.flush()
 
@@ -333,7 +333,7 @@ class StructuredDebugLogger:
             elif type == 'after_execution':
                 component['outputs'] = self.get_parameter_state(comp, (OutArg,))
             output = {'timestamp': datetime.datetime.now().isoformat(), 'level': 'DEBUG', 'type': type,
-                      'component': component, 'ctx': repr(ctx)}
+                      'component': component, 'ctx': ctx}
             self.write(output)
 
     def log_before_execution(self, comp, ctx):

--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -134,7 +134,7 @@ class %s(Component):
 
         # Instantiate all components
         init_code.extend([
-            ast.parse("%s = %s()" % (named_nodes[n.id], n.name)) for n in component_nodes
+            ast.parse("%s = %s(id='%s')" % (named_nodes[n.id], n.name, n.id)) for n in component_nodes
         ])
 
         type_mapping = {
@@ -291,10 +291,7 @@ class %s(Component):
 for node in self.__start_nodes__:
     if hasattr(node, 'init'):
         node.init(ctx)
-    
-next_component = %s
-while next_component is not None:
-    next_component = next_component.do(ctx)        
+SubGraphExecutor(%s).do(ctx)        
         """ % (named_nodes[self.graph[0].ports[0].target.id])
         exec_code.append(ast.parse(trailer))
 


### PR DESCRIPTION
# Description

Sometimes it is quite hard to know what exactly is going on during the execution of a Xircuits file. 

This implements a proof of concept for a structured debug logger. It outputs its log in a json lines format that is readable by json log tools like [fblog](https://github.com/brocode/fblog).

For example:
![image](https://github.com/user-attachments/assets/cf31884e-2f33-48cf-b761-ee368fbd3878)
The execution of a simple xircuits file like this produces the following output:
```
{"timestamp": "2025-02-24T18:02:48.109280", "level": "DEBUG", "type": "before_execution", "component": {"class": "ConcatString", "id": "3d8d1923-f750-4c77-875f-2922a2efcceb", "inputs": {"a": "Hello ", "b": "World!"}}, "ctx": {"args": "Namespace()"}}
{"timestamp": "2025-02-24T18:02:48.109280", "level": "DEBUG", "type": "after_execution", "component": {"class": "ConcatString", "id": "3d8d1923-f750-4c77-875f-2922a2efcceb", "outputs": {"out": "Hello World!"}}, "ctx": {"args": "Namespace()"}}
{"timestamp": "2025-02-24T18:02:48.109280", "level": "DEBUG", "type": "before_execution", "component": {"class": "AgentNumpyMemory", "id": "270fc40c-7462-4335-b8a4-f810bbb95738", "inputs": {}}, "ctx": {"args": "Namespace()"}}
{"timestamp": "2025-02-24T18:02:48.110280", "level": "DEBUG", "type": "after_execution", "component": {"class": "AgentNumpyMemory", "id": "270fc40c-7462-4335-b8a4-f810bbb95738", "outputs": {"memory": "<xai_components.xai_agent.agent_components.NumpyMemoryImpl object at 0x0000024B6008EA60>"}}, "ctx": {"args": "Namespace()"}}
```
And a tool like fblog turns this into:
![image](https://github.com/user-attachments/assets/c832e115-13b8-4c37-92f1-4b88949821c6)

This implementation has a couple caveats:
* This currently only works with Components that use the SubGraphExecutor for execution of its subflows. In principle all components *should* use the subgraph executor for it, but it isn't guaranteed.
* ~The context is always a `repr` of the context, as it may contain non-serializable objects~
* ~If a component outputs non-serializable objects, the debug logging will crash.~

There are two environment variables to enable and configure debug logging:
1. `XIRCUITS_DEBUG=true`  enables the debug logging. In that case it will simply write to `stderr`
2. `XIRCUITS_DEBUG_FILE=<path>` selects where the debug log should be written to.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [x] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

## Logging to stderr 

Create a xircuits file and run it with `XIRCUITS_DEBUG=true` set. You'll see debugging output right on the terminal.

## Logging to a File
Create a xircuits file and run it with `XIRCUITS_DEBUG=true` and `XIRCUITS_DEBUG_FILE=debug.jsonl` set. You'll see no debug output on the terminal, instead a file is created and you can find the debug output there.


## Tested on?

- [x] Windows  
- [x] Linux
- [ ] Mac  
- [ ] Others  (State here -> xxx )  