### PR TITLE
Fix flaky UI tests

### DIFF
--- a/ui-tests/tests/connecting-nodes-test.py
+++ b/ui-tests/tests/connecting-nodes-test.py
@@ -9,7 +9,7 @@ browsers_to_test = ["chromium", "firefox"]
 with sync_playwright() as p:
     for browser_name in browsers_to_test:
         print(f"\nRunning test on: {browser_name}")
-        browser = getattr(p, browser_name).launch(headless=False, slow_mo=500)
+        browser = getattr(p, browser_name).launch(headless=True, slow_mo=500)
         context = browser.new_context()
         page = context.new_page()
 

--- a/ui-tests/tests/editing-literal-nodes-test.py
+++ b/ui-tests/tests/editing-literal-nodes-test.py
@@ -9,7 +9,7 @@ browsers_to_test = ["chromium", "firefox"]
 with sync_playwright() as p:
     for browser_name in browsers_to_test:
         print(f"\nRunning edit test on: {browser_name}")
-        browser = getattr(p, browser_name).launch(headless=False, slow_mo=500)
+        browser = getattr(p, browser_name).launch(headless=True, slow_mo=500)
         context = browser.new_context()
         page = context.new_page()
 

--- a/ui-tests/tests/xircuits_test_utils.py
+++ b/ui-tests/tests/xircuits_test_utils.py
@@ -474,6 +474,7 @@ def clean_xircuits_directory(page, subfolder_name: str):
     page.wait_for_selector('#jupyterlab-splash', state='detached')
 
     page.get_by_text("xai_components", exact=True).dblclick()
+    page.wait_for_selector("text=xai_tests", timeout=10000)
     page.get_by_text("xai_tests", exact=True).dblclick()
     page.get_by_text(subfolder_name, exact=True).dblclick()
     page.wait_for_timeout(1000)
@@ -494,10 +495,12 @@ def clean_xircuits_directory(page, subfolder_name: str):
 
 def copy_xircuits_file(page, source_file: str, target_folder: str):
     print(f"Copying {source_file} to {target_folder}")
+    page.wait_for_timeout(1000)
     page.goto("http://localhost:8888")
     page.wait_for_selector('#jupyterlab-splash', state='detached')
-
+    page.wait_for_timeout(1000)
     page.get_by_text("xai_components", exact=True).dblclick()
+    page.wait_for_selector("text=xai_tests", timeout=10000)
     page.get_by_text("xai_tests", exact=True).dblclick()
     page.get_by_text(source_file, exact=True).click()
     page.keyboard.press("Control+C")


### PR DESCRIPTION

# Description


This PR fixes a flaky behavior in the UI tests where Playwright would occasionally fail while attempting to double-click the 'xai_tests' folder before it was fully loaded.

Changes:
- Added explicit wait for 'xai_tests' folder before double-clicking in both `clean_xircuits_directory` and `copy_xircuits_file` functions.

Testing:
- Verified locally on both Chromium and Firefox.
- Also verified by running GitHub Actions multiple times on my forked repository , and all runs were successful.
