### PR TITLE
🐛 Skip reload for Comment nodes

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -283,17 +283,23 @@ export function addNodeActionCommands(
                 } else if (selected_node.name == "Finish") {
                     node = BaseComponentLibrary('Finish');
                 } else {
+                    const extras = selected_node.getOptions().extras ?? {};
+                    const path = (extras.path || extras.pyFile || extras.componentPath || '').trim();
+                    const isComment = extras.type === 'comment' || selected_node.name.startsWith('Comment');
+
+                    if (!path || isComment) {
+                        continue;
+                    }
                     // For other nodes, fetch from AdvancedComponentLibrary
                     try {
                         let current_node = await fetchNodeByName(selected_node.name);
                         node = AdvancedComponentLibrary({ model: current_node });
                         node.setPosition(selected_node.getX(), selected_node.getY());
                     } catch (error) {
-                        let path = selected_node.getOptions()["extras"].path;
                         console.log(`Error reloading component from path: ${path}. Error: ${error.message}`);
                         selected_node.getOptions().extras["borderColor"] = "red";
                         const message =
-                        `Component could not be loaded from path: \`${path}\`.\nPlease ensure that the component exists!`;
+                            `Component could not be loaded from path: \`${path}\`.\nPlease ensure that the component exists!`;
                         showNodeCenteringNotification(message, selected_node.getID(), engine);
                         nodesToHighlight.push(selected_node);
                         continue;

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -284,8 +284,8 @@ export function addNodeActionCommands(
                     node = BaseComponentLibrary('Finish');
                 } else {
                     const extras = selected_node.getOptions().extras ?? {};
-                    const path = (extras.path || extras.pyFile || extras.componentPath || '').trim();
-                    const isComment = extras.type === 'comment' || selected_node.name.startsWith('Comment');
+                    const path = extras.path || '' .trim();
+                    const isComment = extras.type === 'comment';
 
                     if (!path || isComment) {
                         continue;


### PR DESCRIPTION
# Description

This PR fixes an issue where Comment nodes and other nodes without a valid component path were triggering unnecessary error notifications during the reload process.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests


- Verified that Comment nodes no longer show error notifications on reload.
- Confirmed that regular components still reload correctly and show appropriate error messages when needed.

**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux Fedora
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

