### PR TITLE
Add launcher support for Xircuits templates and user templates

### DIFF
--- a/ui-tests/tests/arg_input_ui_test.py
+++ b/ui-tests/tests/arg_input_ui_test.py
@@ -13,7 +13,7 @@ with sync_playwright() as p:
     page = context.new_page()
     page.goto("http://localhost:8888")
     page.wait_for_selector('#jupyterlab-splash', state='detached')
-    page.get_by_text('Xircuits File', exact=True).click()
+    page.get_by_text('New Xircuits File', exact=True).click()
 
     simulate_drag_component_from_library(page, "UTILS", "PrettyPrint")
     connect_nodes(page, {

--- a/ui-tests/tests/parameter-names-autoshift.py
+++ b/ui-tests/tests/parameter-names-autoshift.py
@@ -7,7 +7,7 @@ with sync_playwright() as p:
     page = context.new_page()
     page.goto("http://localhost:8888")
     page.wait_for_selector('#jupyterlab-splash', state='detached')
-    page.get_by_text('Xircuits File', exact=True).click()
+    page.get_by_text('New Xircuits File', exact=True).click()
  
     simulate_drag_component_from_library(page, "TESTS", "DynaportTester")
  

--- a/ui-tests/tests/parameter-names-despawn.py
+++ b/ui-tests/tests/parameter-names-despawn.py
@@ -7,7 +7,7 @@ with sync_playwright() as p:
     page = context.new_page()
     page.goto("http://localhost:8888")
     page.wait_for_selector('#jupyterlab-splash', state='detached')
-    page.get_by_text('Xircuits File', exact=True).click()
+    page.get_by_text('New Xircuits File', exact=True).click()
 
     simulate_drag_component_from_library(page, "TESTS", "DynaportTester")
 

--- a/ui-tests/tests/parameter-names-spawn.py
+++ b/ui-tests/tests/parameter-names-spawn.py
@@ -7,7 +7,7 @@ with sync_playwright() as p:
     page = context.new_page()
     page.goto("http://localhost:8888")
     page.wait_for_selector('#jupyterlab-splash', state='detached')
-    page.get_by_text('Xircuits File', exact=True).click()
+    page.get_by_text('New Xircuits File', exact=True).click()
 
     simulate_drag_component_from_library(page, "TESTS", "DynaportTester")
 

--- a/ui-tests/tests/protected-nodes-and-lock-test.py
+++ b/ui-tests/tests/protected-nodes-and-lock-test.py
@@ -12,7 +12,7 @@ with sync_playwright() as p:
     page = context.new_page()
     page.goto("http://localhost:8888")
     page.wait_for_selector('#jupyterlab-splash', state='detached')
-    page.get_by_text('Xircuits File', exact=True).click()
+    page.get_by_text('New Xircuits File', exact=True).click()
 
     delete_component_directly(page, "Start")
 

--- a/ui-tests/tests/remote_run_arguments_test.py
+++ b/ui-tests/tests/remote_run_arguments_test.py
@@ -14,7 +14,7 @@ with sync_playwright() as p:
     page = context.new_page()
     page.goto("http://localhost:8888")
     page.wait_for_selector('#jupyterlab-splash', state='detached')
-    page.get_by_text('Xircuits File', exact=True).click()
+    page.get_by_text('New Xircuits File', exact=True).click()
 
     simulate_drag_component_from_library(page, "UTILS", "PrettyPrint")
     connect_nodes(page, {


### PR DESCRIPTION

# Description

This PR introduces the following enhancements to the Xircuits Launcher:

---

###  "Xircuits Templates" section
Adds a new section in the Launcher to display curated example templates like Agent and Service workflows. Each button:
- Installs required component libraries via terminal
- Opens a fresh copy of the workflow file (non-destructive)
- Automatically refreshes the component list

---

###  `registerTemplateButton` helper
A reusable function to add example buttons to the Launcher with custom labels, paths, and ranks.

---

###  "User Templates" section
Automatically loads and displays all `.xircuits` files found in the `.xircuits/templates/` folder.

- Each template opens in a new untitled file
- Section is hidden if the folder is missing or empty

---

###  Improved Launcher order
Ensures:
- `"Xircuits Templates"` always appears first
- `"User Templates"` appears second if available

---

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Tests

To verify the changes:

1. Follow the setup steps described here:  
   https://xircuits.io/docs/main/developer-guide/developing-xircuits-core-features/#rebuild

2. Launch JupyterLab and confirm that:
   - A new section **"Xircuits Templates"** appears in the Launcher with example buttons (e.g., Agent, Service).
   - A **"User Templates"** section appears when `.xircuits/templates` contains `.xircuits` files.
   - Clicking any example opens a new copy and installs the required libraries automatically.



**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux (Fedora)
- [ ] Mac  
- [ ] Others  (State here -> xxx )  


