### PR TITLE
🐛 Fix relative path resolution in xircuits run command

### DIFF
--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -595,8 +595,8 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 
 		// Run Mode
 		context.ready.then(async () => {
-			const current_path = context.path;
-			const model_path = current_path.split(".xircuits")[0] + ".py";
+			const workflow_path = context.path;
+			const model_path = workflow_path.split(".xircuits")[0] + ".py";
 			let code = startRunOutputStr();
 	
 			let result;
@@ -622,7 +622,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			
 			else if (runType === 'terminal-run') {
 				commands.execute(commandIDs.executeToTerminal, {
-					command: `xircuits run ${model_path}`
+					command: `xircuits run ${workflow_path}`
 				});
 			}
 			

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -121,7 +121,19 @@ def cmd_list_libraries(args, extra_args=[]):
     list_component_library()
 
 def cmd_run(args, extra_args=[]):
+    original_cwd = args.original_cwd
 
+    # Resolve the source file path if it's not absolute.
+    source_file = Path(args.source_file)
+    if not source_file.is_absolute():
+        args.source_file = str((original_cwd / source_file).resolve())
+    
+    # Resolve the output file path if provided and not absolute.
+    if getattr(args, "out_file", None):
+        out_file = Path(args.out_file)
+        if not out_file.is_absolute():
+            args.out_file = str((original_cwd / out_file).resolve())
+    
     if args.source_file.endswith('.py'):
         output_filename = args.source_file
     else:
@@ -197,6 +209,10 @@ def main():
     run_parser.set_defaults(func=cmd_run)
 
     args, unknown_args = parser.parse_known_args()
+
+    # For the 'run' command, capture the original working directory before any directory changes.
+    if args.command == "run":
+        args.original_cwd = Path.cwd()
 
     # For any command other than 'init' and 'compile', switch to the xircuits working directory.
     if args.command not in ("init", "compile"):


### PR DESCRIPTION
# Description

This pull request addresses an issue with relative path resolution in the run command. Previously, if the run command was executed from a subdirectory, the relative paths could resolve incorrectly after changing the working directory to the Xircuits base directory. This PR captures the original working directory before switching directories, ensuring that relative file paths (for source and output files) remain accurate. 

## References

N/A

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [x] Others - Xircuits CLI

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

The changes were tested by running the workflow commands from different subdirectories. The relative paths were resolved correctly, ensuring that the run command executed the appropriate files.

**1. Test A**

1. Create a workflow that uses a workflow component in a subdir (e.g., `xai_components/xai_controlflow`) within your Xircuits project.
2. Open a terminal in the subdirectory and run the command:  
   `xircuits run workflow.xircuits`
3. Verify that the workflow is compiled into a Python file and executed correctly.

**Tested on:**

- [ ] Windows  
- [X] Linux
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
