### PR TITLE
Fix id setting issue

### DIFF
--- a/xircuits/compiler/generator.py
+++ b/xircuits/compiler/generator.py
@@ -112,8 +112,8 @@ from xai_components.base import SubGraphExecutor, InArg, OutArg, Component, xai_
         mainFlowCls = ast.parse("""
 @xai_component(type="xircuits_workflow")
 class %s(Component):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, id: str = None):
+        super().__init__(id=id)
         self.__start_nodes__ = []
     
     def execute(self, ctx):
@@ -134,7 +134,7 @@ class %s(Component):
 
         # Instantiate all components
         init_code.extend([
-            ast.parse("%s = %s(id='%s')" % (named_nodes[n.id], n.name, n.id)) for n in component_nodes
+            ast.parse("%s = %s(); %s.__id__ = '%s';" % (named_nodes[n.id], n.name, named_nodes[n.id], n.id)) for n in component_nodes
         ])
 
         type_mapping = {


### PR DESCRIPTION
# Description

With #384 we've added the support for structured logging. This logging requires that each component has a well defined id. 

We assumed that just defining this on `BaseComponent` as a constructor parameter would be enough to get the rudimentary support going. But it turns out that Components with custom constructors didn't like being instantiated with the id in the call parameters.

In particular the Workflow Components that the compiler creates didn't support it. But there are also a couple of other components that have the same issue.

This PR fixes the compiler to emit Workflow Components that will accept an id as a constructor parameter, but also moves the id assignment to be done with an additional property based call.

Ideally, we want to move the id assignment back to the component constructor, but until every component library had a chance to be updated, we will keep this more compatible way of doing it.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update