### PR TITLE
🐛 Fix: Reload sidebar components on save with manual and auto-save detection

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -22,7 +22,7 @@ import { PointModel } from '@projectstorm/react-diagrams';
 import { Point } from '@projectstorm/geometry';
 import { createArgumentNode, createLiteralNode, handleArgumentInput, handleLiteralInput } from '../tray_library/GeneralComponentLib';
 import { CustomDynaPortModel } from '../components/port/CustomDynaPortModel';
-import { manualReload } from '../tray_library/Component';
+import { fetchComponents } from '../tray_library/Component';
 import { BaseComponentLibrary } from '../tray_library/BaseComponentLib';
 import { commandIDs } from "./CommandIDs";
 
@@ -229,7 +229,7 @@ export function addNodeActionCommands(
     commands.addCommand(commandIDs.reloadNode, {
         execute: async () => {
 
-            await manualReload();
+            await fetchComponents();
 
             const widget = tracker.currentWidget?.content as XircuitsPanel;
             const engine = widget.xircuitsApp.getDiagramEngine();

--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -25,7 +25,6 @@ import { MenuSvg } from "@jupyterlab/ui-components";
 import { commandIDs } from "../commands/CommandIDs";
 import { NodePreview } from "./NodePreview";
 import { ellipsesIcon } from "@jupyterlab/ui-components";
-import { manualReload } from "./Component";
 
 
 export const Body = styled.div`
@@ -156,14 +155,16 @@ export default function Sidebar(props: SidebarProps) {
 
     }, [category, componentList]);
 
-    function handleRefreshOnClick() {
-        manualReload();
-        fetchComponentList();
+    async function handleRefreshOnClick(showError = true) {
+        const updated = await refreshComponentListCache(showError);
+        if (updated) {
+            fetchComponentList();       
+        }
     }
 
     useEffect(() => {
-        const refreshComponents = () => {
-            fetchComponentList();
+        const refreshComponents = (_sender, manual = true) => {
+        handleRefreshOnClick(manual);
         };
 
         factory.refreshComponentsSignal.connect(refreshComponents);
@@ -183,8 +184,8 @@ export default function Sidebar(props: SidebarProps) {
             factory.toggleDisplayNodesInLibrary.disconnect(toggleDisplayNodes);
         };
     }, []);
-
     
+
     useEffect(() => {
         const intervalId = setInterval(() => {
             fetchComponentList();


### PR DESCRIPTION
# Description

- Differentiated between manual and auto-save using a time threshold between save command and saveState.

- Emitted refreshComponentsSignal only on manual saves from index.tsx.

- Sidebar listens to the signal and reloads components only when needed.

- Replaced manualReload with the more flexible refreshComponentListCache(showError).

- Suppressed error dialogs during auto-save.




## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Tests

**1. Manual Save triggers sidebar reload with popup **
Steps to reproduce:

1. Open a `.py` component file under `xai_components/`.
2. Make a small change 
3. Press `Ctrl + S` or click the save icon.
4. Sidebar reloads and displays parse error if component has issues.
5. Node list updates correctly.

**2. Auto-save does not trigger popup **
Steps to reproduce:

1. Enable auto-save with short interval (e.g., 1 sec).
2. Modify `.py` file and wait for auto-save.
3. Sidebar refreshes silently (no popup shown).

**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux Fedora
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

