### PR TITLE
✨ Implement "Drop Node on Link" feature

### DIFF
--- a/src/components/link/LinkSplitManager.ts
+++ b/src/components/link/LinkSplitManager.ts
@@ -1,0 +1,61 @@
+// src/components/link/LinkSplitManager.ts
+
+import { DiagramModel, DefaultLinkModel } from '@projectstorm/react-diagrams';
+import { CustomPortModel } from '../port/CustomPortModel';
+
+export class LinkSplitManager {
+    private static hoveredLinkId: string | null = null;
+
+    static getHoveredLinkId(): string | null {
+        return this.hoveredLinkId;
+    }
+    
+    /**
+     * Detects if the pointer is currently hovering over a link.
+     * Returns the linkId if found, or null otherwise.
+     */
+    static detectLinkUnderPointer(clientX: number, clientY: number): string | null {
+        const els = document.elementsFromPoint(clientX, clientY) as HTMLElement[];
+        const gEl = els.find(el => el.dataset && el.dataset.linkid);
+        return gEl?.dataset?.linkid ?? null;
+    }
+
+    
+    static canSplit(link: DefaultLinkModel): boolean {
+        const src = link.getSourcePort() as CustomPortModel;
+        const dst = link.getTargetPort() as CustomPortModel;
+        return src.getName() === 'out-0' && dst.getName() === 'in-0';
+    }
+
+    /**
+     * Highlights a link on hover, only if canSplit returns true.
+     * @param linkId ID of the link under the pointer
+     * @param model  The DiagramModel instance (engine.getModel())
+     */
+    static setHover(linkId: string | null, model: DiagramModel): void {
+    if (linkId === this.hoveredLinkId) return;
+    this.clearHover();
+
+    if (linkId) {
+        const link = model.getLink(linkId) as DefaultLinkModel;
+        if (link && this.canSplit(link)) {
+        const g = document.querySelector(`g[data-linkid="${linkId}"]`) as SVGGElement | null;
+        g?.classList.add('hover');
+        this.hoveredLinkId = linkId;
+        return;
+        }
+    }
+    this.hoveredLinkId = null;
+    }
+
+
+    static clearHover(): void {
+        if (!this.hoveredLinkId) return;
+
+        const g = document.querySelector(
+        `g[data-linkid="${this.hoveredLinkId}"]`
+        ) as SVGGElement | null;
+        g?.classList.remove('hover');
+        this.hoveredLinkId = null;
+    }
+    }

--- a/src/components/link/SplitLinkCommand.ts
+++ b/src/components/link/SplitLinkCommand.ts
@@ -1,76 +1,115 @@
 import {
   DefaultLinkModel,
-  DiagramModel
+  DiagramModel,
+  PointModel
 } from '@projectstorm/react-diagrams';
 import { Point } from '@projectstorm/geometry';
 import { CustomPortModel } from '../port/CustomPortModel';
 import { CustomNodeModel } from '../node/CustomNodeModel';
 import { Notification } from '@jupyterlab/apputils';
 
