### PR TITLE
WIP: Replace docstring bubble with right sidebar preview

### DIFF
--- a/src/component_info_sidebar/ComponentPreviewWidget.tsx
+++ b/src/component_info_sidebar/ComponentPreviewWidget.tsx
@@ -1,0 +1,103 @@
+// ComponentPreviewWidget.tsx
+import { ReactWidget } from '@jupyterlab/apputils';
+import React from 'react';
+import { marked } from 'marked';
+import styled from '@emotion/styled';
+import { infoIcon } from '../ui-components/icons';
+
+const Container = styled.div`
+  height: 100%;
+  overflow-y: auto;
+  box-sizing: border-box;
+  padding: 24px 26px;
+
+  color: var(--jp-ui-font-color0);
+  background: var(--jp-layout-color1);
+
+  border-left: 1px solid var(--jp-border-color1);
+  box-shadow: inset 4px 0 6px rgba(0, 0, 0, 0.04);
+
+  h3 {
+    margin: 0 0 20px;
+    font-size: 1.35rem;
+    font-weight: 600;
+    line-height: 1.4;
+    letter-spacing: 0.2px;
+  }
+
+  .docstring-box {
+    background: var(--jp-layout-color2);
+    border: 1px solid var(--jp-border-color2);
+    border-radius: 10px;
+    padding: 20px 22px;
+    line-height: 1.6;
+    font-size: 0.75rem;
+
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
+  }
+
+  .docstring-box strong,
+  .docstring-box b {
+    color: var(--jp-ui-font-color1);
+    font-weight: 600;
+  }
+
+  ul {
+    margin: 8px 0 8px 24px;
+    padding-inline-start: 0;
+  }
+
+  code {
+    font-family: var(--jp-code-font-family);
+    background: var(--jp-layout-color3);
+    padding: 2px 5px;
+    border-radius: 4px;
+    font-size: 85%;
+  }
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--jp-layout-color3);
+    border-radius: 4px;
+  }
+`;
+
+export interface IComponentInfo { name: string; docstring: string; }
+
+export class ComponentPreviewWidget extends ReactWidget {
+  private _model: IComponentInfo | null = null;
+
+  constructor(model: IComponentInfo | null = null) {
+    super();
+    this.id = 'xircuits-doc-preview';
+    this.title.label = '';                 
+    this.title.caption = 'Component Info';
+    this.title.icon = infoIcon;
+    this.title.closable = false;           
+    this.setModel(model);
+  }
+
+  setModel(model: IComponentInfo | null) {
+    this._model = model;
+    if (model) this.node.dataset.componentName = model.name;
+    else delete this.node.dataset.componentName;
+    this.update();
+  }
+
+  render() {
+    if (!this._model) {
+      return <Container>Please click the "ℹ" icon on any component to view its description here</Container>;
+    }
+    return (
+      <Container>
+        <h3>{this._model.name}</h3>
+        <div
+          className="docstring-box"
+          dangerouslySetInnerHTML={{ __html: marked(this._model.docstring || '_No docstring provided._') }}
+        />
+      </Container>
+    );
+  }
+}

--- a/src/component_info_sidebar/ComponentPreviewWidget.tsx
+++ b/src/component_info_sidebar/ComponentPreviewWidget.tsx
@@ -15,25 +15,25 @@ const Container = styled.div`
   background: var(--jp-layout-color1);
 
   border-left: 1px solid var(--jp-border-color1);
-  box-shadow: inset 4px 0 6px rgba(0, 0, 0, 0.04);
+  box-shadow: inset 2px 0 4px rgba(0, 0, 0, 0.02);
 
   h3 {
-    margin: 0 0 20px;
-    font-size: 1.35rem;
+    margin: 0 0 16px;
+    font-size: 1.4rem;
     font-weight: 600;
-    line-height: 1.4;
+    line-height: 1.3;
     letter-spacing: 0.2px;
   }
 
   .docstring-box {
-    background: var(--jp-layout-color2);
-    border: 1px solid var(--jp-border-color2);
-    border-radius: 10px;
-    padding: 20px 22px;
-    line-height: 1.6;
-    font-size: 0.75rem;
-
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
+    background: var(--jp-layout-color1);        
+    border: 1px solid var(--jp-border-color2);  
+    border-left: 4px solid var(--jp-brand-color1, var(--jp-brand-color0));
+    border-radius: 4px;                         
+    padding: 16px 18px;
+    line-height: 1.55;
+    font-size: 0.85rem;
+    box-shadow: none;                         
   }
 
   .docstring-box strong,
@@ -43,7 +43,7 @@ const Container = styled.div`
   }
 
   ul {
-    margin: 8px 0 8px 24px;
+    margin: 8px 0 8px 22px;
     padding-inline-start: 0;
   }
 
