### PR TITLE
Replace ReactTooltip with Notification.error + add Center action button

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -25,6 +25,7 @@ import { CustomDynaPortModel } from '../components/port/CustomDynaPortModel';
 import { manualReload } from '../tray_library/Component';
 import { BaseComponentLibrary } from '../tray_library/BaseComponentLib';
 import { commandIDs } from "./CommandIDs";
+import { showNodeCenteringNotification } from '../helpers/notificationEffects';
 
 /**
  * Add the commands for node actions.
@@ -290,8 +291,10 @@ export function addNodeActionCommands(
                     } catch (error) {
                         let path = selected_node.getOptions()["extras"].path;
                         console.log(`Error reloading component from path: ${path}. Error: ${error.message}`);
-                        selected_node.getOptions().extras["tip"] = `Component could not be loaded from path: \`${path}\`.\nPlease ensure that the component exists!`;
                         selected_node.getOptions().extras["borderColor"] = "red";
+                        const message =
+                        `Component could not be loaded from path: \`${path}\`.\nPlease ensure that the component exists!`;
+                        showNodeCenteringNotification(message, selected_node.getID(), engine);
                         nodesToHighlight.push(selected_node);
                         continue;
                     }

--- a/src/components/node/CustomNodeWidget.tsx
+++ b/src/components/node/CustomNodeWidget.tsx
@@ -315,11 +315,6 @@ const ComponentLibraryNode = ({ node, engine, shell, app, handleDeletableNode })
         setDescriptionStr(dscrptStr);
     };
 
-    const hideErrorTooltip = () => {
-        delete node.getOptions().extras["tip"];
-        node.getOptions().extras["borderColor"] = "rgb(0,192,255)";
-    };
-
     return (
         <div style={{ position: "relative" }}>
             {showDescription && <div className="description-tooltip">
@@ -357,48 +352,6 @@ const ComponentLibraryNode = ({ node, engine, shell, app, handleDeletableNode })
                 </S.Title>
                 <PortsComponent node={node} engine={engine} app={app}/>
             </S.Node>
-            {(node.getOptions().extras["tip"] != undefined && node.getOptions().extras["tip"] != "") ?
-                <ReactTooltip
-                    id={node.getOptions().id}
-                    clickable
-                    place="bottom"
-                    className="error-tooltip"
-                    arrowColor="rgba(255, 0, 0, .9)"
-                    delayHide={100}
-                    delayUpdate={50}
-                    getContent={() =>
-                        <div data-no-drag className="error-container">
-                            <p className="error-title">Error</p>
-                            <div className="markdown-body" dangerouslySetInnerHTML={{ __html: marked(node.getOptions().extras["tip"] ?? '') }} />
-                            <button type="button" className="close" data-dismiss="modal" aria-label="Close" onClick={hideErrorTooltip}>
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                        </div>
-                    }
-                    overridePosition={({ left, top }) => {
-                        const currentNode = node;
-                        const nodeDimension = { x: currentNode.width, y: currentNode.height };
-                        const nodePosition = { x: currentNode.getX(), y: currentNode.getY() };
-                        let newPositionX = nodePosition.x;
-                        let newPositionY = nodePosition.y;
-                        let offset = 0;
-
-                        if (!shell.leftCollapsed) {
-                            let leftSidebar = document.getElementById('jp-left-stack');
-                            offset = leftSidebar.clientWidth + 2;
-                        }
-
-                        newPositionX = newPositionX - 184 + offset + (nodeDimension.x / 2);
-                        newPositionY = newPositionY + 90 + nodeDimension.y;
-
-                        const tooltipPosition = engine.getRelativePoint(newPositionX, newPositionY);
-
-                        left = tooltipPosition.x;
-                        top = tooltipPosition.y;
-                        return { top, left };
-                    }}
-                />
-                : null}
         </div>
     );
 };

--- a/src/helpers/notificationEffects.ts
+++ b/src/helpers/notificationEffects.ts
@@ -1,0 +1,51 @@
+import { DiagramEngine } from '@projectstorm/react-diagrams';
+import { Notification } from '@jupyterlab/apputils';
+
+export function showNodeCenteringNotification(
+  message: string,
+  nodeId: string,
+  engine?: DiagramEngine
+) {
+  if (!engine) return;
+
+  Notification.error(message, {
+    autoClose: 3000,
+    actions: [
+      {
+        label: 'Center Node',
+        caption: 'Center node on canvas',
+        callback: (event: MouseEvent) => {
+          event.preventDefault(); 
+          centerNodeInView(engine, nodeId);
+      }
+    }
+    ]
+  });
+}
+
+export function centerNodeInView(engine: DiagramEngine, nodeId: string) {
+  const model = engine.getModel();
+  const node  = model.getNode(nodeId);
+  if (!node) return;
+  
+  const { x, y } = node.getPosition();
+  const { width = 150, height = 100 } = (node as any).getSize?.() ?? {};
+
+  const canvas  = (engine as any).canvas as HTMLElement;
+  const content = canvas.closest(
+    '.lm-Widget[role="region"][aria-label="main area content"]'
+  ) as HTMLElement;
+  if (!content) return;
+
+  const { width: vpW, height: vpH } = content.getBoundingClientRect();
+  const zoom = model.getZoomLevel() / 100;
+
+  const offsetX = vpW / 2 - (x + width / 2) * zoom;
+  const offsetY = vpH / 2 - (y + height / 2) * zoom;
+
+  node.getOptions().extras["borderColor"]="red";
+  node.setSelected(true);
+
+  model.setOffset(offsetX, offsetY);
+  engine.repaintCanvas();
+}

--- a/src/helpers/notificationEffects.ts
+++ b/src/helpers/notificationEffects.ts
@@ -12,8 +12,8 @@ export function showNodeCenteringNotification(
     autoClose: 3000,
     actions: [
       {
-        label: 'Center Node',
-        caption: 'Center node on canvas',
+        label: 'Show Node',
+        caption: 'Show Node on canvas',
         callback: (event: MouseEvent) => {
           event.preventDefault(); 
           centerNodeInView(engine, nodeId);


### PR DESCRIPTION
# Description

1. This PR replaces all instances of error tooltip bubbles (`ReactTooltip`) with standardized `Notification.error` calls:

   * Removed all tooltip-based error messages (mainly using `extras["tip"]`).
   * Replaced them with `Notification.error` displaying the same message.
   * Preserved visual highlighting via `borderColor = "red"` and `node.setSelected(true)` where applicable.
   * Removed one redundant `Notification.error` call for `[★]COMPULSORY InPorts` check to avoid duplicate error messages when running workflows.

2. Standardized error notifications with action buttons for better UX:

    * Introduced a new showNodeCenteringNotification() helper function.
    * This function displays an error message using Notification.error(...), and includes a "Center" button.
    * Clicking the "Center" button auto-scrolls and centers the related node in the canvas for easier visibility and debugging.
    * The toast remains visible for the duration of autoClose (e.g. 3 seconds), even after clicking the action button.
       
## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. In-to-In Port Connection Check**
- Attempted to connect two `InPorts` together.
- Notification: `"Link cannot be created between inPorts."`  

**2. Triangle Port Link Check**
- Tried connecting non-triangle port to triangle port.
-  Notification: `"Flow ports (▶) can only connect to other flow ports (▶)."`

**3. Invalid Link Direction**
- Connected ports from left-to-right instead of right-to-left.
- Notification: `"Link should be created from an outPort to an inPort."`

**4. Data Type Mismatch**
- Linked ports with incompatible data types.
- Notification includes expected vs. provided types.

**5. InPort Already Connected**
- Tried connecting a second link to an InPort.
- Notification: `"You can only create one link for this inPort..."`

**6. Last Node is Not “Finish”**
- Workflow ends with wrong node.
- Notification: `"Please make sure this \"<name>\" node ends with a \"Finish\" node."`

**7. Unconnected ★ InPort**
- Tried compiling/running with missing [★] compulsory connections.
- Notification: `"Please make sure the [★]COMPULSORY InPorts are connected."`

**8. Component Path Error**
- Dropped a missing/invalid component.
- Notification: `"Component could not be loaded from path..."`

### General Behavior on Toast Notifications

 - On click button: the canvas auto-scrolls to center the corresponding node for easier visibility and debugging.

These interactions can be tested with any of the above notifications.

**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux Fedora
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