+/**
+ * Calculates the squared distance from point `p` to the closest point on segment AB.
+ * Used to find which segment of the original link is closest to the dropPosition location.
+ */
+const dist2Seg = (p: Point, a: Point, b: Point) => {
+  const dx = b.x - a.x, dy = b.y - a.y;
+  if (!dx && !dy) return (p.x - a.x)**2 + (p.y - a.y)**2;
+  const t = Math.max(
+    0,
+    Math.min(
+      1,
+      ((p.x - a.x)*dx + (p.y - a.y)*dy)/(dx*dx + dy*dy)
+    )
+  );
+  const qx = a.x + t*dx, qy = a.y + t*dy;
+  return (p.x - qx)**2 + (p.y - qy)**2;
+};
+
 export class SplitLinkCommand {
-    constructor(
-        private diagramModel : DiagramModel,
-        private draggedNode   : CustomNodeModel,
-        private linkId        : string,   
-        private dropPosition  : Point      
-    ) {}
+  constructor(
+    private diagramModel : DiagramModel,
+    private draggedNode  : CustomNodeModel,
+    private linkId       : string,
+    private dropPosition : Point
+  ) {}
 
-    private forceLink(src: CustomPortModel, dst: CustomPortModel): void {
-        Object.values(src.getLinks()).forEach(l => this.diagramModel.removeLink(l));
-        Object.values(dst.getLinks()).forEach(l => this.diagramModel.removeLink(l));
+  // Creates a new link between two ports and inserts bend-points if needed
+  private createLink(
+    src: CustomPortModel,
+    dst: CustomPortModel,
+    bends: PointModel[]
+  ) {
+    const newLink = new DefaultLinkModel();
+    newLink.setSourcePort(src);
+    newLink.setTargetPort(dst);
+    bends.forEach(p =>
+      newLink.addPoint(newLink.generatePoint(p.getX(), p.getY()), newLink.getPoints().length - 1)
+    );
+    this.diagramModel.addLink(newLink);
+  }
 
-        // Create and add new link directly
-        const newLink = new DefaultLinkModel();
-        newLink.setSourcePort(src);
-        newLink.setTargetPort(dst);
-        this.diagramModel.addLink(newLink);
+  execute() {
+    const inPort = this.draggedNode.getPort('in-0') as CustomPortModel;
+    const outPort = this.draggedNode.getPort('out-0') as CustomPortModel;
+
+    if (!inPort || !outPort) {
+      Notification.error("This component can't connect — missing ports.", { autoClose: 3000 });
+      return;
     }
 
-    execute(): void {
-        const sourcePort = this.draggedNode.getPort("in-0");
-        const targetPort = this.draggedNode.getPort("out-0");
+    const existingInLinks = Object.values(inPort.getLinks());
+    const existingOutLinks = Object.values(outPort.getLinks());
+    if (existingInLinks.length > 0 || existingOutLinks.length > 0) {
+      Notification.info("One or more ports are already connected. Existing connections will be removed.", { autoClose: 3000 });
+      existingInLinks.forEach(l => this.diagramModel.removeLink(l));
+      existingOutLinks.forEach(l => this.diagramModel.removeLink(l));
+    }
 
-        if (
-            (sourcePort && Object.keys(sourcePort.getLinks()).length > 0) ||
-            (targetPort && Object.keys(targetPort.getLinks()).length > 0)
-            ) {
-            Notification.info("One or more ports are already connected. Existing connection will be overwritten.", { autoClose: 3000 });
-            }
+    const oldLink = this.diagramModel.getLink(this.linkId) as DefaultLinkModel;
+    if (!oldLink) return;
 
-        if (!sourcePort || !targetPort) {
-            Notification.error("This component can't connect — missing ports.", { autoClose: 3000 });
-            return;
-        }
-        const oldLink = this.diagramModel.getLink(this.linkId) as DefaultLinkModel;
-        if (!oldLink) return;
-
-        const srcPort = oldLink.getSourcePort() as CustomPortModel;
-        const dstPort = oldLink.getTargetPort() as CustomPortModel;
-        if (!srcPort || !dstPort) return;
-        if (srcPort.getName() !== 'out-0' || dstPort.getName() !== 'in-0') {
+    const srcPort = oldLink.getSourcePort() as CustomPortModel;
+    const dstPort = oldLink.getTargetPort() as CustomPortModel;
+    if (!srcPort || !dstPort) return;
+    if (srcPort.getName() !== 'out-0' || dstPort.getName() !== 'in-0') {
         return;
         }
 
-        if (!this.diagramModel.getNode(this.draggedNode.getID())) {
-        this.diagramModel.addNode(this.draggedNode);
-        }
-
-        this.draggedNode.setPosition(this.dropPosition.x, this.dropPosition.y);
-
-        const inPort  = this.draggedNode.getPort('in-0')  as CustomPortModel;
-        const outPort = this.draggedNode.getPort('out-0') as CustomPortModel;
-        if (!inPort || !outPort) {
-        console.warn('[SplitLink] Dropped node is missing in-0 or out-0 ports.');
-        return;
-        }
-
-        this.diagramModel.removeLink(oldLink);
-
-        Object.values(srcPort.getLinks()).forEach(l => this.diagramModel.removeLink(l));
-        Object.values(inPort.getLinks()).forEach(l => this.diagramModel.removeLink(l));
-        Object.values(dstPort.getLinks()).forEach(l => this.diagramModel.removeLink(l));
-
-        this.forceLink(srcPort, inPort);   
-        this.forceLink(outPort, dstPort); 
+    if (!this.diagramModel.getNode(this.draggedNode.getID())) {
+      this.diagramModel.addNode(this.draggedNode);
     }
+
+    this.draggedNode.setPosition(this.dropPosition.x, this.dropPosition.y);
+
+    const points = oldLink.getPoints();
+    this.diagramModel.removeLink(oldLink);
+
+    // Straight link (no bends)
+    if (points.length <= 2) {
+      this.createLink(srcPort, inPort, []);
+      this.createLink(outPort, dstPort, []);
+      return;
     }
+
+    // Find the segment closest to the dropPosition point
+    let segIdx = 0, minDist = Infinity;
+    points.slice(0, -1).forEach((_, i) => {
+      const a = new Point(points[i].getX(), points[i].getY());
+      const b = new Point(points[i+1].getX(), points[i+1].getY());
+      const d2 = dist2Seg(this.dropPosition, a, b);
+      if (d2 < minDist) {
+        minDist = d2;
+        segIdx = i;
+      }
+    });
+
+    // Bend-points before and after the dropPosition segment (excluding endpoints)
+    const leftBends = segIdx > 0 ? points.slice(1, segIdx+1) : [];
+    const rightBends = segIdx+1 < points.length-1 ? points.slice(segIdx+1, -1) : [];
+
+    // Reconnect with preserved bend-points
+    this.createLink(srcPort, inPort, leftBends);
+    this.createLink(outPort, dstPort, rightBends);
+  }
+}

--- a/src/components/link/SplitLinkCommand.ts
+++ b/src/components/link/SplitLinkCommand.ts
@@ -1,0 +1,76 @@
+import {
+  DefaultLinkModel,
+  DiagramModel
+} from '@projectstorm/react-diagrams';
+import { Point } from '@projectstorm/geometry';
+import { CustomPortModel } from '../port/CustomPortModel';
+import { CustomNodeModel } from '../node/CustomNodeModel';
+import { Notification } from '@jupyterlab/apputils';
+
+export class SplitLinkCommand {
+    constructor(
+        private diagramModel : DiagramModel,
+        private draggedNode   : CustomNodeModel,
+        private linkId        : string,   
+        private dropPosition  : Point      
+    ) {}
+
+    private forceLink(src: CustomPortModel, dst: CustomPortModel): void {
+        Object.values(src.getLinks()).forEach(l => this.diagramModel.removeLink(l));
+        Object.values(dst.getLinks()).forEach(l => this.diagramModel.removeLink(l));
+
+        // Create and add new link directly
+        const newLink = new DefaultLinkModel();
+        newLink.setSourcePort(src);
+        newLink.setTargetPort(dst);
+        this.diagramModel.addLink(newLink);
+    }
+
+    execute(): void {
+        const sourcePort = this.draggedNode.getPort("in-0");
+        const targetPort = this.draggedNode.getPort("out-0");
+
+        if (
+            (sourcePort && Object.keys(sourcePort.getLinks()).length > 0) ||
+            (targetPort && Object.keys(targetPort.getLinks()).length > 0)
+            ) {
+            Notification.info("One or more ports are already connected. Existing connection will be overwritten.", { autoClose: 3000 });
+            }
+
+        if (!sourcePort || !targetPort) {
+            Notification.error("This component can't connect — missing ports.", { autoClose: 3000 });
+            return;
+        }
+        const oldLink = this.diagramModel.getLink(this.linkId) as DefaultLinkModel;
+        if (!oldLink) return;
+
+        const srcPort = oldLink.getSourcePort() as CustomPortModel;
+        const dstPort = oldLink.getTargetPort() as CustomPortModel;
+        if (!srcPort || !dstPort) return;
+        if (srcPort.getName() !== 'out-0' || dstPort.getName() !== 'in-0') {
+        return;
+        }
+
+        if (!this.diagramModel.getNode(this.draggedNode.getID())) {
+        this.diagramModel.addNode(this.draggedNode);
+        }
+
+        this.draggedNode.setPosition(this.dropPosition.x, this.dropPosition.y);
+
+        const inPort  = this.draggedNode.getPort('in-0')  as CustomPortModel;
+        const outPort = this.draggedNode.getPort('out-0') as CustomPortModel;
+        if (!inPort || !outPort) {
+        console.warn('[SplitLink] Dropped node is missing in-0 or out-0 ports.');
+        return;
+        }
+
+        this.diagramModel.removeLink(oldLink);
+
+        Object.values(srcPort.getLinks()).forEach(l => this.diagramModel.removeLink(l));
+        Object.values(inPort.getLinks()).forEach(l => this.diagramModel.removeLink(l));
+        Object.values(dstPort.getLinks()).forEach(l => this.diagramModel.removeLink(l));
+
+        this.forceLink(srcPort, inPort);   
+        this.forceLink(outPort, dstPort); 
+    }
+    }

--- a/src/components/link/SplitLinkCommand.ts
+++ b/src/components/link/SplitLinkCommand.ts
@@ -13,57 +13,55 @@ import { Notification } from '@jupyterlab/apputils';
  * Used to find which segment of the original link is closest to the dropPosition location.
  */
 const dist2Seg = (p: Point, a: Point, b: Point) => {
-  const dx = b.x - a.x, dy = b.y - a.y;
-  if (!dx && !dy) return (p.x - a.x)**2 + (p.y - a.y)**2;
-  const t = Math.max(
-    0,
-    Math.min(
-      1,
-      ((p.x - a.x)*dx + (p.y - a.y)*dy)/(dx*dx + dy*dy)
-    )
-  );
-  const qx = a.x + t*dx, qy = a.y + t*dy;
-  return (p.x - qx)**2 + (p.y - qy)**2;
-};
+    const dx = b.x - a.x, dy = b.y - a.y;
+    if (!dx && !dy) return (p.x - a.x)**2 + (p.y - a.y)**2;
+    const t = Math.max(
+        0,
+        Math.min(
+          1,
+          ((p.x - a.x)*dx + (p.y - a.y)*dy)/(dx*dx + dy*dy)
+      )
+    );
+    const qx = a.x + t*dx, qy = a.y + t*dy;
+    return (p.x - qx)**2 + (p.y - qy)**2;
+  };
 
 export class SplitLinkCommand {
-  constructor(
-    private diagramModel : DiagramModel,
-    private draggedNode  : CustomNodeModel,
-    private linkId       : string,
-    private dropPosition : Point
-  ) {}
+    constructor(
+        private diagramModel : DiagramModel,
+        private draggedNode  : CustomNodeModel,
+        private linkId       : string,
+        private dropPosition : Point
+      ) {}
 
-  // Creates a new link between two ports and inserts bend-points if needed
-  private createLink(
-    src: CustomPortModel,
-    dst: CustomPortModel,
-    bends: PointModel[]
-  ) {
-    const newLink = new DefaultLinkModel();
-    newLink.setSourcePort(src);
-    newLink.setTargetPort(dst);
-    bends.forEach(p =>
-      newLink.addPoint(newLink.generatePoint(p.getX(), p.getY()), newLink.getPoints().length - 1)
-    );
-    this.diagramModel.addLink(newLink);
+  // Helper to clone a point onto a new link (maintains internal refs).
+  private clonePoint(orig: PointModel, link: DefaultLinkModel): PointModel {
+      return link.generatePoint(orig.getX(), orig.getY());
   }
 
-  execute() {
-    const inPort = this.draggedNode.getPort('in-0') as CustomPortModel;
-    const outPort = this.draggedNode.getPort('out-0') as CustomPortModel;
+   /** Remove all links on *any* port of the dragged node */
+  private clearAllNodeLinks() {
+    Object.values(this.draggedNode.getPorts()).forEach(port =>
+      Object.values((port as CustomPortModel).getLinks()).forEach(l => this.diagramModel.removeLink(l))
+    );
+  }
+  execute(): void {
+      const inPort = this.draggedNode.getPort('in-0') as CustomPortModel;
+      const outPort = this.draggedNode.getPort('out-0') as CustomPortModel;
 
     if (!inPort || !outPort) {
-      Notification.error("This component can't connect — missing ports.", { autoClose: 3000 });
-      return;
+        Notification.error("This component can't connect — missing ports.", { autoClose: 3000 });
+        return;
     }
+    
+    this.clearAllNodeLinks();
 
     const existingInLinks = Object.values(inPort.getLinks());
     const existingOutLinks = Object.values(outPort.getLinks());
     if (existingInLinks.length > 0 || existingOutLinks.length > 0) {
-      Notification.info("One or more ports are already connected. Existing connections will be removed.", { autoClose: 3000 });
-      existingInLinks.forEach(l => this.diagramModel.removeLink(l));
-      existingOutLinks.forEach(l => this.diagramModel.removeLink(l));
+        Notification.info("One or more ports are already connected. Existing connections will be removed.", { autoClose: 3000 });
+        existingInLinks.forEach(l => this.diagramModel.removeLink(l));
+        existingOutLinks.forEach(l => this.diagramModel.removeLink(l));
     }
 
     const oldLink = this.diagramModel.getLink(this.linkId) as DefaultLinkModel;
@@ -77,39 +75,70 @@ export class SplitLinkCommand {
         }
 
     if (!this.diagramModel.getNode(this.draggedNode.getID())) {
-      this.diagramModel.addNode(this.draggedNode);
+        this.diagramModel.addNode(this.draggedNode);
     }
 
     this.draggedNode.setPosition(this.dropPosition.x, this.dropPosition.y);
 
-    const points = oldLink.getPoints();
+    const points = [...oldLink.getPoints()];
     this.diagramModel.removeLink(oldLink);
 
     // Straight link (no bends)
     if (points.length <= 2) {
-      this.createLink(srcPort, inPort, []);
-      this.createLink(outPort, dstPort, []);
-      return;
+        const leftLink = new DefaultLinkModel();
+        const rightLink = new DefaultLinkModel();
+        leftLink.setSourcePort(srcPort);
+        leftLink.setTargetPort(inPort);
+        rightLink.setSourcePort(outPort);
+        rightLink.setTargetPort(dstPort);
+        this.diagramModel.addLink(leftLink);
+        this.diagramModel.addLink(rightLink);
+        return;
     }
 
     // Find the segment closest to the dropPosition point
     let segIdx = 0, minDist = Infinity;
     points.slice(0, -1).forEach((_, i) => {
-      const a = new Point(points[i].getX(), points[i].getY());
-      const b = new Point(points[i+1].getX(), points[i+1].getY());
-      const d2 = dist2Seg(this.dropPosition, a, b);
+        const a = new Point(points[i].getX(), points[i].getY());
+        const b = new Point(points[i+1].getX(), points[i+1].getY());
+        const d2 = dist2Seg(this.dropPosition, a, b);
       if (d2 < minDist) {
-        minDist = d2;
-        segIdx = i;
+          minDist = d2;
+          segIdx = i;
       }
     });
 
-    // Bend-points before and after the dropPosition segment (excluding endpoints)
-    const leftBends = segIdx > 0 ? points.slice(1, segIdx+1) : [];
-    const rightBends = segIdx+1 < points.length-1 ? points.slice(segIdx+1, -1) : [];
+    // Clone original link twice to retain type and options
+    const leftLink = oldLink.clone() as DefaultLinkModel;
+    const rightLink = oldLink.clone() as DefaultLinkModel;
 
-    // Reconnect with preserved bend-points
-    this.createLink(srcPort, inPort, leftBends);
-    this.createLink(outPort, dstPort, rightBends);
+    // Prepare point arrays (including drop point)
+    const leftBends: PointModel[] = points
+        .slice(0, segIdx + 1)
+        .map(p => this.clonePoint(p, leftLink));
+    leftBends.push(leftLink.generatePoint(this.dropPosition.x, this.dropPosition.y));
+
+    const rightBends: PointModel[] = [
+        rightLink.generatePoint(this.dropPosition.x, this.dropPosition.y),
+        ...points.slice(segIdx + 1).map(p => this.clonePoint(p, rightLink))
+    ];
+
+    // Assign ports & set points
+    leftLink.setSourcePort(srcPort);
+    leftLink.setTargetPort(inPort);
+    leftLink.setPoints(leftBends);
+
+    rightLink.setSourcePort(outPort);
+    rightLink.setTargetPort(dstPort);
+    rightLink.setPoints(rightBends);
+
+    this.diagramModel.addLink(leftLink);
+    this.diagramModel.addLink(rightLink);
+    
+    // Highlight new links
+    leftLink.setSelected(true);
+    rightLink.setSelected(true);
+    leftBends.forEach(pt => pt.setSelected(true));
+    rightBends.forEach(pt => pt.setSelected(true));
   }
 }

--- a/src/components/state/MoveItemsState.ts
+++ b/src/components/state/MoveItemsState.ts
@@ -128,9 +128,8 @@ export class MoveItemsState<E extends CanvasEngine = CanvasEngine> extends Abstr
     const model = (this.engine as any).getModel() as DiagramModel;
     const items = this.engine.getModel().getSelectedEntities();
     const draggedNode = items.find(item => item instanceof CustomNodeModel) as CustomNodeModel|undefined;
-    const canNodeSplit = !!draggedNode?.getPort('in-0') && !!draggedNode?.getPort('out-0');
 
-    if (linkId && canNodeSplit) {
+    if (linkId) {
       const link = model.getLink(linkId) as DefaultLinkModel;
       const srcNode = link?.getSourcePort()?.getNode();
       const dstNode = link?.getTargetPort()?.getNode();

--- a/src/components/state/MoveItemsState.ts
+++ b/src/components/state/MoveItemsState.ts
@@ -12,6 +12,10 @@ import {
   State
 } from '@projectstorm/react-canvas-core';
 import { Point } from '@projectstorm/geometry';
+import { LinkSplitManager } from '../link/LinkSplitManager';
+import { SplitLinkCommand } from '../link/SplitLinkCommand';
+import { CustomNodeModel } from '../node/CustomNodeModel';
+import { DiagramModel, DefaultLinkModel } from '@projectstorm/react-diagrams';
 
 export class MoveItemsState<E extends CanvasEngine = CanvasEngine> extends AbstractDisplacementState<E> {
   initialPositions: {
@@ -52,6 +56,11 @@ export class MoveItemsState<E extends CanvasEngine = CanvasEngine> extends Abstr
             this.engine.getModel().clearSelection();
           }
           element.setSelected(true);
+          const mouseEv = event.event as MouseEvent;
+          const linkId = LinkSplitManager.detectLinkUnderPointer(mouseEv.clientX, mouseEv.clientY);
+          const model = (this.engine as any).getModel() as DiagramModel;
+          LinkSplitManager.setHover(linkId, model);
+
           this.engine.repaintCanvas();
           this.initialPosition = element['position'];
           this.finalPosition = element['position'];
@@ -60,20 +69,48 @@ export class MoveItemsState<E extends CanvasEngine = CanvasEngine> extends Abstr
     );
 
     this.registerAction(
-      new Action({
-        type: InputType.MOUSE_UP,
-        fire: () => {
-          // When node in the same position, just return
-          if (
-            this.initialPosition?.x === this.finalPosition?.x &&
-            this.initialPosition?.y === this.finalPosition?.y
-          ) {
-            return;
-          }
-          this.fireEvent();
+  new Action({
+    type: InputType.MOUSE_UP,
+    fire: (event) => {
+      const mouseEv = event.event as MouseEvent;
+      const linkId = LinkSplitManager.getHoveredLinkId();
+      const items = this.engine.getModel().getSelectedEntities();
+      const draggedNode = items.find(item => item instanceof CustomNodeModel) as CustomNodeModel;
+      const model = (this.engine as any).getModel() as DiagramModel;
+      const link = model.getLink(linkId) as DefaultLinkModel;
+
+      if (link) {
+        const srcNode = link.getSourcePort().getNode();
+        const dstNode = link.getTargetPort().getNode();
+
+        if (srcNode === draggedNode || dstNode === draggedNode) {
+          LinkSplitManager.clearHover();
+          return;
         }
-      })
-    );
+      }
+
+      if (linkId && draggedNode) {
+        const point = this.engine.getRelativeMousePoint(mouseEv);
+        new SplitLinkCommand(
+          (this.engine as any).model, 
+          draggedNode,
+          linkId,
+          point
+        ).execute();
+      }
+
+      LinkSplitManager.clearHover();
+
+      if (
+        this.initialPosition?.x === this.finalPosition?.x &&
+        this.initialPosition?.y === this.finalPosition?.y
+      ) {
+        return;
+      }
+      this.fireEvent();
+    }
+  })
+);
   }
 
   fireEvent = () => {
@@ -86,8 +123,27 @@ export class MoveItemsState<E extends CanvasEngine = CanvasEngine> extends Abstr
   }
 
   fireMouseMoved(event: AbstractDisplacementStateEvent) {
+    const mouseEv = event.event as MouseEvent;
+    const linkId = LinkSplitManager.detectLinkUnderPointer(mouseEv.clientX, mouseEv.clientY);
+    const model = (this.engine as any).getModel() as DiagramModel;
     const items = this.engine.getModel().getSelectedEntities();
-    const model = this.engine.getModel();
+    const draggedNode = items.find(item => item instanceof CustomNodeModel) as CustomNodeModel|undefined;
+    const canNodeSplit = !!draggedNode?.getPort('in-0') && !!draggedNode?.getPort('out-0');
+
+    if (linkId && canNodeSplit) {
+      const link = model.getLink(linkId) as DefaultLinkModel;
+      const srcNode = link?.getSourcePort()?.getNode();
+      const dstNode = link?.getTargetPort()?.getNode();
+
+      if (draggedNode && draggedNode !== srcNode && draggedNode !== dstNode) {
+        LinkSplitManager.setHover(linkId, model);
+      } else {
+        LinkSplitManager.clearHover();
+      }
+    } else {
+      LinkSplitManager.clearHover();
+    }
+
     for (const item of items) {
       if (item instanceof BasePositionModel) {
         if (item.isLocked()) {


### PR DESCRIPTION
# Description

This PR introduces a new feature that allows users to drag and drop a component directly onto an existing connection, automatically splitting the link and inserting the component in between — whether the component is dragged from the sidebar or from within the canvas itself.

### Video Demo


https://github.com/user-attachments/assets/9bbdfe88-bfe0-49fe-b7a8-21a0bbd4de80





### Key Features

#### 🔹 1. Link Hover Detection
- Detects when a node is dragged over a valid link (`out-0 → in-0`) using \`LinkSplitManager.detectLinkUnderPointer\`.
- Highlights the hovered link using the \`.hover\` class.

---

#### 🔹 2. Smart Link Splitting
- Introduces \`SplitLinkCommand\` that:
  - Validates required ports (\`in-0\`, \`out-0\`) on the dragged component.
  - Removes the original link and reconnects:
    - \`source → draggedNode.in-0\`
    - \`draggedNode.out-0 → target\`
- Ensures existing links on affected ports are removed before reconnecting.

---

#### 🔹 3. User Feedback
- Adds contextual notifications to inform the user when:
  - Required ports are missing.
  - Ports are already connected and will be overwritten.
  - The link is invalid or unsupported for splitting.

---

#### 🔹 4. Canvas Integration
- \`MoveItemsState.ts\`: triggers \`SplitLinkCommand\` when dragging from canvas over a valid link.
- \`XircuitsBodyWidget.tsx\`: handles \`onDrop\` event for sidebar-dragged components, and calls \`updateHoveredLink\` to support link detection and hover state.
- Includes fallback handling when no valid link is detected.

---

### Edge Case Handling
- Drops are rejected if the component lacks required ports.
- Link is validated to match \`out-0 → in-0\` before applying the split.
- Automatically clears hover state after execution.

---

### File Changes
- \`SplitLinkCommand.ts\`: defines the logic for link splitting and reconnection.
- \`LinkSplitManager.ts\`: manages link detection and hover state.
- \`MoveItemsState.ts\`: detects drop events from canvas and executes split.
- \`XircuitsBodyWidget.tsx\`: handles drop events from the sidebar and triggers \`SplitLinkCommand\` with link validation.

---

### Notes
- Only supports main flow connections (\`out-0 → in-0\`) 


---


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Tests

### **Test 1: Insert node from Canvas**

**Steps:**

1. Drag a node (with in-0 and out-0 ports) from the canvas.
2. Hover it over an existing out-0 → in-0 link.
3. Observe that the link highlights in yellow dashed style.
4. Drop the node.

**Expected Result:**

* The original link is split.
* The dragged node is inserted between the two connected nodes.
* The canvas updates with two new links:

  * source → draggedNode.in-0
  * draggedNode.out-0 → target

---

### **Test 2: Insert node from Sidebar**

**Steps:**

1. Drag a new node from the sidebar.
2. Hover it over an existing out-0 → in-0 link.
3. Observe the link highlighting.
4. Drop the node.

**Expected Result:**

* Same as above: the link is split, and node inserted between.

---

### **Test 3: Node without required ports**

**Steps:**

1. Drag a node that **does not contain** both in-0 and out-0 ports.
2. Drop it on a valid link.

**Expected Result:**

* No link is modified.
* An error notification appears:
  ➤ *“This component can’t connect — missing ports.”*

---

### **Test 4: Node with existing connections**

**Steps:**

1. Create a node and connect its ports manually.
2. Drag it over a link and drop it.

**Expected Result:**

* Previous connections are removed.
* Info notification appears:
  ➤ *“One or more ports are already connected. Existing connection will be overwritten.”*

---

### **Tested on:**

* [x] Linux (Fedora)
* [ ] Windows
* [ ] macOS
* [ ] Others
