### PR TITLE
Add new tests

### DIFF
--- a/.github/workflows/run-cli-tests.yml
+++ b/.github/workflows/run-cli-tests.yml
@@ -1,0 +1,33 @@
+name: Run CLI Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ "*" ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade pip and install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+
+      - name: Run CLI tests
+        run: |
+          python -m pytest -v tests/tests.py

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -233,6 +233,9 @@ def test_run_command():
     # Verify that the corresponding .py file was created
     py_file = example_file.replace(".xircuits", ".py")
     assert os.path.exists(py_file)
+    assert "Compiled" in stdout, "Expected 'Compiled' not found in output."
+    assert "Finished Executing" in stdout, "Expected 'Finished Executing' not found in output."
+
 
 def test_list_libraries_command():
     """Test that list command shows available libraries"""
@@ -250,13 +253,9 @@ def test_install_library_command():
     """Test that install command installs a library"""
     # Initialize first
     run_command("xircuits init")
-    
-    # Install a library (use a small one for testing)
-    stdout, stderr, return_code = run_command("xircuits install flask", timeout=60)
-    
-    # Check library was installed by running list
-    list_stdout, _, _ = run_command("xircuits list")
-    assert "flask" in list_stdout.lower()
+    library_name ="flask"
+    stdout, stderr, return_code = run_command(f"xircuits install {library_name}", timeout=60)
+    assert f"library {library_name} ready to use" in stdout.lower()
 
 def test_working_directory_detection():
     """Test that Xircuits correctly finds the working directory"""
@@ -389,18 +388,16 @@ def test_compile_with_python_paths_file():
 def test_run_existing_py_file():
     run_command("xircuits init")
 
-    test_py = "test_script.py"
-    with open(test_py, "w") as f:
-        f.write("print('Hello from test_script')")
+    # Find an example file in the xai_controlflow folder
+    example_file = "xai_components/xai_controlflow/WorkflowComponentsExample.py"
+    assert os.path.exists(example_file), f"Expected workflow file '{example_file}' not found."
 
-    try:
-        stdout, stderr, return_code = run_command(f"xircuits run {test_py}")
+    command = f"xircuits run {example_file} --example_input=Hello_Xircuits!"
+    
+    stdout, stderr, return_code = run_command(command)
+    assert return_code == 0, "Expected return code 0 for successful execution"
+    assert "Hello_Xircuits!" in stdout, "Expected input 'Hello_Xircuits!' not found in output"
 
-        assert "Hello from test_script" in stdout, "Expected output not found in run command output"
-        assert return_code == 0, "Expected return code 0 for successful execution"
-    finally:
-        if os.path.exists(test_py):
-            os.remove(test_py)
 
 def test_run_with_custom_output():
     """Test run with a custom output file name"""
@@ -476,7 +473,7 @@ def test_run_with_custom_arguments(tmp_path):
     assert return_code == 0, "Initialization failed."
 
     # Install the library from GitHub.
-    stdout, stderr, return_code = run_command("xircuits fetch-only https://github.com/rabea-al/xai-tests", timeout=60)
+    stdout, stderr, return_code = run_command("xircuits fetch-only https://github.com/XpressAI/xai-tests", timeout=60)
     assert return_code == 0, "Library installation failed."
 
     # Determine the library directory.
@@ -672,7 +669,7 @@ def test_run_non_recursive_mode_with_install():
     stdout, stderr, rc = run_command("xircuits init", timeout=15)
     assert rc == 0, "Initialization failed."
 
-    install_cmd = "xircuits install https://github.com/rabea-al/xai-tests"
+    install_cmd = "xircuits install https://github.com/XpressAI/xai-tests"
     stdout, stderr, rc = run_command(install_cmd, timeout=60)
     assert rc == 0, "Library installation failed."
 
@@ -703,7 +700,7 @@ def test_compile_non_recursive_mode_with_install():
     stdout, stderr, rc = run_command("xircuits init", timeout=15)
     assert rc == 0, "Initialization failed."
 
-    install_cmd = "xircuits install https://github.com/rabea-al/xai-tests"
+    install_cmd = "xircuits install https://github.com/XpressAI/xai-tests"
     stdout, stderr, rc = run_command(install_cmd, timeout=60)
     assert rc == 0, "Library installation failed."
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 
 # Setup test directory
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def test_directory():
     """Create a test directory and clean it up after tests"""
     # Hardcoded test directory name
