### PR TITLE
Sync JupyterLab theme with Xircuits toggle

### DIFF
--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -700,8 +700,14 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			return;
 		}
 
-		let mode = lightMode;
-		setLightMode(!mode)
+		const newLightMode = !lightMode;
+
+		const desiredTheme = newLightMode ? 'JupyterLab Light' : 'JupyterLab Dark';
+		void app.commands.execute('apputils:change-theme', { theme: desiredTheme });
+		// Delay to avoid visual mismatch while JupyterLab updates theme
+		setTimeout(() => {
+		setLightMode(newLightMode);
+		}, 120);
 	}
 
 	// Helper function to compute argument nodes on demand

--- a/style/base.css
+++ b/style/base.css
@@ -89,22 +89,6 @@ body.low-powered-mode .lucide-battery-charging {
   fill: currentColor;
 }
 
-body.light-mode .dark-mode-switch .sun {
-  visibility: visible;
-}
-
-body.light-mode .dark-mode-switch .moon {
-  visibility: hidden;
-}
-
-body .dark-mode-switch .sun {
-  visibility: hidden;
-}
-
-body .dark-mode-switch .moon {
-  visibility: visible;
-}
-
 body.light-mode .xircuits-canvas {
   background-color: #f5f5f5;
   background-image: radial-gradient(oklch(85% 0% 0) 1px, transparent 0);
@@ -169,3 +153,12 @@ body.light-mode .xircuits-canvas .node .comment-node>div:nth-child(2) {
 body.light-mode .xircuits-canvas  {
   stroke: darkgreen;
 }
+jp-button[title="Toggle Light/Dark Mode"] .sun{ visibility: hidden; }
+
+body.light-mode jp-button[title="Toggle Light/Dark Mode"]  .moon  { visibility: hidden; }
+
+body.light-mode jp-button[title="Toggle Light/Dark Mode"]  .sun  { visibility: visible; }
+
+
+
+


### PR DESCRIPTION
# Description

This PR implements one-way theme synchronization between Xircuits and JupyterLab:

- When the user toggles the theme from the Xircuits toolbar, JupyterLab's theme is updated accordingly (Light or Dark).
- Added a slight delay before updating Xircuits theme to prevent visual mismatch during JupyterLab’s theme transition.

Note: Changes in JupyterLab’s theme settings will not affect Xircuits — sync is one-way only (Xircuits → JupyterLab).

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)



**Tested on? Specify Version.**

- [x] Fedora 


