### PR TITLE
revert comp parser notif

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -22,7 +22,7 @@ import { PointModel } from '@projectstorm/react-diagrams';
 import { Point } from '@projectstorm/geometry';
 import { createArgumentNode, createLiteralNode, handleArgumentInput, handleLiteralInput } from '../tray_library/GeneralComponentLib';
 import { CustomDynaPortModel } from '../components/port/CustomDynaPortModel';
-import { manualReload } from '../tray_library/Component';
+import { fetchComponents } from '../tray_library/Component';
 import { BaseComponentLibrary } from '../tray_library/BaseComponentLib';
 import { commandIDs } from "./CommandIDs";
 
@@ -229,8 +229,8 @@ export function addNodeActionCommands(
     commands.addCommand(commandIDs.reloadNode, {
         execute: async () => {
 
-            await manualReload();
-
+            await fetchComponents();
+            
             const widget = tracker.currentWidget?.content as XircuitsPanel;
             const engine = widget.xircuitsApp.getDiagramEngine();
             const model = engine.getModel();

--- a/src/tray_library/Component.tsx
+++ b/src/tray_library/Component.tsx
@@ -1,5 +1,6 @@
 import { Notification } from '@jupyterlab/apputils';
 import { requestAPI } from "../server/handler";
+
 let componentsCache = {
   data: null
 };
@@ -9,10 +10,12 @@ export async function fetchComponents() {
   try {
     const componentsResponse = await requestAPI<any>('components/');
     const components = componentsResponse["components"];
-    const error_msg = componentsResponse["error_msg"];
+    const error_info = componentsResponse["error_info"];
+    if (error_info) {
+      const uniqueId = `${error_info.full_path}\nLine:${error_info.line}`;
+      const formatted =`Error found in: ${uniqueId}\n${error_info.message}`;
 
-    if (error_msg) {
-      Notification.error(error_msg, { autoClose: 3000 });
+      Notification.error(formatted, { autoClose: 6000 });
     }
     console.log("Fetch complete.")
     return components;

--- a/src/tray_library/Component.tsx
+++ b/src/tray_library/Component.tsx
@@ -1,44 +1,23 @@
-import { showDialog, Dialog } from '@jupyterlab/apputils';
+import { Notification } from '@jupyterlab/apputils';
 import { requestAPI } from "../server/handler";
-import React from 'react';
-
 let componentsCache = {
   data: null
 };
 
-export async function manualReload() {
-  await refreshComponentListCache(true);
-}
-
-export async function fetchComponents(isManualReload = false) {
+export async function fetchComponents() {
   console.log("Fetching all components... this might take a while.")
   try {
     const componentsResponse = await requestAPI<any>('components/');
     const components = componentsResponse["components"];
     const error_msg = componentsResponse["error_msg"];
 
-    if (error_msg && isManualReload) {
-      await showDialog({
-        title: 'Parse Component Failed',
-        body: (
-          <pre>{error_msg}</pre>
-        ),
-        buttons: [Dialog.warnButton({ label: 'OK' })]
-      });
+    if (error_msg) {
+      Notification.error(error_msg, { autoClose: 3000 });
     }
     console.log("Fetch complete.")
     return components;
   } catch (error) {
     console.error('Failed to get components', error);
-    if (isManualReload) {
-      // Show error popup only if this is a manual reload
-      await showDialog({
-        title: 'Network Error',
-        body: <pre>{String(error)}</pre>,
-        buttons: [Dialog.warnButton({ label: 'OK' })]
-      });
-    }
-    return [];
   }
 }
 
@@ -51,6 +30,6 @@ export async function ComponentList() {
   return componentsCache.data;
 }
 
-export async function refreshComponentListCache(isManualReload = false) {
-  componentsCache.data = await fetchComponents(isManualReload);
+export async function refreshComponentListCache() {
+  componentsCache.data = await fetchComponents();
 }

--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -25,8 +25,6 @@ import { MenuSvg } from "@jupyterlab/ui-components";
 import { commandIDs } from "../commands/CommandIDs";
 import { NodePreview } from "./NodePreview";
 import { ellipsesIcon } from "@jupyterlab/ui-components";
-import { manualReload } from "./Component";
-
 
 export const Body = styled.div`
   flex-grow: 1;
@@ -157,13 +155,13 @@ export default function Sidebar(props: SidebarProps) {
     }, [category, componentList]);
 
     function handleRefreshOnClick() {
-        manualReload();
+        refreshComponentListCache();
         fetchComponentList();
     }
 
     useEffect(() => {
         const refreshComponents = () => {
-            fetchComponentList();
+            handleRefreshOnClick();
         };
 
         factory.refreshComponentsSignal.connect(refreshComponents);


### PR DESCRIPTION

# Description

This PR Improves error toasts for Python components by showing detailed info (file path, line number and error type)

- Reverted the component parsing saving notification, and replaced it with JupyterLab notification.

- Structured the toast message to display the file path, line number, and error type by utilizing the new error_info returned from the backend.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Test: Triggering Toast Notification on Syntax Error**

1. Created a test Python component file with a forced `SyntaxError` (e.g., missing colon or invalid expression).
2. Saved the file to trigger parsing via Xircuits component loader.
3. Observed toast notification showing:

   * Full file path
   * Exact line number
   * Error type and message


**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux Fedora
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
