### PR TITLE
Show component parse error only on manual reload

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -22,7 +22,7 @@ import { PointModel } from '@projectstorm/react-diagrams';
 import { Point } from '@projectstorm/geometry';
 import { createArgumentNode, createLiteralNode, handleArgumentInput, handleLiteralInput } from '../tray_library/GeneralComponentLib';
 import { CustomDynaPortModel } from '../components/port/CustomDynaPortModel';
-import { fetchComponents } from '../tray_library/Component';
+import { manualReload } from '../tray_library/Component';
 import { BaseComponentLibrary } from '../tray_library/BaseComponentLib';
 import { commandIDs } from "./CommandIDs";
 
@@ -229,7 +229,7 @@ export function addNodeActionCommands(
     commands.addCommand(commandIDs.reloadNode, {
         execute: async () => {
 
-            await fetchComponents();
+            await manualReload();
 
             const widget = tracker.currentWidget?.content as XircuitsPanel;
             const engine = widget.xircuitsApp.getDiagramEngine();

--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -25,6 +25,7 @@ import { MenuSvg } from "@jupyterlab/ui-components";
 import { commandIDs } from "../commands/CommandIDs";
 import { NodePreview } from "./NodePreview";
 import { ellipsesIcon } from "@jupyterlab/ui-components";
+import { manualReload } from "./Component";
 
 
 export const Body = styled.div`
@@ -156,13 +157,13 @@ export default function Sidebar(props: SidebarProps) {
     }, [category, componentList]);
 
     function handleRefreshOnClick() {
-        refreshComponentListCache();
+        manualReload();
         fetchComponentList();
     }
 
     useEffect(() => {
         const refreshComponents = () => {
-            handleRefreshOnClick();
+            fetchComponentList();
         };
 
         factory.refreshComponentsSignal.connect(refreshComponents);


### PR DESCRIPTION
# Description

- Added a manual reload flag to control popup visibility.
- Error popup now appears only when reload is triggered manually.
- Silent reloads (e.g. auto-save) will no longer show parse errors to the user.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)
- [ ] 
## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Test A – Silent Reload (Auto-save):**
   1. Open a component Python file (e.g. `utils.py`).
   2. Introduce a syntax error (e.g. missing parenthesis).
   3. Wait for auto-save to trigger.
   4. ✅ Confirm that no popup appears.

**2. Test B – Manual Reload :**
   1. Click reload.
   2. ✅ Confirm that the popup appears showing the syntax error from the file.

**3. Test C – Fix the Syntax Error:**
   1. Fix the invalid syntax.
   2. Reload.
   3. ✅ Confirm that the popup does not appear anymore.

**Tested on? Specify Version.**

- [x] Linux (Fedora)