### PR TITLE
✨ Migrate library checks to get_config & API-based installs + 🐞 Fix launcher section reorder

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -584,7 +584,6 @@ const xircuits: JupyterFrontEndPlugin<void> = {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
-            'X-XSRFToken': getXsrfToken() ?? ''
           },
           credentials: 'same-origin'
         });
@@ -795,10 +794,10 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       );
       reorderSections(sections);
     }
-
+    // Prevent reordering the same launcher multiple times.
+    // layoutModified may trigger multiple times (e.g., theme change, panel move)
     app.restored.then(() => {
-      const processed = new WeakSet<HTMLElement>();
-
+    const processed = new WeakSet<HTMLElement>();
     (app.shell as any).layoutModified?.connect(() => {
         document.querySelectorAll<HTMLElement>('.jp-Launcher').forEach(ln => {
           if (!processed.has(ln)) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -573,22 +573,12 @@ const xircuits: JupyterFrontEndPlugin<void> = {
       });
     }
 
-    function getXsrfToken(): string | null {
-      const matches = document.cookie.match('\\b_xsrf=([^;]*)\\b');
-      return matches ? decodeURIComponent(matches[1]) : null;
-    }
-
     async function getInstalledLibraries(): Promise<Set<string>> {
       try {
-        const res = await fetch('/xircuits/library/get_config', {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          credentials: 'same-origin'
+        const result = await requestAPI<any>('library/get_config', {
+          method: 'GET'
         });
 
-        const result = await res.json();
         return new Set<string>(
           result.config.libraries
             .filter((lib: any) => lib.status === 'installed' && typeof lib.name === 'string')
@@ -625,21 +615,14 @@ const xircuits: JupyterFrontEndPlugin<void> = {
           if (!confirmed) return false;
 
           try {
-            const xsrf = getXsrfToken();
 
-            const res = await fetch('/xircuits/library/install', {
+            const result = await requestAPI<any>('library/install', {
               method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'X-XSRFToken': xsrf ?? ''
-              },
-              credentials: 'same-origin',
               body: JSON.stringify({ libraryName: lib })
             });
 
-            const result = await res.json();
 
-            if (res.ok && result.status === 'OK') {
+            if (result.status === 'OK') {
               console.log(`Library ${lib} installed successfully.`);
               return true;
             } else {


### PR DESCRIPTION

# Description

- Switched library presence check from folder-based detection to using the `get_config` endpoint.
- Replaced terminal-based library installation with a more stable API-based flow.
- Fixed a case where the launcher sections were not reordered correctly after auto-opening.


## Pull Request Type

- [x] Xircuits Core (JupyterLab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux (Fedora)
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