@@ -49,7 +49,7 @@ def setup_test_environment(test_directory):
     os.chdir(original_dir)
 
 # Helper to run commands
-def run_command(command, timeout=10, expected_output=None, check_stderr=False,
+def run_command(command, timeout=10, input_data=None, expected_output=None, check_stderr=False,
                 expected_in_output=None, unexpected_in_output=None, 
                 expected_files=None, wait_for_exit=True, no_browser=False):
     """
@@ -58,6 +58,7 @@ def run_command(command, timeout=10, expected_output=None, check_stderr=False,
     Args:
         command: Command string to run
         timeout: Timeout in seconds
+        input_data: Data to be passed to the process's stdin
         expected_output: String that should be in output for test to pass
         check_stderr: Whether to check stderr
         expected_in_output: List of strings that should be in output
@@ -69,8 +70,8 @@ def run_command(command, timeout=10, expected_output=None, check_stderr=False,
     Returns:
         Tuple of (stdout, stderr, return_code)
     """
-    # Add --no-browser to start commands
-    if no_browser and ('start' in command or 'jupyter' in command):
+    # Add --no-browser to start commands if applicable
+    if no_browser and (('xircuits' in command) or ('start' in command) or ('jupyter' in command)):
         command = command + " --no-browser"
         
     print(f"Running command: {command}")
@@ -81,6 +82,7 @@ def run_command(command, timeout=10, expected_output=None, check_stderr=False,
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        stdin=subprocess.PIPE, # Enable input
         text=True,
         preexec_fn=os.setsid  # For group termination
     )
@@ -119,7 +121,7 @@ def run_command(command, timeout=10, expected_output=None, check_stderr=False,
         elif wait_for_exit:
             # Just wait for the process to finish with timeout
             try:
-                stdout_data, stderr_data = process.communicate(timeout=timeout)
+                stdout_data, stderr_data = process.communicate(input=input_data, timeout=timeout)
             except subprocess.TimeoutExpired:
                 os.killpg(os.getpgid(process.pid), signal.SIGTERM)
                 stdout_data, stderr_data = process.communicate()
@@ -135,7 +137,7 @@ def run_command(command, timeout=10, expected_output=None, check_stderr=False,
         # Ensure process is terminated on exception
         try:
             os.killpg(os.getpgid(process.pid), signal.SIGTERM)
-        except:
+        except Exception:
             pass
         raise e
     
@@ -170,6 +172,13 @@ def run_command(command, timeout=10, expected_output=None, check_stderr=False,
 
 def test_help_command():
     """Test that help command works properly"""
+    stdout, stderr, return_code = run_command("xircuits --h")
+    assert return_code == 0
+    assert "usage:" in stdout
+    assert "Xircuits Command Line Interface" in stdout
+
+def test_alternative_help_command():
+    """Test that help command works properly"""
     stdout, stderr, return_code = run_command("xircuits --help")
     assert return_code == 0
     assert "usage:" in stdout
@@ -185,33 +194,23 @@ def test_init_command():
     assert os.path.exists(".xircuits")
     assert os.path.exists("xai_components")
 
-def test_examples_command():
-    """Test that examples command downloads examples"""
-    # Initialize first
-    run_command("xircuits init")
-    
-    # Now download examples
-    stdout, stderr, return_code = run_command("xircuits examples")
-    assert return_code == 0
-    assert "Example workflows ready" in stdout
-    
-    # Check that examples directory was created
-    assert os.path.exists("examples")
-    # Check for some common example file
-    assert any(Path("examples").glob("*.xircuits"))
-
 def test_compile_command():
-    """Test that compile command works properly"""
-    # Initialize and download examples
+    """Test that the compile command works properly."""
+    # Initialize Xircuits
     run_command("xircuits init")
-    
-    workflow_path = "xai_components/xai_controlflow/"
-    
-    # Compile the file
+
+    # Search for .xircuits files in the xai_controlflow folder using glob
+    xircuits_files = list(Path("xai_components/xai_controlflow").glob("*.xircuits"))
+    assert xircuits_files, "No .xircuits files found in xai_controlflow."
+
+    # Select the first available .xircuits file
+    example_file = str(xircuits_files[0])
+
+    # Compile the selected .xircuits file
     stdout, stderr, return_code = run_command(f"xircuits compile {example_file}")
-    assert return_code == 0
-    
-    # Check that a Python file was created
+    assert return_code == 0, "Compile command failed."
+
+    # Verify that the corresponding .py file was created
     py_file = example_file.replace(".xircuits", ".py")
     assert os.path.exists(py_file)
 
@@ -219,21 +218,19 @@ def test_run_command():
     """Test that run command compiles and executes a workflow"""
     # Initialize and download examples
     run_command("xircuits init")
-    run_command("xircuits examples")
     
-    # Find a simple example file to run
-    example_files = list(Path("examples").glob("hello_world.xircuits"))
-    if not example_files:
-        example_files = list(Path("examples").glob("*.xircuits"))
-    
-    assert example_files, "No example files found"
-    example_file = str(example_files[0])
-    
-    # Run the file
+    # Search for .xircuits files in the xai_controlflow folder using glob
+    xircuits_files = list(Path("xai_components/xai_controlflow").glob("*.xircuits"))
+    assert xircuits_files, "No .xircuits files found in xai_controlflow."
+
+    # Select the first available .xircuits file
+    example_file = str(xircuits_files[0])
+
+    # Compile the selected .xircuits file
     stdout, stderr, return_code = run_command(f"xircuits run {example_file}")
-    # Note: Return code might not be 0 depending on the workflow
-    
-    # Check that a Python file was created
+    assert return_code == 0, "Compile command failed."
+
+    # Verify that the corresponding .py file was created
     py_file = example_file.replace(".xircuits", ".py")
     assert os.path.exists(py_file)
 
@@ -261,35 +258,6 @@ def test_install_library_command():
     list_stdout, _, _ = run_command("xircuits list")
     assert "flask" in list_stdout.lower()
 
-# def test_start_command():
-#     """Test that start command starts jupyter lab"""
-#     # Initialize first
-#     run_command("xircuits init")
-    
-#     # Check that start command launches jupyterlab (with no-browser flag)
-#     stdout, stderr, _ = run_command("xircuits start", 
-#                                    timeout=5, 
-#                                    wait_for_exit=False,
-#                                    expected_output="Jupyter Server",
-#                                    no_browser=True)  # Add no_browser flag
-    
-#     # Check for signs that Jupyter Lab started
-#     assert (
-#         "jupyter lab" in stdout or 
-#         "jupyterlab" in stdout.lower() or
-#         "jupyter server" in stdout.lower()
-#     )
-
-def test_auto_initialization():
-    """Test auto-initialization with environment variable"""
-    # Run command with environment variable set
-    cmd = "XIRCUITS_INIT=1 xircuits list"
-    stdout, stderr, return_code = run_command(cmd)
-    
-    # Verify directories were created
-    assert os.path.exists(".xircuits")
-    assert os.path.exists("xai_components")
-
 def test_working_directory_detection():
     """Test that Xircuits correctly finds the working directory"""
     # Initialize in parent directory
@@ -308,25 +276,456 @@ def test_working_directory_detection():
 
 def test_compile_with_custom_output():
     """Test compiling with a custom output file name"""
-    # Initialize and download examples
     run_command("xircuits init")
-    run_command("xircuits examples")
     
-    # Find an example file
-    example_files = list(Path("examples").glob("*.xircuits"))
-    assert example_files, "No example files found"
+    # Find an example file in the xai_controlflow folder
+    example_files = list(Path("xai_components/xai_controlflow").glob("*.xircuits"))
+    assert example_files, "No .xircuits files found in xai_controlflow."
     example_file = str(example_files[0])
     
     custom_output = "custom_output.py"
-    # Compile with custom output name
+    # Compile with the custom output name
     stdout, stderr, return_code = run_command(f"xircuits compile {example_file} {custom_output}")
-    assert return_code == 0
+    assert return_code == 0, "Compile command failed."
     
     # Check that the custom named Python file was created
-    assert os.path.exists(custom_output)
+    assert os.path.exists(custom_output), f"Expected output file '{custom_output}' not found."
+
 
 def test_error_handling_invalid_command():
     """Test that invalid commands are handled gracefully"""
     stdout, stderr, return_code = run_command("xircuits invalid_command")
     # Should print help or error message, not crash
     assert return_code != 0
+
+def test_install_invalid_library():
+    stdout, stderr, return_code = run_command("xircuits install non_existing_library")
+
+    expected_error_message = "component library submodule not found"
+    assert expected_error_message in stdout or expected_error_message in stderr, \
+        f"Expected error message '{expected_error_message}' not found in output"
+
+def test_fetch_only_valid_library(tmp_path):
+    # Change to the temporary directory.
+    os.chdir(tmp_path)
+
+    # Initialize Xircuits in the temporary directory.
+    stdout, stderr, return_code = run_command("xircuits init", timeout=15)
+    assert return_code == 0, "Initialization failed."
+
+    library_name = "xai_gradio"
+    stdout, stderr, return_code = run_command(f"xircuits fetch-only {library_name}", timeout=60)
+    assert return_code == 0, f"Fetch-only command failed for {library_name}"
+    output = stdout + stderr
+
+    expected_fetch = f"Fetching {library_name}..."
+    assert expected_fetch in output, f"Expected '{expected_fetch}' not found in output"
+
+    expected_msg1 = f"{library_name} library fetched and stored in"
+    expected_msg2 = f"{library_name} library already exists in"
+    assert (expected_msg1 in output or expected_msg2 in output), \
+        f"Expected fetching message not found in output: {output}"
+
+    assert "Installing" not in output, "Unexpected 'Installing' message found in fetch-only output"
+
+    lib_path = tmp_path / "xai_components" / library_name
+    assert lib_path.exists(), f"Library {library_name} should exist in xai_components after fetch-only."
+
+def test_install_already_installed_library():
+    library_name = "xai_utils"  # Select a library that is already installed
+    run_command(f"xircuits install {library_name}")  # Ensure the library is installed beforehand
+
+    stdout, stderr, return_code = run_command(f"xircuits install {library_name}")
+
+    assert return_code == 0, f"Reinstalling {library_name} failed unexpectedly"
+
+    unexpected_message = "cloning"
+    assert unexpected_message not in stdout.lower(), \
+        f"Unexpected cloning detected: '{unexpected_message}' found in output"
+
+def test_compile_invalid_xircuits():
+    # Create an invalid Xircuits file in the current directory.
+    invalid_file = "invalid_workflow.xircuits"
+    # Create an invalid Xircuits file with unexpected content (simulate invalid JSON or format)
+    with open(invalid_file, "w") as f:
+        f.write("{invalid_json}")  # Invalid content
+
+    try:
+        stdout, stderr, return_code = run_command(f"xircuits compile {invalid_file}")
+
+        expected_error_message = "Error reading"
+        assert expected_error_message in stdout or expected_error_message in stderr, \
+            f"Expected error message '{expected_error_message}' not found in output"
+    finally:
+        if os.path.exists(invalid_file):
+            os.remove(invalid_file)
+
+def test_compile_with_python_paths_file():
+    run_command("xircuits init")
+
+    example_file = "xai_components/xai_template/HelloTutorial.xircuits"
+
+    # Create a JSON file with the component paths.
+    json_file = "paths.json"
+    paths_data = {
+        "ConcatString": "xai_components/xai_utils/utils.py",
+        "Print": "xai_components/xai_utils/utils.py"
+    }
+    with open(json_file, "w") as f:
+        json.dump(paths_data, f)
+
+    try:
+        stdout, stderr, return_code = run_command(f"xircuits compile {example_file} --python-paths-file={json_file}")
+        assert return_code == 0, "Compile command failed when using a python paths file."
+
+        assert "Compiled" in stdout, "Expected 'Compiled' in output not found."
+
+        py_file = example_file.replace(".xircuits", ".py")
+        assert os.path.exists(py_file), f"Expected compiled file {py_file} not found."
+    finally:
+        if os.path.exists(json_file):
+            os.remove(json_file)
+
+def test_run_existing_py_file():
+    run_command("xircuits init")
+
+    test_py = "test_script.py"
+    with open(test_py, "w") as f:
+        f.write("print('Hello from test_script')")
+
+    try:
+        stdout, stderr, return_code = run_command(f"xircuits run {test_py}")
+
+        assert "Hello from test_script" in stdout, "Expected output not found in run command output"
+        assert return_code == 0, "Expected return code 0 for successful execution"
+    finally:
+        if os.path.exists(test_py):
+            os.remove(test_py)
+
+def test_run_with_custom_output():
+    """Test run with a custom output file name"""
+    run_command("xircuits init")
+    
+    # Find an example file in the xai_controlflow folder
+    example_files = list(Path("xai_components/xai_controlflow").glob("*.xircuits"))
+    assert example_files, "No .xircuits files found in xai_controlflow."
+    example_file = str(example_files[0])
+    
+    custom_output = "custom_output.py"
+    # run with the custom output name
+    stdout, stderr, return_code = run_command(f"xircuits run {example_file} {custom_output}")
+    assert return_code == 0, "run command failed."
+    
+    # Check that the custom named Python file was created
+    assert os.path.exists(custom_output), f"Expected output file '{custom_output}' not found."
+
+def test_run_invalid_xircuits():
+    run_command("xircuits init")
+
+    # Create an invalid Xircuits file in the current directory.
+    invalid_file = "invalid_workflow.xircuits"
+    with open(invalid_file, "w") as f:
+        f.write("{invalid_json}")  # Invalid content to simulate an error
+
+    try:
+        stdout, stderr, return_code = run_command(f"xircuits run {invalid_file}")
+
+        expected_error_message = "Error reading"
+        error_found = expected_error_message in stdout or expected_error_message in stderr
+        assert error_found, f"Expected error message '{expected_error_message}' not found in output"
+    finally:
+        if os.path.exists(invalid_file):
+            os.remove(invalid_file)
+
+def test_run_with_python_paths_file():
+    run_command("xircuits init")
+
+    example_file = "xai_components/xai_template/HelloTutorial.xircuits"
+
+    # Create a JSON file with component paths.
+    json_file = "paths.json"
+    paths_data = {
+        "ConcatString": "xai_components/xai_utils/utils.py",
+        "Print": "xai_components/xai_utils/utils.py"
+    }
+    with open(json_file, "w") as f:
+        json.dump(paths_data, f)
+
+    try:
+        stdout, stderr, return_code = run_command(f"PYTHONPATH=. xircuits run {example_file} --python-paths-file={json_file}")
+
+        assert return_code == 0, "Run command failed when using a python paths file."
+        assert "Finished Executing" in stdout, "Expected 'Finished Executing' in output not found."
+
+        py_file = example_file.replace(".xircuits", ".py")
+        assert os.path.exists(py_file), f"Expected compiled file {py_file} not found."
+    finally:
+        if os.path.exists(json_file):
+            os.remove(json_file)
+
+def test_run_with_custom_arguments(tmp_path):
+    import os
+    import shutil
+    from pathlib import Path
+
+    # Change to the temporary directory.
+    os.chdir(tmp_path)
+
+    # Initialize Xircuits.
+    stdout, stderr, return_code = run_command("xircuits init")
+    assert return_code == 0, "Initialization failed."
+
+    # Install the library from GitHub.
+    stdout, stderr, return_code = run_command("xircuits fetch-only https://github.com/rabea-al/xai-tests", timeout=60)
+    assert return_code == 0, "Library installation failed."
+
+    # Determine the library directory.
+    lib_dir = Path("xai_components") / "xai-tests"
+    if not lib_dir.exists():
+        lib_dir = Path("xai_components") / "xai_tests"
+    assert lib_dir.exists(), f"Library directory not found in xai_components. Checked: {lib_dir}"
+
+    # Define the example file path from the installed library.
+    example_file = lib_dir / "ArgumentParameters.xircuits"
+    assert example_file.exists(), f"Example file '{example_file}' not found in the library directory."
+
+    # Define the output file path.
+    output_file = tmp_path / "ArgumentParameters.py"
+
+    # Run the workflow with custom arguments.
+    cmd = f"xircuits run {example_file} {output_file} -- --str1=Hello_ --str2=Xircuits"
+    stdout, stderr, return_code = run_command(cmd)
+    assert return_code == 0, "Run command failed with custom arguments."
+    assert "Hello_Xircuits" in stdout, "Expected output 'Hello_Xircuits' not found in run command output."
+    assert output_file.exists(), f"Expected output file '{output_file}' not found."
+
+
+def test_interrupted_initialization():
+    # Start the 'xircuits init' command in a separate process.
+    process = subprocess.Popen(
+        "xircuits init",
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        preexec_fn=os.setsid
+    )
+
+    try:
+        # Wait a very short time then send the SIGINT signal.
+        time.sleep(0.1)
+        os.killpg(os.getpgid(process.pid), signal.SIGINT)
+
+        stdout, stderr = process.communicate(timeout=5)
+
+        assert process.returncode != 0, "Expected interruption handling not found in output."
+        assert not os.path.exists(".xircuits") or not os.path.exists("xai_components"), \
+            "Initialization directories should not exist after interruption."
+    finally:
+        try:
+            os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+        except Exception:
+            pass
+
+def test_insufficient_permissions():
+    readonly_dir = Path("readonly_dir")
+    readonly_dir.mkdir(exist_ok=True)
+
+    # Set the directory permissions to read-only (0555).
+    readonly_dir.chmod(0o555)
+
+    # Save the current directory then change to the read-only directory.
+    original_dir = os.getcwd()
+    os.chdir(readonly_dir)
+
+    try:
+        stdout, stderr, return_code = run_command("xircuits init", timeout=10)
+
+        assert return_code != 0, "Expected failure due to insufficient permissions, but command succeeded."
+
+        error_indicators = ["Permission denied", "not allowed"]
+        output = stdout + stderr
+        assert any(indicator.lower() in output.lower() for indicator in error_indicators), \
+            "Expected permission error not found in output."
+    finally:
+        # Return to the original directory, restore directory permissions, then remove the directory.
+        os.chdir(original_dir)
+        readonly_dir.chmod(0o755)
+        shutil.rmtree(readonly_dir)
+
+def test_no_arguments_starts_jupyter_lab():
+    stdout, stderr, return_code = run_command("xircuits", timeout=5, wait_for_exit=False, no_browser=True)
+
+    output = stdout + stderr
+    assert ("jupyter lab" in output.lower() or 
+            "jupyter server" in output.lower() or
+            "jupyterlab" in output), "Expected Jupyter Lab startup message not found in output."
+
+def test_start_command():
+    run_command("xircuits init")
+
+    stdout, stderr, return_code = run_command("xircuits start", timeout=5, wait_for_exit=False, no_browser=True)
+
+    output = stdout + stderr
+    assert ("jupyter lab" in output.lower() or 
+            "jupyter server" in output.lower() or 
+            "jupyterlab" in output), "Expected Jupyter Lab startup indicators not found in output."
+
+def test_start_with_extra_arguments():
+    run_command("xircuits init")
+
+    stdout, stderr, return_code = run_command("xircuits start --port=8899", timeout=5, wait_for_exit=False, no_browser=True)
+
+    output = stdout + stderr
+    assert "8899" in output, "Expected port 8899 to be indicated in the output."
+
+def test_auto_initialization(tmp_path):
+    os.chdir(tmp_path)
+
+    # Remove existing directories to ensure a clean environment.
+    if os.path.exists(".xircuits"):
+        shutil.rmtree(".xircuits")
+    if os.path.exists("xai_components"):
+        shutil.rmtree("xai_components")
+
+    process = subprocess.Popen(
+        "XIRCUITS_INIT=1 xircuits --no-browser",
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        preexec_fn=os.setsid
+    )
+
+    time.sleep(5)
+
+    os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+    process.wait(timeout=5)
+
+    assert os.path.exists(".xircuits"), "Expected .xircuits directory to be created during auto-initialization."
+    assert os.path.exists("xai_components"), "Expected xai_components directory to be created during auto-initialization."
+
+def test_reinit_in_already_initialized_directory():
+    # Ensure that any existing initialization directories are removed from the current directory.
+    if os.path.exists(".xircuits"):
+        shutil.rmtree(".xircuits")
+    if os.path.exists("xai_components"):
+        shutil.rmtree("xai_components")
+
+    # Run the command for the first time.
+    stdout1, stderr1, rc1 = run_command("xircuits init", timeout=15)
+    assert rc1 == 0, "First initialization failed."
+    assert os.path.exists(".xircuits"), "Expected .xircuits directory to be created during first initialization."
+    assert os.path.exists("xai_components"), "Expected xai_components directory to be created during first initialization."
+
+    # Run the command a second time in the same directory.
+    stdout2, stderr2, rc2 = run_command("xircuits init", timeout=15)
+    output2 = stdout2 + stderr2
+
+    # According to current behavior on re-initialization, the command should return a non-zero exit code or print a message indicating that the directory already exists.
+    assert rc2 != 0, "Re-initializing in an already initialized directory should fail."
+    expected_indicator = "file exists"
+    assert expected_indicator in output2.lower() or "already initialized" in output2.lower(), \
+        f"Expected message indicating reinitialization was handled gracefully not found in output:\n{output2}"
+
+def test_start_in_non_initialized_directory(tmp_path):
+    # Change to the isolated test directory.
+    os.chdir(tmp_path)
+
+    # Ensure that there are no pre-existing initialization directories in the current directory.
+    if os.path.exists(".xircuits"):
+        shutil.rmtree(".xircuits")
+    if os.path.exists("xai_components"):
+        shutil.rmtree("xai_components")
+
+    stdout, stderr, return_code = run_command("xircuits start --no-browser", timeout=15, input_data="n\n")
+
+    expected_prompt = "Would you like to initialize Xircuits in the current directory?"
+    output = stdout + stderr
+    assert expected_prompt in output, f"Expected prompt '{expected_prompt}' not found in output:\n{output}"
+
+def test_xircuits_missing_xai_components(tmp_path):
+    # Change to the isolated test directory.
+    os.chdir(tmp_path)
+
+    # Run 'xircuits init' to initialize the environment.
+    stdout, stderr, return_code = run_command("xircuits init", timeout=15)
+    assert return_code == 0, "Initialization failed."
+
+    # Verify that the .xircuits directory exists and xai_components exists.
+    assert (tmp_path / ".xircuits").exists(), "'.xircuits' directory not found after init."
+    assert (tmp_path / "xai_components").exists(), "'xai_components' directory not found after init."
+
+    # Remove the xai_components directory.
+    shutil.rmtree(tmp_path / "xai_components")
+    assert not (tmp_path / "xai_components").exists(), "'xai_components' directory should be missing."
+
+    stdout, stderr, return_code = run_command("xircuits", timeout=15, input_data="n\n")
+    output = stdout + stderr
+
+    # Check that the expected initialization prompt appears.
+    expected_prompt = "Would you like to initialize Xircuits in the current directory?"
+    assert expected_prompt in output, f"Expected prompt '{expected_prompt}' not found in output:\n{output}"
+
+
+def test_run_non_recursive_mode_with_install():
+    stdout, stderr, rc = run_command("xircuits init", timeout=15)
+    assert rc == 0, "Initialization failed."
+
+    install_cmd = "xircuits install https://github.com/rabea-al/xai-tests"
+    stdout, stderr, rc = run_command(install_cmd, timeout=60)
+    assert rc == 0, "Library installation failed."
+
+    # Determine the directory where the library was installed.
+    lib_dir = os.path.join("xai_components", "xai-tests")
+    if not os.path.exists(lib_dir):
+        lib_dir = os.path.join("xai_components", "xai_tests")
+    assert os.path.exists(lib_dir), f"Expected library directory not found in xai_components. Checked: {lib_dir}"
+
+    # Define file paths.
+    outer_file = os.path.join(lib_dir, "OuterWorkflowExample.xircuits")
+    sub_file = os.path.join(lib_dir, "WorkflowComponentsExample.xircuits")
+    assert os.path.exists(outer_file), f"Outer workflow file not found in {lib_dir}"
+
+    outer_py = outer_file.replace(".xircuits", ".py")
+    sub_py = sub_file.replace(".xircuits", ".py")
+
+    # Run the command in non-recursive mode to compile only the outer file.
+    run_cmd = f"xircuits run {outer_file} --non-recursive"
+    stdout, stderr, rc = run_command(run_cmd, timeout=30)
+    assert rc == 0, "Run command in non-recursive mode failed."
+
+    # Check that the compiled outer file was created.
+    assert os.path.exists(outer_py), f"Expected compiled file {outer_py} not found."
+    assert not os.path.exists(sub_py), f"Sub-workflow file {sub_py} should not be compiled in non-recursive mode."
+
+def test_compile_non_recursive_mode_with_install():
+    stdout, stderr, rc = run_command("xircuits init", timeout=15)
+    assert rc == 0, "Initialization failed."
+
+    install_cmd = "xircuits install https://github.com/rabea-al/xai-tests"
+    stdout, stderr, rc = run_command(install_cmd, timeout=60)
+    assert rc == 0, "Library installation failed."
+
+    # Determine the directory where the library was installed.
+    lib_dir = os.path.join("xai_components", "xai-tests")
+    if not os.path.exists(lib_dir):
+        lib_dir = os.path.join("xai_components", "xai_tests")
+    assert os.path.exists(lib_dir), f"Expected library directory not found in xai_components. Checked: {lib_dir}"
+
+    # Define file paths.
+    outer_file = os.path.join(lib_dir, "OuterWorkflowExample.xircuits")
+    sub_file = os.path.join(lib_dir, "WorkflowComponentsExample.xircuits")
+    assert os.path.exists(outer_file), f"Outer workflow file not found in {lib_dir}"
+
+    outer_py = outer_file.replace(".xircuits", ".py")
+    sub_py = sub_file.replace(".xircuits", ".py")
+
+    # Run the compile command in non-recursive mode to compile only the outer file.
+    compile_cmd = f"xircuits compile {outer_file} --non-recursive"
+    stdout, stderr, rc = run_command(compile_cmd, timeout=30)
+    assert rc == 0, "Compile command in non-recursive mode failed."
+
+    # Check that the compiled outer file was created.
+    assert os.path.exists(outer_py), f"Expected compiled file {outer_py} not found."
+    assert not os.path.exists(sub_py), f"Sub-workflow file {sub_py} should not be compiled in non-recursive mode."

--- a/xircuits/library/list_library.py
+++ b/xircuits/library/list_library.py
@@ -12,7 +12,7 @@ def get_installed_packages():
 
 def check_requirements_installed(installed_packages, requirements):
     """Check if all required packages are installed."""
-    required_packages = {pkg.strip() for pkg in requirements}
+    required_packages = {pkg.split("==")[0].strip() for pkg in requirements}
     missing_packages = required_packages - installed_packages
     return len(missing_packages) == 0, missing_packages
 


### PR DESCRIPTION
# Description

This PR introduces a new set of CLI test cases under `tests/tests.py` to improve the test coverage of core functionalities.  
Additionally, a new GitHub Actions workflow file `run-cli-tests.yml` was added under `.github/workflows/` to automate running these tests.  

The goal is to ensure CLI components behave as expected and are tested on every push, pull request, or manual dispatch across multiple Python versions.  

---

This PR also fixes an issue where installed libraries were incorrectly marked as incomplete (`[*]`) when listed using `xircuits list`, despite being properly installed.  

The issue occurred because the `check_requirements_installed` function was comparing the full requirement string (e.g., `"sendgrid==6.11.0"`) with the list of installed package names obtained from `pip freeze` (e.g., `"sendgrid"`), which does not include version information.  

To fix this:
- The comparison logic has been updated to extract only the package name (before `==`) from the requirements list.
- This ensures that if the package is installed, the library will be correctly marked as installed, preventing the `[ * ]` marker from appearing.

---

# Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)  
- [ ] Xircuits Canvas (Custom RD Related changes)  
- [ ] Xircuits Component Library  
- [ ] Xircuits Project Template  
- [x] Testing Automation  
- [ ] Documentation  
- [ ] Others (Please Specify)  

---

# Type of Change

- [x] New feature (non-breaking change which adds functionality)  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] This change requires a documentation update  

---

# Test

1. Clone the repository  
2. Ensure dependencies are installed (preferably in a virtual environment):
   ```bash
   pip install -e .
   ```
3. Run the tests manually:
   ```bash
   pytest -v tests/tests.py
   ```
4. Alternatively, push to a branch or open a PR to trigger the GitHub Action:
   - The workflow will automatically test on Python 3.8, 3.9, 3.10, and 3.11.
   - You can also dispatch it manually from the **Actions** tab.

---

# Tested On

- [ ] Windows  
- [x] Linux (Fedora)  
- [ ] macOS  
- [ ] Others: _N/A_

---