### PR TITLE
Another debug logging fix

### DIFF
--- a/xai_components/base.py
+++ b/xai_components/base.py
@@ -324,6 +324,8 @@ class StructuredDebugLogger:
 
     def _log(self, comp, ctx, type):
         if self.debug:
+            if isinstance(comp, SubGraphExecutor): return
+
             component = {
                 'class': comp.__class__.__name__,
                 'id': comp.__id__,


### PR DESCRIPTION
# Description

In more complex scenarios it may happen that the component that is passed into the debug logger is a SubGraphExecutor itself. 

This PR adds the handling for that case.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update