### PR TITLE
Add uninstall support for component libraries in CLI and UI

### DIFF
--- a/src/context-menu/TrayContextMenu.tsx
+++ b/src/context-menu/TrayContextMenu.tsx
@@ -5,7 +5,7 @@ import { startRunOutputStr } from '../components/runner/RunOutput';
 import '../../style/ContextMenu.css';
 import { buildLocalFilePath, fetchLibraryConfig } from '../tray_library/ComponentLibraryConfig';
 import { commandIDs } from "../commands/CommandIDs";
-import { downloadIcon, linkIcon, folderIcon, textEditorIcon, kernelIcon } from "@jupyterlab/ui-components";
+import { downloadIcon, linkIcon, folderIcon, textEditorIcon, kernelIcon, deleteIcon } from "@jupyterlab/ui-components";
 import { Notification } from '@jupyterlab/apputils';
 import { normalizeLibraryName } from '../tray_library/ComponentLibraryConfig';
 
@@ -165,6 +165,21 @@ const TrayContextMenu = ({ app, x, y, visible, libraryName, status, refreshTrigg
         }
     };
 
+    const handleUninstall = async (libraryName: string) => {
+        if (!confirm(`Uninstall ${libraryName}?`)) return;
+
+        try {
+            await requestAPI<any>('library/uninstall', {
+            method: 'POST',
+            body: JSON.stringify({ libraryName })
+            });
+            Notification.success(`Library ${libraryName} uninstalled.`, { autoClose: 3000 });
+            refreshTrigger();
+        } catch (err) {
+            Notification.error(`Failed to uninstall ${libraryName}: ${err}`, { autoClose: false });
+        }
+        };
+
     if (!visible) {
         return null;
     }
@@ -211,6 +226,9 @@ const TrayContextMenu = ({ app, x, y, visible, libraryName, status, refreshTrigg
                     )}
                     {validOptions.showPageInNewTab && (
                       <Option icon={linkIcon.react} label="Open Repository" onClick={() => handleShowPageInNewTab(libraryName)} />
+                    )}
+                    {validOptions.showPageInNewTab && (
+                      <Option icon={deleteIcon.react} label={`Uninstall ${libraryName}`} onClick={() => handleUninstall(libraryName)} />
                     )}
                 </>
             )}

--- a/xircuits/handlers/__init__.py
+++ b/xircuits/handlers/__init__.py
@@ -4,7 +4,7 @@ from .compile_xircuits import CompileXircuitsFileRouteHandler, CompileRecursiveX
 from .components import ComponentsRouteHandler
 from .config import RunConfigRouteHandler, SplitModeConfigHandler
 from .debugger import DebuggerRouteHandler
-from .request_library import InstallLibraryRouteHandler, FetchLibraryRouteHandler, GetLibraryDirectoryRouteHandler, GetLibraryReadmeRouteHandler, GetLibraryExampleRouteHandler, ReloadComponentLibraryConfigHandler, GetComponentLibraryConfigHandler, CreateNewLibraryHandler
+from .request_library import InstallLibraryRouteHandler, FetchLibraryRouteHandler, UninstallLibraryRouteHandler, GetLibraryDirectoryRouteHandler, GetLibraryReadmeRouteHandler, GetLibraryExampleRouteHandler, ReloadComponentLibraryConfigHandler, GetComponentLibraryConfigHandler, CreateNewLibraryHandler
 
 
 def setup_handlers(web_app, url_path):
@@ -49,6 +49,9 @@ def setup_handlers(web_app, url_path):
             url_path_join(base_url, url_path, "library/fetch"),
             FetchLibraryRouteHandler
         ),
+        (
+            url_path_join(base_url, url_path, "library/uninstall"),
+            UninstallLibraryRouteHandler),
         (
             url_path_join(base_url, url_path, "library/install"),
             InstallLibraryRouteHandler

--- a/xircuits/library/__init__.py
+++ b/xircuits/library/__init__.py
@@ -1,4 +1,4 @@
 from .list_library import list_component_library
-from .install_fetch_library import install_library, fetch_library, get_library_config, build_library_file_path_from_config
+from .install_fetch_library import install_library, fetch_library, get_library_config, build_library_file_path_from_config, uninstall_library
 from .generate_component_library_config import save_component_library_config, get_component_library_config
 from .create_library import create_or_update_library

--- a/xircuits/library/install_fetch_library.py
+++ b/xircuits/library/install_fetch_library.py
@@ -121,3 +121,19 @@ def fetch_library(library_name: str):
             print(message)
     else:
         print(f"{library_name} library already exists in {component_library_path}.")
+
+def uninstall_library(library_name: str) -> None:
+    """
+    Remove the component‑library directory and refresh list.
+    """
+    lib_path = Path(build_component_library_path(library_name))
+
+    if not lib_path.exists():
+        print(f"Library '{library_name}' not found.")
+        return
+
+    try:
+        shutil.rmtree(lib_path)
+        print(f"Library '{library_name}' uninstalled.")
+    except Exception as e:
+        print(f"Failed to uninstall '{library_name}': {e}")

--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 from .utils import is_empty, copy_from_installed_wheel
-from .library import list_component_library, install_library, fetch_library, save_component_library_config
+from .library import list_component_library, install_library, fetch_library, save_component_library_config, uninstall_library
 from .compiler import compile, recursive_compile
 
 def init_xircuits():
@@ -96,6 +96,9 @@ def cmd_fetch_library(args, extra_args=[]):
 def cmd_install_library(args, extra_args=[]):
     install_library(args.library_name.lower())
 
+def cmd_uninstall_library(args, extra_args=[]):
+    uninstall_library(args.library_name.lower())
+
 def cmd_compile(args, extra_args=[]):
     component_paths = {}
     if args.python_paths_file:
@@ -177,6 +180,11 @@ def main():
     fetch_parser = subparsers.add_parser('fetch-only', help='Fetch a library for Xircuits. Does not install.')
     fetch_parser.add_argument('library_name', type=str, help='Name of the library to fetch')
     fetch_parser.set_defaults(func=cmd_fetch_library)
+
+    # 'uninstall' command.
+    uninstall_parser = subparsers.add_parser('uninstall', help='Uninstall a component library for Xircuits.')
+    uninstall_parser.add_argument('library_name', type=str, help='Name of the library to uninstall')
+    uninstall_parser.set_defaults(func=cmd_uninstall_library)
 
     # 'examples' command.
     examples_parser = subparsers.add_parser('examples', help='Get example workflows for Xircuits.')


### PR DESCRIPTION

# Description

This PR introduces the ability to uninstall component libraries:

- UI: Added a new option to the context menu allowing users to uninstall a library directly from the sidebar.

- CLI: Added a new uninstall command to remove a library via terminal.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

#### **1. Test A - Uninstall via UI (Context Menu)**

1. Go to the **Component Library** sidebar.
2. Right-click on an installed library (e.g. `agent`, `flask`).
3. Click on **Uninstall agent** from the context menu.
4. Confirm the uninstall prompt.
5. Check that:

   * The library disappears immediately from the list.
   * A success notification appears.
   * Files are deleted from `xai_components`.

#### **2. Test B - Uninstall via CLI**

1. Open terminal.
2. Run:

   ```bash
   xircuits uninstall agent
   ```
3. Confirm that:

   * The CLI outputs `Library 'agent' uninstalled.`
   * The library folder is removed from `xai_components`.
   * No errors appear if the library doesn't exist — a warning is printed instead.


**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux Fedora
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

