### PR TITLE
Add RunParallelProcess component

### DIFF
--- a/examples/RunParallelProcess.xircuits
+++ b/examples/RunParallelProcess.xircuits
@@ -1,0 +1,1600 @@
+{
+    "id": "af91b71f-c0d5-4c70-ab30-82b33b6afc5f",
+    "offsetX": 0,
+    "offsetY": 95,
+    "zoom": 100,
+    "gridSize": 0,
+    "layers": [
+        {
+            "id": "231b0921-350a-4a0a-9c7b-51a9f29c5563",
+            "type": "diagram-links",
+            "isSvg": true,
+            "transformed": true,
+            "models": {
+                "4d45352f-5d26-4568-8852-3d8280ddfa69": {
+                    "id": "4d45352f-5d26-4568-8852-3d8280ddfa69",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "e63436e6-0152-455f-8799-bd5015772ad9",
+                    "sourcePort": "822b8d01-4660-4e64-a9d7-d9198ff69d80",
+                    "target": "cba1e57f-12ce-43d8-97de-a85488974261",
+                    "targetPort": "be613877-2ba4-4c48-b8ab-2aade45658f9",
+                    "points": [
+                        {
+                            "id": "f1d81d62-c3a9-432d-9b5e-38372f2b49d8",
+                            "type": "point",
+                            "x": 88.71668243408203,
+                            "y": 71.33333587646484
+                        },
+                        {
+                            "id": "5dd3d8f6-f7b0-4a20-8aec-a3867dc0f148",
+                            "type": "point",
+                            "x": 157.50003814697266,
+                            "y": 70.33333587646484
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "d18868e9-df76-4ead-8418-0e0451ce4228": {
+                    "id": "d18868e9-df76-4ead-8418-0e0451ce4228",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "16e46549-f371-465d-a66a-c520498f3d2a",
+                    "sourcePort": "d207541d-2a48-438e-84ab-d1bcbf436829",
+                    "target": "3af44e62-b3dd-452a-a369-f080d0b06c56",
+                    "targetPort": "8f70631f-8995-4c84-98c3-af81d2b5aeef",
+                    "points": [
+                        {
+                            "id": "4b7bf012-f4ae-4c73-8954-1c0cddec8d79",
+                            "type": "point",
+                            "x": 942.2000503540039,
+                            "y": 320.16666412353516
+                        },
+                        {
+                            "id": "aadd0dbd-e9c1-48db-a172-b3d71519706d",
+                            "type": "point",
+                            "x": 991.1666870117188,
+                            "y": 320
+                        },
+                        {
+                            "id": "5e4b7ed9-0388-45be-85af-1e607300ed84",
+                            "type": "point",
+                            "selected": false,
+                            "x": 989.1666870117188,
+                            "y": 92
+                        },
+                        {
+                            "id": "eab2adb4-69e1-4c76-a34d-32a4eb37ce7f",
+                            "type": "point",
+                            "x": 1016.4999771118164,
+                            "y": 92.16666412353516
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "e1788deb-50f4-4168-9658-62697a2aaabb": {
+                    "id": "e1788deb-50f4-4168-9658-62697a2aaabb",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "cba1e57f-12ce-43d8-97de-a85488974261",
+                    "sourcePort": "6e53798c-0fad-4ad9-8cb6-b8808ee57c13",
+                    "target": "3af44e62-b3dd-452a-a369-f080d0b06c56",
+                    "targetPort": "9b479d99-8646-4a8d-9d46-7761b5f78046",
+                    "points": [
+                        {
+                            "id": "837407f1-410a-484e-8e5e-28c263c3be6f",
+                            "type": "point",
+                            "x": 393.4166717529297,
+                            "y": 70.33333587646484
+                        },
+                        {
+                            "id": "504e4b04-993e-4930-8231-68d1571f1a8d",
+                            "type": "point",
+                            "x": 1016.4999771118164,
+                            "y": 70.33333587646484
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "cd0af678-03ae-4fc4-a049-8c02125c6baf": {
+                    "id": "cd0af678-03ae-4fc4-a049-8c02125c6baf",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "3af44e62-b3dd-452a-a369-f080d0b06c56",
+                    "sourcePort": "763d89c2-fe3f-4353-8d7b-e0114278b681",
+                    "target": "041ebb9e-144b-4d09-8b5e-cdccb67b085c",
+                    "targetPort": "32ced266-72fd-4aee-9ee0-bae79370e9ac",
+                    "points": [
+                        {
+                            "id": "e3f6c3c7-828b-4bb7-b8b8-b9a966022afa",
+                            "type": "point",
+                            "x": 1133.450050354004,
+                            "y": 70.33333587646484
+                        },
+                        {
+                            "id": "e50b90f2-8c4b-49ed-93b7-2992f9c95e59",
+                            "type": "point",
+                            "x": 1212.333351135254,
+                            "y": 71.33333587646484
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "78af0299-616b-4c79-925b-e1092fe45b66": {
+                    "id": "78af0299-616b-4c79-925b-e1092fe45b66",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "cba1e57f-12ce-43d8-97de-a85488974261",
+                    "sourcePort": "de0cbf2a-f220-4873-b96e-684cab5e7a90",
+                    "target": "cbba1c24-254d-46a5-b977-2b43e593fdea",
+                    "targetPort": "b876d77a-f843-4f1e-873d-2a009dd5f69c",
+                    "points": [
+                        {
+                            "id": "5ac49159-5464-4f01-b061-426f6eb1afa8",
+                            "type": "point",
+                            "x": 393.4166717529297,
+                            "y": 92.16666412353516
+                        },
+                        {
+                            "id": "e2d7fa0e-6885-4b0c-9899-72699543b395",
+                            "type": "point",
+                            "x": 436.16668701171875,
+                            "y": 93
+                        },
+                        {
+                            "id": "61f84aff-ab27-4465-8f65-380073e6c511",
+                            "type": "point",
+                            "x": 436.16668701171875,
+                            "y": 279
+                        },
+                        {
+                            "id": "c01cce04-c949-4a48-a025-c581e3e53560",
+                            "type": "point",
+                            "x": 469.50003814697266,
+                            "y": 279.3333511352539
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "c17339bc-53d7-4d31-8850-ebfe5a99bf3c": {
+                    "id": "c17339bc-53d7-4d31-8850-ebfe5a99bf3c",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "cbba1c24-254d-46a5-b977-2b43e593fdea",
+                    "sourcePort": "5f6cf083-713b-4175-99df-aa7bf3a23060",
+                    "target": "16e46549-f371-465d-a66a-c520498f3d2a",
+                    "targetPort": "0f535083-8e1a-4918-a591-e6e65909666e",
+                    "points": [
+                        {
+                            "id": "366a99c7-6b51-49c9-a9ec-1d2af5b1d3c4",
+                            "type": "point",
+                            "x": 715.1833267211914,
+                            "y": 301.16666412353516
+                        },
+                        {
+                            "id": "1fdf3b7f-fcf9-426f-b6a8-2d869a76b09e",
+                            "type": "point",
+                            "x": 789.4999771118164,
+                            "y": 298.3333511352539
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "df03857f-3111-4efe-a671-e0a0f6cfd978": {
+                    "id": "df03857f-3111-4efe-a671-e0a0f6cfd978",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "cba1e57f-12ce-43d8-97de-a85488974261",
+                    "sourcePort": "db62b491-a389-4b2d-be3b-5771d0a50830",
+                    "target": "d235034d-43c0-4514-9126-062c95b8a770",
+                    "targetPort": "a038cdd3-0363-42c1-bcb4-b09ad8649bbf",
+                    "points": [
+                        {
+                            "id": "5503555b-bb16-4fae-8fe2-d47d80a15446",
+                            "type": "point",
+                            "x": 393.4166717529297,
+                            "y": 113.99998474121094
+                        },
+                        {
+                            "id": "99136cdd-7506-45b2-8dc8-69e666119044",
+                            "type": "point",
+                            "x": 1038.1666870117188,
+                            "y": 116
+                        },
+                        {
+                            "id": "a67743c0-7d77-4ffb-ad89-1b3560b034b7",
+                            "type": "point",
+                            "x": 1040.1666870117188,
+                            "y": 350
+                        },
+                        {
+                            "id": "5df387b1-7443-4e7d-9651-c27899064083",
+                            "type": "point",
+                            "x": 1104.4999771118164,
+                            "y": 350.16666412353516
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "ca257036-45f5-458c-8b02-b3e13de308b7": {
+                    "id": "ca257036-45f5-458c-8b02-b3e13de308b7",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "cbba1c24-254d-46a5-b977-2b43e593fdea",
+                    "sourcePort": "762522fe-e144-4863-8290-603045b97876",
+                    "target": "d235034d-43c0-4514-9126-062c95b8a770",
+                    "targetPort": "00c83f36-2415-4d88-93e9-a7b69d8e5da6",
+                    "points": [
+                        {
+                            "id": "2430e8dc-7815-4af1-8c70-cf6d5b4fd2d4",
+                            "type": "point",
+                            "x": 715.1833267211914,
+                            "y": 322.99998474121094
+                        },
+                        {
+                            "id": "3e84b26a-5104-40c4-833b-8e57339b7f57",
+                            "type": "point",
+                            "x": 744.1666870117188,
+                            "y": 324
+                        },
+                        {
+                            "id": "16afc9ac-9e73-4312-b626-86d02f8e41ae",
+                            "type": "point",
+                            "x": 744.1666870117188,
+                            "y": 457
+                        },
+                        {
+                            "id": "c5dbc700-3183-457d-905d-d27d487ff603",
+                            "type": "point",
+                            "x": 1023.1666870117188,
+                            "y": 456
+                        },
+                        {
+                            "id": "32456fbb-3a45-47e2-9b8a-5a26b5f3e978",
+                            "type": "point",
+                            "x": 1021.1666870117188,
+                            "y": 373
+                        },
+                        {
+                            "id": "a1c7c75c-8989-4282-8feb-b15749c852d2",
+                            "type": "point",
+                            "x": 1104.4999771118164,
+                            "y": 371.99998474121094
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "0aeffb80-e43d-43f7-a062-18d4be7a3887": {
+                    "id": "0aeffb80-e43d-43f7-a062-18d4be7a3887",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "d235034d-43c0-4514-9126-062c95b8a770",
+                    "sourcePort": "c492df7e-9ba6-4419-a0a7-af04b97e7f1e",
+                    "target": "c03fddf1-788a-4483-b14c-94d5d7e3b790",
+                    "targetPort": "26d7ac62-e843-48f6-b8f2-89ee3c82cac1",
+                    "points": [
+                        {
+                            "id": "f0ddd7d9-af40-4854-b1dd-e15c81295135",
+                            "type": "point",
+                            "x": 1221.050033569336,
+                            "y": 328.3333511352539
+                        },
+                        {
+                            "id": "81033391-6511-4cb4-bc94-3228cf62c6c2",
+                            "type": "point",
+                            "x": 1272.4999771118164,
+                            "y": 332.3333511352539
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "00ec6148-49c7-4f74-b2b4-bb9e8be94388": {
+                    "id": "00ec6148-49c7-4f74-b2b4-bb9e8be94388",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "d235034d-43c0-4514-9126-062c95b8a770",
+                    "sourcePort": "d2b697c4-8800-411a-818b-1593679dce97",
+                    "target": "c03fddf1-788a-4483-b14c-94d5d7e3b790",
+                    "targetPort": "71a0b8ec-9b88-4ec7-adec-3112315e04cc",
+                    "points": [
+                        {
+                            "id": "9f9facbe-7cb7-4016-9b2f-b96c3da0163e",
+                            "type": "point",
+                            "x": 1221.050033569336,
+                            "y": 350.16666412353516
+                        },
+                        {
+                            "id": "d9a3bdf8-d56e-45c6-87ba-fc8f009cd3e5",
+                            "type": "point",
+                            "x": 1272.4999771118164,
+                            "y": 354.16666412353516
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "0582f6ee-4be2-4226-b3b6-b3df650d8a74": {
+                    "id": "0582f6ee-4be2-4226-b3b6-b3df650d8a74",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "d2fe0256-f394-48ba-8935-bf3122d457ac",
+                    "sourcePort": "dc751074-3a0b-41f7-8977-32fb1c8dac79",
+                    "target": "cbba1c24-254d-46a5-b977-2b43e593fdea",
+                    "targetPort": "94d0c371-ce73-48b0-b53a-b18a94f9e528",
+                    "points": [
+                        {
+                            "id": "fa23f44e-bfd3-48f1-b06a-e862ae0bac26",
+                            "type": "point",
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "id": "a16bdbed-2714-439f-817c-6c53ccdc5f79",
+                            "type": "point",
+                            "x": 469.0833740234375,
+                            "y": 300.25
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "e6f48c13-efaf-423a-9ba6-430b02b6ec65": {
+                    "id": "e6f48c13-efaf-423a-9ba6-430b02b6ec65",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "16e46549-f371-465d-a66a-c520498f3d2a",
+                    "sourcePort": "c2511e51-e208-407f-833f-be894586f4d1",
+                    "target": "9fa51310-ccda-41c8-b91c-b827502a0f25",
+                    "targetPort": "1fc2977f-de76-4d21-a550-1ed7ab0f8dba",
+                    "points": [
+                        {
+                            "id": "4b1d2122-7945-4489-9e6e-89601cbdc4a7",
+                            "type": "point",
+                            "x": 942.2000503540039,
+                            "y": 341.99998474121094
+                        },
+                        {
+                            "id": "cc61492a-f4f8-4401-b41f-3a1c426983b2",
+                            "type": "point",
+                            "x": 970.1666870117188,
+                            "y": 341
+                        },
+                        {
+                            "id": "c609b136-7f03-48a1-9b59-ae9177c2de61",
+                            "type": "point",
+                            "x": 971.1666870117188,
+                            "y": 584
+                        },
+                        {
+                            "id": "9c604617-759a-4178-ad85-6e025deebec0",
+                            "type": "point",
+                            "x": 997.4999771118164,
+                            "y": 583.3333511352539
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "c2d83de8-d82e-454d-a8d0-21eecd690096": {
+                    "id": "c2d83de8-d82e-454d-a8d0-21eecd690096",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "9fa51310-ccda-41c8-b91c-b827502a0f25",
+                    "sourcePort": "a893e826-51ef-4199-9ace-05a344282248",
+                    "target": "d235034d-43c0-4514-9126-062c95b8a770",
+                    "targetPort": "d43d03c8-0cd7-4470-919f-c8c95d71636a",
+                    "points": [
+                        {
+                            "id": "c7d12534-6a90-43ae-8ce5-87af83ac41ae",
+                            "type": "point",
+                            "x": 1136.266700744629,
+                            "y": 583.3333511352539
+                        },
+                        {
+                            "id": "f5024c1d-2af0-4ba0-aeb6-7723bc00b8ee",
+                            "type": "point",
+                            "x": 1176.1666870117188,
+                            "y": 584
+                        },
+                        {
+                            "id": "ca6f5dd7-cf2d-4051-ba73-59506f7c3de1",
+                            "type": "point",
+                            "x": 1174.1666870117188,
+                            "y": 500
+                        },
+                        {
+                            "id": "dab3cbc8-b463-4964-b140-83ba57fa4916",
+                            "type": "point",
+                            "x": 1070.1666870117188,
+                            "y": 501
+                        },
+                        {
+                            "id": "5742d748-d2c2-4694-956f-cf0d55bde3f8",
+                            "type": "point",
+                            "x": 1071.1666870117188,
+                            "y": 328
+                        },
+                        {
+                            "id": "3ef01739-54f6-41f3-8330-71b09c739b3f",
+                            "type": "point",
+                            "x": 1104.4999771118164,
+                            "y": 328.3333511352539
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "a2197218-1882-4eaa-9316-d95abf72bd5f": {
+                    "id": "a2197218-1882-4eaa-9316-d95abf72bd5f",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "0ab80806-e7c8-4ba0-99c6-04d7521aeef8",
+                    "sourcePort": "df479f7b-32b6-49ca-9179-98a0ca7133d7",
+                    "target": "cba1e57f-12ce-43d8-97de-a85488974261",
+                    "targetPort": "bdfc9023-fbbf-45aa-8809-3d97a763c812",
+                    "points": [
+                        {
+                            "id": "7f1a8916-90d2-42cc-9f5c-34881ac548fe",
+                            "type": "point",
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "id": "1f5d53c6-943b-4ddc-80a8-6326df6d8e55",
+                            "type": "point",
+                            "x": 157.0833740234375,
+                            "y": 91.25
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "47f98267-f865-477d-b0ee-241ad0034819": {
+                    "id": "47f98267-f865-477d-b0ee-241ad0034819",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "111c1068-e790-4eb3-824a-95e9a69a4dce",
+                    "sourcePort": "bcd91a82-00d6-4858-994e-97be4a6a05e6",
+                    "target": "16e46549-f371-465d-a66a-c520498f3d2a",
+                    "targetPort": "a55ea7c9-4333-40d9-8d68-9925de72bd92",
+                    "points": [
+                        {
+                            "id": "59f352b2-5649-4c5a-b7d5-fed302eb79b3",
+                            "type": "point",
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "id": "b57ce292-0a82-4e57-a527-7529b15d7e3e",
+                            "type": "point",
+                            "x": 789.0833129882812,
+                            "y": 319.25
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "ef72c477-5afd-4a16-8d4d-5397f3e38f00": {
+                    "id": "ef72c477-5afd-4a16-8d4d-5397f3e38f00",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "5b6e0728-0102-45da-be75-a6e78c207796",
+                    "sourcePort": "baea3b88-45be-439f-a6b0-ec1782cbf954",
+                    "target": "9fa51310-ccda-41c8-b91c-b827502a0f25",
+                    "targetPort": "508c496a-ff4b-488b-ab96-a072ee3bc0fa",
+                    "points": [
+                        {
+                            "id": "0d65ea26-28fa-445a-88ce-92862891c5fb",
+                            "type": "point",
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "id": "faf2e794-bb4f-47f3-ac5f-b261f90207a6",
+                            "type": "point",
+                            "x": 997.0833129882812,
+                            "y": 604.25
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                }
+            }
+        },
+        {
+            "id": "2fe167e9-c3fe-432b-b890-85957a598aef",
+            "type": "diagram-nodes",
+            "isSvg": false,
+            "transformed": true,
+            "models": {
+                "e63436e6-0152-455f-8799-bd5015772ad9": {
+                    "id": "e63436e6-0152-455f-8799-bd5015772ad9",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "Start",
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": 21,
+                    "y": 34,
+                    "ports": [
+                        {
+                            "id": "822b8d01-4660-4e64-a9d7-d9198ff69d80",
+                            "type": "default",
+                            "extras": {},
+                            "x": 78.30001831054688,
+                            "y": 60.91667175292969,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "e63436e6-0152-455f-8799-bd5015772ad9",
+                            "links": [
+                                "4d45352f-5d26-4568-8852-3d8280ddfa69"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "Start",
+                    "color": "rgb(255,102,102)",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "822b8d01-4660-4e64-a9d7-d9198ff69d80"
+                    ]
+                },
+                "041ebb9e-144b-4d09-8b5e-cdccb67b085c": {
+                    "id": "041ebb9e-144b-4d09-8b5e-cdccb67b085c",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "Finish",
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": 1201,
+                    "y": 34,
+                    "ports": [
+                        {
+                            "id": "32ced266-72fd-4aee-9ee0-bae79370e9ac",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1201.9166870117188,
+                            "y": 60.91667175292969,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "041ebb9e-144b-4d09-8b5e-cdccb67b085c",
+                            "links": [
+                                "cd0af678-03ae-4fc4-a049-8c02125c6baf"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "21c160b7-3c11-4fcb-9d10-1e240ce2a75e",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1201.9166870117188,
+                            "y": 82.75,
+                            "name": "parameter-dynalist-outputs",
+                            "alignment": "left",
+                            "parentNode": "041ebb9e-144b-4d09-8b5e-cdccb67b085c",
+                            "links": [],
+                            "in": true,
+                            "label": "outputs",
+                            "varName": "outputs",
+                            "portType": "",
+                            "dataType": "dynalist",
+                            "dynaPortOrder": 0,
+                            "dynaPortRef": {
+                                "previous": null,
+                                "next": null
+                            }
+                        }
+                    ],
+                    "name": "Finish",
+                    "color": "rgb(255,102,102)",
+                    "portsInOrder": [
+                        "32ced266-72fd-4aee-9ee0-bae79370e9ac",
+                        "21c160b7-3c11-4fcb-9d10-1e240ce2a75e"
+                    ],
+                    "portsOutOrder": []
+                },
+                "cba1e57f-12ce-43d8-97de-a85488974261": {
+                    "id": "cba1e57f-12ce-43d8-97de-a85488974261",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "branch",
+                        "path": "xai_components/xai_controlflow/branches.py",
+                        "description": "A component that iterates over a list, executing body branches for each item.\n\n##### inPorts:\n- items (list): The list of items to iterate over.\n\n##### outPorts:\n- current_item (any): The current item in the iteration.\n- current_index (int): The index of the current item in the iteration.\n\n##### Branches:\n- body: Branch that executes for each item.",
+                        "lineNo": [
+                            {
+                                "lineno": 85,
+                                "end_lineno": 112
+                            }
+                        ],
+                        "borderColor": "rgb(0,192,255)",
+                        "finishNodeId": "3af44e62-b3dd-452a-a369-f080d0b06c56",
+                        "isBranchNode": true
+                    },
+                    "x": 146.16668701171875,
+                    "y": 33,
+                    "ports": [
+                        {
+                            "id": "be613877-2ba4-4c48-b8ab-2aade45658f9",
+                            "type": "default",
+                            "extras": {},
+                            "x": 147.0833740234375,
+                            "y": 59.91667175292969,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "cba1e57f-12ce-43d8-97de-a85488974261",
+                            "links": [
+                                "4d45352f-5d26-4568-8852-3d8280ddfa69"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "bdfc9023-fbbf-45aa-8809-3d97a763c812",
+                            "type": "default",
+                            "extras": {},
+                            "x": 147.0833740234375,
+                            "y": 81.75,
+                            "name": "parameter-list-items",
+                            "alignment": "left",
+                            "parentNode": "cba1e57f-12ce-43d8-97de-a85488974261",
+                            "links": [
+                                "a2197218-1882-4eaa-9316-d95abf72bd5f"
+                            ],
+                            "in": true,
+                            "label": "★items",
+                            "varName": "★items",
+                            "portType": "",
+                            "dataType": "list"
+                        },
+                        {
+                            "id": "6e53798c-0fad-4ad9-8cb6-b8808ee57c13",
+                            "type": "default",
+                            "extras": {},
+                            "x": 383,
+                            "y": 59.91667175292969,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "cba1e57f-12ce-43d8-97de-a85488974261",
+                            "links": [
+                                "e1788deb-50f4-4168-9658-62697a2aaabb"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "de0cbf2a-f220-4873-b96e-684cab5e7a90",
+                            "type": "default",
+                            "extras": {},
+                            "x": 383,
+                            "y": 81.75,
+                            "name": "out-flow-body",
+                            "alignment": "right",
+                            "parentNode": "cba1e57f-12ce-43d8-97de-a85488974261",
+                            "links": [
+                                "78af0299-616b-4c79-925b-e1092fe45b66"
+                            ],
+                            "in": false,
+                            "label": "body ▶",
+                            "varName": "body ▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "db62b491-a389-4b2d-be3b-5771d0a50830",
+                            "type": "default",
+                            "extras": {},
+                            "x": 383,
+                            "y": 103.58331298828125,
+                            "name": "parameter-out-any-current_item",
+                            "alignment": "right",
+                            "parentNode": "cba1e57f-12ce-43d8-97de-a85488974261",
+                            "links": [
+                                "df03857f-3111-4efe-a671-e0a0f6cfd978"
+                            ],
+                            "in": false,
+                            "label": "current_item",
+                            "varName": "current_item",
+                            "portType": "",
+                            "dataType": "any"
+                        },
+                        {
+                            "id": "a3c5ed5a-a8ae-4713-b7e7-b68566bbb171",
+                            "type": "default",
+                            "extras": {},
+                            "x": 383,
+                            "y": 125.41668701171875,
+                            "name": "parameter-out-int-current_index",
+                            "alignment": "right",
+                            "parentNode": "cba1e57f-12ce-43d8-97de-a85488974261",
+                            "links": [],
+                            "in": false,
+                            "label": "current_index",
+                            "varName": "current_index",
+                            "portType": "",
+                            "dataType": "int"
+                        }
+                    ],
+                    "name": "ForEach",
+                    "color": "rgb(255,153,102)",
+                    "portsInOrder": [
+                        "be613877-2ba4-4c48-b8ab-2aade45658f9",
+                        "bdfc9023-fbbf-45aa-8809-3d97a763c812"
+                    ],
+                    "portsOutOrder": [
+                        "6e53798c-0fad-4ad9-8cb6-b8808ee57c13",
+                        "de0cbf2a-f220-4873-b96e-684cab5e7a90",
+                        "db62b491-a389-4b2d-be3b-5771d0a50830",
+                        "a3c5ed5a-a8ae-4713-b7e7-b68566bbb171"
+                    ]
+                },
+                "c03fddf1-788a-4483-b14c-94d5d7e3b790": {
+                    "id": "c03fddf1-788a-4483-b14c-94d5d7e3b790",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "library_component",
+                        "path": "xai_components/xai_utils/utils.py",
+                        "description": "Prints a message in a pretty format using pprint.\n\n##### inPorts:\n- msg (any): The message to be pretty printed.",
+                        "lineNo": [
+                            {
+                                "lineno": 78,
+                                "end_lineno": 89
+                            }
+                        ],
+                        "borderColor": "rgb(0,192,255)",
+                        "sourceBranchId": "16e46549-f371-465d-a66a-c520498f3d2a",
+                        "portId": "c2511e51-e208-407f-833f-be894586f4d1",
+                        "nextNode": "None"
+                    },
+                    "x": 1261.1666870117188,
+                    "y": 295,
+                    "ports": [
+                        {
+                            "id": "26d7ac62-e843-48f6-b8f2-89ee3c82cac1",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1262.0833129882812,
+                            "y": 321.91668701171875,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "c03fddf1-788a-4483-b14c-94d5d7e3b790",
+                            "links": [
+                                "0aeffb80-e43d-43f7-a062-18d4be7a3887"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "71a0b8ec-9b88-4ec7-adec-3112315e04cc",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1262.0833129882812,
+                            "y": 343.75,
+                            "name": "parameter-any-msg",
+                            "alignment": "left",
+                            "parentNode": "c03fddf1-788a-4483-b14c-94d5d7e3b790",
+                            "links": [
+                                "00ec6148-49c7-4f74-b2b4-bb9e8be94388"
+                            ],
+                            "in": true,
+                            "label": "msg",
+                            "varName": "msg",
+                            "portType": "",
+                            "dataType": "any"
+                        },
+                        {
+                            "id": "3af2ccf4-61d2-4367-a1e2-91f7daf0aa0c",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1365.9833374023438,
+                            "y": 321.91668701171875,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "c03fddf1-788a-4483-b14c-94d5d7e3b790",
+                            "links": [],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "PrettyPrint",
+                    "color": "rgb(51,51,51)",
+                    "portsInOrder": [
+                        "26d7ac62-e843-48f6-b8f2-89ee3c82cac1",
+                        "71a0b8ec-9b88-4ec7-adec-3112315e04cc"
+                    ],
+                    "portsOutOrder": [
+                        "3af2ccf4-61d2-4367-a1e2-91f7daf0aa0c"
+                    ]
+                },
+                "16e46549-f371-465d-a66a-c520498f3d2a": {
+                    "id": "16e46549-f371-465d-a66a-c520498f3d2a",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "library_component",
+                        "path": "xai_components/xai_utils/utils.py",
+                        "description": "Executes a given body in separate processes using multiprocessing and dill.\n\n##### inPorts:\n- n_workers (int): Number of worker processes to use for executing the body in parallel.\n\n##### outPorts:\n- futures (list): Futures representing parallel executions.\n\n##### Branches:\n- body: The body (subgraph) to be run in each process.",
+                        "lineNo": [
+                            {
+                                "lineno": 746,
+                                "end_lineno": 778
+                            }
+                        ],
+                        "borderColor": "rgb(0,192,255)",
+                        "sourceBranchId": "cbba1c24-254d-46a5-b977-2b43e593fdea",
+                        "portId": "5f6cf083-713b-4175-99df-aa7bf3a23060",
+                        "finishNodeId": "None",
+                        "isBranchNode": true
+                    },
+                    "x": 778.1666870117188,
+                    "y": 261,
+                    "ports": [
+                        {
+                            "id": "0f535083-8e1a-4918-a591-e6e65909666e",
+                            "type": "default",
+                            "extras": {},
+                            "x": 779.0833129882812,
+                            "y": 287.91668701171875,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "16e46549-f371-465d-a66a-c520498f3d2a",
+                            "links": [
+                                "c17339bc-53d7-4d31-8850-ebfe5a99bf3c"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "a55ea7c9-4333-40d9-8d68-9925de72bd92",
+                            "type": "default",
+                            "extras": {},
+                            "x": 779.0833129882812,
+                            "y": 309.75,
+                            "name": "parameter-int-n_workers",
+                            "alignment": "left",
+                            "parentNode": "16e46549-f371-465d-a66a-c520498f3d2a",
+                            "links": [
+                                "47f98267-f865-477d-b0ee-241ad0034819"
+                            ],
+                            "in": true,
+                            "label": "n_workers",
+                            "varName": "n_workers",
+                            "portType": "",
+                            "dataType": "int"
+                        },
+                        {
+                            "id": "f9404eab-fd8d-4487-ad23-a0ade2689f35",
+                            "type": "default",
+                            "extras": {},
+                            "x": 931.7833862304688,
+                            "y": 287.91668701171875,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "16e46549-f371-465d-a66a-c520498f3d2a",
+                            "links": [],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "d207541d-2a48-438e-84ab-d1bcbf436829",
+                            "type": "default",
+                            "extras": {},
+                            "x": 931.7833862304688,
+                            "y": 309.75,
+                            "name": "parameter-out-list-futures",
+                            "alignment": "right",
+                            "parentNode": "16e46549-f371-465d-a66a-c520498f3d2a",
+                            "links": [
+                                "d18868e9-df76-4ead-8418-0e0451ce4228"
+                            ],
+                            "in": false,
+                            "label": "futures",
+                            "varName": "futures",
+                            "portType": "",
+                            "dataType": "list"
+                        },
+                        {
+                            "id": "c2511e51-e208-407f-833f-be894586f4d1",
+                            "type": "default",
+                            "extras": {},
+                            "x": 931.7833862304688,
+                            "y": 331.58331298828125,
+                            "name": "out-flow-body",
+                            "alignment": "right",
+                            "parentNode": "16e46549-f371-465d-a66a-c520498f3d2a",
+                            "links": [
+                                "e6f48c13-efaf-423a-9ba6-430b02b6ec65"
+                            ],
+                            "in": false,
+                            "label": "body ▶",
+                            "varName": "body ▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "RunParallelProcess",
+                    "color": "blue",
+                    "portsInOrder": [
+                        "0f535083-8e1a-4918-a591-e6e65909666e",
+                        "a55ea7c9-4333-40d9-8d68-9925de72bd92"
+                    ],
+                    "portsOutOrder": [
+                        "f9404eab-fd8d-4487-ad23-a0ade2689f35",
+                        "d207541d-2a48-438e-84ab-d1bcbf436829",
+                        "c2511e51-e208-407f-833f-be894586f4d1"
+                    ]
+                },
+                "3af44e62-b3dd-452a-a369-f080d0b06c56": {
+                    "id": "3af44e62-b3dd-452a-a369-f080d0b06c56",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "library_component",
+                        "path": "xai_components/xai_utils/utils.py",
+                        "description": "Waits for a list of futures to complete.\n\n##### inPorts:\n- futures (list): The list of futures to wait for.",
+                        "lineNo": [
+                            {
+                                "lineno": 781,
+                                "end_lineno": 791
+                            }
+                        ],
+                        "borderColor": "rgb(0,192,255)",
+                        "nextNode": "None"
+                    },
+                    "x": 1005.1666870117188,
+                    "y": 33,
+                    "ports": [
+                        {
+                            "id": "9b479d99-8646-4a8d-9d46-7761b5f78046",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1006.0833129882812,
+                            "y": 59.91667175292969,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "3af44e62-b3dd-452a-a369-f080d0b06c56",
+                            "links": [
+                                "e1788deb-50f4-4168-9658-62697a2aaabb"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "8f70631f-8995-4c84-98c3-af81d2b5aeef",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1006.0833129882812,
+                            "y": 81.75,
+                            "name": "parameter-list-futures",
+                            "alignment": "left",
+                            "parentNode": "3af44e62-b3dd-452a-a369-f080d0b06c56",
+                            "links": [
+                                "d18868e9-df76-4ead-8418-0e0451ce4228"
+                            ],
+                            "in": true,
+                            "label": "★futures",
+                            "varName": "★futures",
+                            "portType": "",
+                            "dataType": "list"
+                        },
+                        {
+                            "id": "763d89c2-fe3f-4353-8d7b-e0114278b681",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1123.0333862304688,
+                            "y": 59.91667175292969,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "3af44e62-b3dd-452a-a369-f080d0b06c56",
+                            "links": [
+                                "cd0af678-03ae-4fc4-a049-8c02125c6baf"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "AwaitFutures",
+                    "color": "blue",
+                    "portsInOrder": [
+                        "9b479d99-8646-4a8d-9d46-7761b5f78046",
+                        "8f70631f-8995-4c84-98c3-af81d2b5aeef"
+                    ],
+                    "portsOutOrder": [
+                        "763d89c2-fe3f-4353-8d7b-e0114278b681"
+                    ]
+                },
+                "cbba1c24-254d-46a5-b977-2b43e593fdea": {
+                    "id": "cbba1c24-254d-46a5-b977-2b43e593fdea",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "branch",
+                        "path": "xai_components/xai_controlflow/branches.py",
+                        "description": "A component that iterates over a list, executing body branches for each item.\n\n##### inPorts:\n- items (list): The list of items to iterate over.\n\n##### outPorts:\n- current_item (any): The current item in the iteration.\n- current_index (int): The index of the current item in the iteration.\n\n##### Branches:\n- body: Branch that executes for each item.",
+                        "lineNo": [
+                            {
+                                "lineno": 85,
+                                "end_lineno": 112
+                            }
+                        ],
+                        "borderColor": "rgb(0,192,255)",
+                        "sourceBranchId": "cba1e57f-12ce-43d8-97de-a85488974261",
+                        "portId": "de0cbf2a-f220-4873-b96e-684cab5e7a90",
+                        "finishNodeId": "None",
+                        "isBranchNode": true
+                    },
+                    "x": 458.16668701171875,
+                    "y": 242,
+                    "ports": [
+                        {
+                            "id": "b876d77a-f843-4f1e-873d-2a009dd5f69c",
+                            "type": "default",
+                            "extras": {},
+                            "x": 459.0833740234375,
+                            "y": 268.91668701171875,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "cbba1c24-254d-46a5-b977-2b43e593fdea",
+                            "links": [
+                                "78af0299-616b-4c79-925b-e1092fe45b66"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "94d0c371-ce73-48b0-b53a-b18a94f9e528",
+                            "type": "default",
+                            "extras": {},
+                            "x": 459.0833740234375,
+                            "y": 290.75,
+                            "name": "parameter-list-items",
+                            "alignment": "left",
+                            "parentNode": "cbba1c24-254d-46a5-b977-2b43e593fdea",
+                            "links": [
+                                "0582f6ee-4be2-4226-b3b6-b3df650d8a74"
+                            ],
+                            "in": true,
+                            "label": "★items",
+                            "varName": "★items",
+                            "portType": "",
+                            "dataType": "list"
+                        },
+                        {
+                            "id": "6f379ae4-75cf-411f-81a0-4ff6e4d60df5",
+                            "type": "default",
+                            "extras": {},
+                            "x": 704.7666625976562,
+                            "y": 268.91668701171875,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "cbba1c24-254d-46a5-b977-2b43e593fdea",
+                            "links": [],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "5f6cf083-713b-4175-99df-aa7bf3a23060",
+                            "type": "default",
+                            "extras": {},
+                            "x": 704.7666625976562,
+                            "y": 290.75,
+                            "name": "out-flow-body",
+                            "alignment": "right",
+                            "parentNode": "cbba1c24-254d-46a5-b977-2b43e593fdea",
+                            "links": [
+                                "c17339bc-53d7-4d31-8850-ebfe5a99bf3c"
+                            ],
+                            "in": false,
+                            "label": "body ▶",
+                            "varName": "body ▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "762522fe-e144-4863-8290-603045b97876",
+                            "type": "default",
+                            "extras": {},
+                            "x": 704.7666625976562,
+                            "y": 312.58331298828125,
+                            "name": "parameter-out-any-current_item",
+                            "alignment": "right",
+                            "parentNode": "cbba1c24-254d-46a5-b977-2b43e593fdea",
+                            "links": [
+                                "ca257036-45f5-458c-8b02-b3e13de308b7"
+                            ],
+                            "in": false,
+                            "label": "current_item",
+                            "varName": "current_item",
+                            "portType": "",
+                            "dataType": "any"
+                        },
+                        {
+                            "id": "7e9c0c6d-f2cf-47e1-8dea-6b343f09ec54",
+                            "type": "default",
+                            "extras": {},
+                            "x": 704.7666625976562,
+                            "y": 334.41668701171875,
+                            "name": "parameter-out-int-current_index",
+                            "alignment": "right",
+                            "parentNode": "cbba1c24-254d-46a5-b977-2b43e593fdea",
+                            "links": [],
+                            "in": false,
+                            "label": "current_index",
+                            "varName": "current_index",
+                            "portType": "",
+                            "dataType": "int"
+                        }
+                    ],
+                    "name": "ForEach",
+                    "color": "rgb(255,153,102)",
+                    "portsInOrder": [
+                        "b876d77a-f843-4f1e-873d-2a009dd5f69c",
+                        "94d0c371-ce73-48b0-b53a-b18a94f9e528"
+                    ],
+                    "portsOutOrder": [
+                        "6f379ae4-75cf-411f-81a0-4ff6e4d60df5",
+                        "5f6cf083-713b-4175-99df-aa7bf3a23060",
+                        "762522fe-e144-4863-8290-603045b97876",
+                        "7e9c0c6d-f2cf-47e1-8dea-6b343f09ec54"
+                    ]
+                },
+                "d235034d-43c0-4514-9126-062c95b8a770": {
+                    "id": "d235034d-43c0-4514-9126-062c95b8a770",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "library_component",
+                        "path": "xai_components/xai_utils/utils.py",
+                        "description": "Concatenates two strings.\n\n##### inPorts:\n- a (str): The first string.\n- b (str): The second string.\n\n##### outPorts:\n- out (str): The concatenated result of strings a and b.",
+                        "lineNo": [
+                            {
+                                "lineno": 92,
+                                "end_lineno": 107
+                            }
+                        ],
+                        "borderColor": "rgb(0,192,255)",
+                        "sourceBranchId": "16e46549-f371-465d-a66a-c520498f3d2a",
+                        "portId": "c2511e51-e208-407f-833f-be894586f4d1"
+                    },
+                    "x": 1093.1666870117188,
+                    "y": 291,
+                    "ports": [
+                        {
+                            "id": "d43d03c8-0cd7-4470-919f-c8c95d71636a",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1094.0833129882812,
+                            "y": 317.91668701171875,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "d235034d-43c0-4514-9126-062c95b8a770",
+                            "links": [
+                                "c2d83de8-d82e-454d-a8d0-21eecd690096"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "a038cdd3-0363-42c1-bcb4-b09ad8649bbf",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1094.0833129882812,
+                            "y": 339.75,
+                            "name": "parameter-string-a",
+                            "alignment": "left",
+                            "parentNode": "d235034d-43c0-4514-9126-062c95b8a770",
+                            "links": [
+                                "df03857f-3111-4efe-a671-e0a0f6cfd978"
+                            ],
+                            "in": true,
+                            "label": "a",
+                            "varName": "a",
+                            "portType": "",
+                            "dataType": "string"
+                        },
+                        {
+                            "id": "00c83f36-2415-4d88-93e9-a7b69d8e5da6",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1094.0833129882812,
+                            "y": 361.58331298828125,
+                            "name": "parameter-string-b",
+                            "alignment": "left",
+                            "parentNode": "d235034d-43c0-4514-9126-062c95b8a770",
+                            "links": [
+                                "ca257036-45f5-458c-8b02-b3e13de308b7"
+                            ],
+                            "in": true,
+                            "label": "b",
+                            "varName": "b",
+                            "portType": "",
+                            "dataType": "string"
+                        },
+                        {
+                            "id": "c492df7e-9ba6-4419-a0a7-af04b97e7f1e",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1210.6333618164062,
+                            "y": 317.91668701171875,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "d235034d-43c0-4514-9126-062c95b8a770",
+                            "links": [
+                                "0aeffb80-e43d-43f7-a062-18d4be7a3887"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "d2b697c4-8800-411a-818b-1593679dce97",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1210.6333618164062,
+                            "y": 339.75,
+                            "name": "parameter-out-string-out",
+                            "alignment": "right",
+                            "parentNode": "d235034d-43c0-4514-9126-062c95b8a770",
+                            "links": [
+                                "00ec6148-49c7-4f74-b2b4-bb9e8be94388"
+                            ],
+                            "in": false,
+                            "label": "out",
+                            "varName": "out",
+                            "portType": "",
+                            "dataType": "string"
+                        }
+                    ],
+                    "name": "ConcatString",
+                    "color": "rgb(192,255,0)",
+                    "portsInOrder": [
+                        "d43d03c8-0cd7-4470-919f-c8c95d71636a",
+                        "a038cdd3-0363-42c1-bcb4-b09ad8649bbf",
+                        "00c83f36-2415-4d88-93e9-a7b69d8e5da6"
+                    ],
+                    "portsOutOrder": [
+                        "c492df7e-9ba6-4419-a0a7-af04b97e7f1e",
+                        "d2b697c4-8800-411a-818b-1593679dce97"
+                    ]
+                },
+                "d2fe0256-f394-48ba-8935-bf3122d457ac": {
+                    "id": "d2fe0256-f394-48ba-8935-bf3122d457ac",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "list",
+                        "attached": true
+                    },
+                    "x": 228.16668701171875,
+                    "y": 431,
+                    "ports": [
+                        {
+                            "id": "dc751074-3a0b-41f7-8977-32fb1c8dac79",
+                            "type": "default",
+                            "extras": {},
+                            "x": 228.16668701171875,
+                            "y": 431,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "d2fe0256-f394-48ba-8935-bf3122d457ac",
+                            "links": [
+                                "0582f6ee-4be2-4226-b3b6-b3df650d8a74"
+                            ],
+                            "in": false,
+                            "label": "\"Eduardo\",\"Fahreza\",\"Paul\",\"Mansour\"",
+                            "varName": "\"Eduardo\",\"Fahreza\",\"Paul\",\"Mansour\"",
+                            "portType": "",
+                            "dataType": "list"
+                        }
+                    ],
+                    "name": "Literal List",
+                    "color": "yellow",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "dc751074-3a0b-41f7-8977-32fb1c8dac79"
+                    ]
+                },
+                "9fa51310-ccda-41c8-b91c-b827502a0f25": {
+                    "id": "9fa51310-ccda-41c8-b91c-b827502a0f25",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "library_component",
+                        "path": "xai_components/xai_utils/utils.py",
+                        "description": "Pauses the python process.\n\n##### inPorts:\n- sleep_timer (float): The number of seconds to pause. Default `5.0` seconds.",
+                        "lineNo": [
+                            {
+                                "lineno": 344,
+                                "end_lineno": 355
+                            }
+                        ],
+                        "borderColor": "rgb(0,192,255)",
+                        "sourceBranchId": "16e46549-f371-465d-a66a-c520498f3d2a",
+                        "portId": "c2511e51-e208-407f-833f-be894586f4d1"
+                    },
+                    "x": 986.1666870117188,
+                    "y": 546,
+                    "ports": [
+                        {
+                            "id": "1fc2977f-de76-4d21-a550-1ed7ab0f8dba",
+                            "type": "default",
+                            "extras": {},
+                            "x": 987.0833129882812,
+                            "y": 572.9166870117188,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "9fa51310-ccda-41c8-b91c-b827502a0f25",
+                            "links": [
+                                "e6f48c13-efaf-423a-9ba6-430b02b6ec65"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "508c496a-ff4b-488b-ab96-a072ee3bc0fa",
+                            "type": "default",
+                            "extras": {},
+                            "x": 987.0833129882812,
+                            "y": 594.75,
+                            "name": "parameter-float-sleep_timer",
+                            "alignment": "left",
+                            "parentNode": "9fa51310-ccda-41c8-b91c-b827502a0f25",
+                            "links": [
+                                "ef72c477-5afd-4a16-8d4d-5397f3e38f00"
+                            ],
+                            "in": true,
+                            "label": "sleep_timer",
+                            "varName": "sleep_timer",
+                            "portType": "",
+                            "dataType": "float"
+                        },
+                        {
+                            "id": "a893e826-51ef-4199-9ace-05a344282248",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1125.8500366210938,
+                            "y": 572.9166870117188,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "9fa51310-ccda-41c8-b91c-b827502a0f25",
+                            "links": [
+                                "c2d83de8-d82e-454d-a8d0-21eecd690096"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "SleepComponent",
+                    "color": "green",
+                    "portsInOrder": [
+                        "1fc2977f-de76-4d21-a550-1ed7ab0f8dba",
+                        "508c496a-ff4b-488b-ab96-a072ee3bc0fa"
+                    ],
+                    "portsOutOrder": [
+                        "a893e826-51ef-4199-9ace-05a344282248"
+                    ]
+                },
+                "0ab80806-e7c8-4ba0-99c6-04d7521aeef8": {
+                    "id": "0ab80806-e7c8-4ba0-99c6-04d7521aeef8",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "list",
+                        "attached": true
+                    },
+                    "x": -14.83331298828125,
+                    "y": 205,
+                    "ports": [
+                        {
+                            "id": "df479f7b-32b6-49ca-9179-98a0ca7133d7",
+                            "type": "default",
+                            "extras": {},
+                            "x": -14.83331298828125,
+                            "y": 205,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "0ab80806-e7c8-4ba0-99c6-04d7521aeef8",
+                            "links": [
+                                "a2197218-1882-4eaa-9316-d95abf72bd5f"
+                            ],
+                            "in": false,
+                            "label": "\"Hello, \",\"Hola, \",\"Hallo, \"",
+                            "varName": "\"Hello, \",\"Hola, \",\"Hallo, \"",
+                            "portType": "",
+                            "dataType": "list"
+                        }
+                    ],
+                    "name": "Literal List",
+                    "color": "yellow",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "df479f7b-32b6-49ca-9179-98a0ca7133d7"
+                    ]
+                },
+                "111c1068-e790-4eb3-824a-95e9a69a4dce": {
+                    "id": "111c1068-e790-4eb3-824a-95e9a69a4dce",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "int",
+                        "attached": true
+                    },
+                    "x": 212.16668701171875,
+                    "y": 557,
+                    "ports": [
+                        {
+                            "id": "bcd91a82-00d6-4858-994e-97be4a6a05e6",
+                            "type": "default",
+                            "extras": {},
+                            "x": 212.16668701171875,
+                            "y": 557,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "111c1068-e790-4eb3-824a-95e9a69a4dce",
+                            "links": [
+                                "47f98267-f865-477d-b0ee-241ad0034819"
+                            ],
+                            "in": false,
+                            "label": "12",
+                            "varName": "12",
+                            "portType": "",
+                            "dataType": "int"
+                        }
+                    ],
+                    "name": "Literal Integer",
+                    "color": "blue",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "bcd91a82-00d6-4858-994e-97be4a6a05e6"
+                    ]
+                },
+                "5b6e0728-0102-45da-be75-a6e78c207796": {
+                    "id": "5b6e0728-0102-45da-be75-a6e78c207796",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "float",
+                        "attached": true
+                    },
+                    "x": 851.1666870117188,
+                    "y": 635,
+                    "ports": [
+                        {
+                            "id": "baea3b88-45be-439f-a6b0-ec1782cbf954",
+                            "type": "default",
+                            "extras": {},
+                            "x": 851.1666870117188,
+                            "y": 635,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "5b6e0728-0102-45da-be75-a6e78c207796",
+                            "links": [
+                                "ef72c477-5afd-4a16-8d4d-5397f3e38f00"
+                            ],
+                            "in": false,
+                            "label": "30",
+                            "varName": "30",
+                            "portType": "",
+                            "dataType": "float"
+                        }
+                    ],
+                    "name": "Literal Float",
+                    "color": "green",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "baea3b88-45be-439f-a6b0-ec1782cbf954"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
     "requests",
     "toml",
     "importlib_resources",
-    "asgiref"
+    "asgiref",
+    "dill"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
# Description

Xircuits already includes a `RunParallelThread` component that executes tasks in parallel using threads. However, in CPython, threads are not truly parallel due to the GIL. For our use case - running TVB simulations that involve heavy mathematical computations - threading actually performed worse than running everything sequentially.

To address this, I created a new `RunParallelProcess` component that uses separate processes instead of threads, enabling true parallelism for CPU-bound workloads.

**Note**: Logs from components executed in parallel processes will no longer appear in the JupyterLab output. They will only be visible in the terminal from which JupyterLab was launched.

This feature introduces a new dependency: [dill](https://github.com/uqfoundation/dill), used for serializing Python objects.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [x] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

I added a test file `/examples/RunParallelProcess.xircuits` to demonstrate the usage of this new component.


**Tested on? Specify Version.**

- [x] Windows  
- [ ] Linux
- [ ] Mac  
- [ ] Others  (State here -> xxx )  