### PR TITLE
Show notif for unconnected compulsory ports  and warning in CLI

### DIFF
--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -830,6 +830,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		if (shell.currentWidget?.id !== widgetId) {
 			return;
 		}
+		checkAllCompulsoryInPortsConnected();  
 		onChange()
 		setInitialize(true);
 		setSaved(true);
@@ -853,6 +854,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			showNodeCenteringNotification(message, lastNode.getID(), engine);
 			return;
 		}
+		checkAllCompulsoryInPortsConnected();  
 		const success = await commands.execute(commandIDs.compileFile, { componentList });
 
 		if (success) {

--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -756,6 +756,22 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		});
 	}
 
+	const getNodesConnectedOnAtLeastOneSide = (): NodeModel[] => {
+		const nodes = engine.getModel().getNodes();
+
+		return nodes.filter((node: any) => {
+			const inPorts  = node.portsIn  ?? [];
+			const outPorts = node.portsOut ?? [];
+
+			const allPorts = (inPorts.length || outPorts.length)
+			? [...inPorts, ...outPorts]
+			: Object.values(node.getPorts?.() ?? {});
+
+			const hasAny = allPorts.some((p: any) => Object.keys(p.getLinks()).length > 0);
+			return hasAny;
+		});
+		};
+		
 	const checkAllNodesConnected = (): boolean | null => {
 		let allNodes = getAllNodesFromStartToFinish();
 		let lastNode = allNodes[allNodes.length - 1];
@@ -772,7 +788,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 	}
 
 	const checkAllCompulsoryInPortsConnected = (): boolean | null => {
-		let allNodes = getAllNodesFromStartToFinish();
+		let allNodes = getNodesConnectedOnAtLeastOneSide();
 		for (let i = 0; i < allNodes.length; i++) {
 			for (let k = 0; k < allNodes[i]["portsIn"].length; k++) {
 				let node = allNodes[i]["portsIn"][k]

--- a/xircuits/compiler/validation.py
+++ b/xircuits/compiler/validation.py
@@ -1,9 +1,13 @@
-import json
+import json, sys
 from pathlib import Path
+from typing import Union
 
-def enforce_compulsory_ports(path: str | Path) -> None:
-    data = json.loads(Path(path).read_text(encoding="utf-8"))
-
+def enforce_compulsory_ports(path: Union[str, Path]) -> None:
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        print(f"Error reading '{path}'. The file is not valid JSON.")
+        sys.exit(1)
     node_layer = next(layer for layer in data["layers"]
                       if layer["type"] == "diagram-nodes")
     models = node_layer["models"].values()

--- a/xircuits/compiler/validation.py
+++ b/xircuits/compiler/validation.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+def enforce_compulsory_ports(path: str | Path) -> None:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+
+    node_layer = next(layer for layer in data["layers"]
+                      if layer["type"] == "diagram-nodes")
+    models = node_layer["models"].values()
+
+    for node in models:
+        for port in node["ports"]:
+            if port.get("in") and str(port.get("label", "")).startswith("★") \
+               and len(port.get("links", [])) == 0:
+                print("Warning: COMPULSORY InPorts not connected.")
+                return

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from .utils import is_empty, copy_from_installed_wheel
 from .library import list_component_library, install_library, fetch_library, save_component_library_config
 from .compiler import compile, recursive_compile
+from .compiler.validation import enforce_compulsory_ports
 
 def init_xircuits():
     """
@@ -100,6 +101,8 @@ def cmd_compile(args, extra_args=[]):
     component_paths = {}
     if args.python_paths_file:
         component_paths = json.load(args.python_paths_file)
+    
+    enforce_compulsory_ports(args.source_file)
     
     if args.recursive:
         # Pass the user-specified out_file (if any) to recursive_compile


### PR DESCRIPTION

# Description

This PR introduces:

- Error message for unconnected [★] compulsory InPorts during save and compile in the GUI (previously only shown on run).

- CLI-level warning via enforce_compulsory_ports without blocking compilation.

- No breaking behavior; compilation and save continue as usual.

<img width="527" height="313" alt="image" src="https://github.com/user-attachments/assets/53664ed6-e97f-4930-ac72-3f80e93de9df" />


## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests


**1. GUI: Save and Compile with unconnected compulsory ports**

   1. On the canvas, leave a component that has a [★] compulsory InPort unconnected.
   2. Click **Save**:
      - You will see a success notification: `Workflow saved successfully.`
      - You will also see an error notification: `Please make sure the [★]COMPULSORY InPorts are connected.`

   3. Click **Compile**:
      - You will see a success notification: `Workflow compiled successfully.`
      - You will also see the same error notification about unconnected compulsory ports.

**2. CLI: Compile with unconnected compulsory ports**

   1. From terminal, run:
      ```bash
      xircuits compile path/to/workflow.xircuits
      ```
   2. If the workflow contains any unconnected [★] compulsory InPorts:
      - You will see a CLI warning:
        ```
        Warning: COMPULSORY InPorts not connected.
        ```
      - Compilation will still proceed successfully and generate the `.py` file.


**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux Fedora
- [ ] Mac  
- [ ] Others  (State here -> xxx )  