### PR TITLE
🐛 Update Component List to Only Search on the Base Component Library Path

### DIFF
--- a/xircuits/handlers/components.py
+++ b/xircuits/handlers/components.py
@@ -121,7 +121,7 @@ class ComponentsRouteHandler(APIHandler):
                         and directory.is_dir() \
                         and not any(pathlib.Path.samefile(directory, d) for d in visited_directories):
                     visited_directories.append(directory)
-                    python_files = directory.rglob("xai_*/*.py")
+                    python_files = directory.glob("xai_*/*.py")
 
                     python_path = directory.expanduser().resolve()
 


### PR DESCRIPTION
# Description

If a venv is created in a component library *and* xircuits is installed in that venv, Xircuits will pick up the components inside the venv, putting them as higher priority than the ones in the base path, leading to weird paths like `xai_components/xai_libName/.venv/site-packages/xai_components/xai_utils/utils.py`.

This PR updates the search logic to just pick up components in the base component library path. As a side benefit, compiled workflows won't automatically be picked up as workflow components, as typically they would be placed in the examples dir.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [z] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [z] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Make a venv inside a component library and install xircuits in that venv. Verify that importing a baked-in component (like utils) would not pick up the path from that venv.
2. Verify that only workflows in the base workflow path to be picked up by the component sidebar.

**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux
- [ ] Mac  
- [ ] Others  (State here -> xxx )  