@@ -56,11 +56,11 @@ const Container = styled.div`
   }
 
   &::-webkit-scrollbar {
-    width: 8px;
+    width: 6px;
   }
   &::-webkit-scrollbar-thumb {
     background: var(--jp-layout-color3);
-    border-radius: 4px;
+    border-radius: 3px;
   }
 `;
 

--- a/src/component_info_sidebar/previewHelper.ts
+++ b/src/component_info_sidebar/previewHelper.ts
@@ -1,0 +1,35 @@
+//previewHelper.ts
+import { JupyterFrontEnd, ILabShell } from '@jupyterlab/application';
+import { Widget } from '@lumino/widgets';
+import { ComponentPreviewWidget, IComponentInfo } from './ComponentPreviewWidget';
+
+export function togglePreviewWidget(app: JupyterFrontEnd, model: IComponentInfo) {
+  const labShell = app.shell as unknown as ILabShell;
+  const rightCollapsed = (labShell as any).rightCollapsed ?? (labShell as any).collapsedRight;
+
+  const widgets: Widget[] = Array.from(labShell.widgets('right'));
+  let widget = widgets.find(w => w.id === 'xircuits-doc-preview') as ComponentPreviewWidget | undefined;
+
+  if (!widget) {
+    widget = new ComponentPreviewWidget(model);
+    widget.node.style.minWidth = '340px';
+    labShell.add(widget, 'right', { rank: 0 });     
+    labShell.activateById(widget.id);
+    return;
+  }
+
+  if (rightCollapsed) {
+    labShell.expandRight();
+    widget.setModel(model);
+    labShell.activateById(widget.id);
+    return;
+  }
+
+  const currentName = widget.node.dataset.componentName;
+  if (currentName === model.name) {
+    labShell.collapseRight();
+  } else {
+    widget.setModel(model);
+    labShell.activateById(widget.id);
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,6 +34,7 @@ import { commandIDs } from "./commands/CommandIDs";
 import { IEditorTracker } from '@jupyterlab/fileeditor';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 import { handleInstall } from './context-menu/TrayContextMenu';
+import { ComponentPreviewWidget } from './component_info_sidebar/ComponentPreviewWidget';
 
 const FACTORY = 'Xircuits editor';
 
@@ -158,6 +159,12 @@ const xircuits: JupyterFrontEndPlugin<void> = {
 
     restorer.add(sidebarWidget, sidebarWidget.id);
     app.shell.add(sidebarWidget, "left");
+
+    const previewWidget = new ComponentPreviewWidget(null);   
+    previewWidget.id = 'xircuits-doc-preview';               
+    previewWidget.node.style.minWidth = '340px';
+    app.shell.add(previewWidget, 'right', { rank: 1 });
+    restorer.add(previewWidget, previewWidget.id);
 
     // Additional commands for node action
     addNodeActionCommands(app, tracker, translator);

--- a/style/icons/info.svg
+++ b/style/icons/info.svg
@@ -1,7 +1,8 @@
 <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
-    <polyline points="196 220 260 220 260 392" 
-        style="fill:none;stroke:#000;stroke-linecap:round;stroke-linejoin:round;stroke-width:40px"/>
-    <line x1="187" y1="396" x2="325" y2="396" 
-        style="fill:none;stroke:#000;stroke-linecap:round;stroke-miterlimit:10;stroke-width:40px"/>
-    <path d="M256,160a32,32,0,1,1,32-32A32,32,0,0,1,256,160Z"/>
+  <g stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="40">
+    <polyline points="196 220 260 220 260 392" />
+    <line x1="187" y1="396" x2="325" y2="396" />
+  </g>
+
+  <circle cx="256" cy="128" r="32" fill="currentColor"/>
 </svg>


### PR DESCRIPTION

# Description

- Replaced the old chat-bubble style that appeared when clicking the ℹ︎ icon on a component with a new preview panel that opens in the right sidebar.
- Updated the infoIcon to support both light and dark themes automatically.


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Launch Binder (or run locally).
2. Drag any component into the canvas.
3. Click the **ℹ︎** icon on the node.

   * The right sidebar should expand and show the component name and docstring.
4. Click the same ℹ︎ again → the sidebar collapses.
5. Click ℹ︎ on a different component → the sidebar swaps to the new docstring.


**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux Fedora
- [ ] Mac  
- [ ] Others  (State here -> xxx )  


