### PR TITLE
🐛 Support macOS ⌘ Key in Keyboard Shortcuts

### DIFF
--- a/src/commands/CustomActionEvent.tsx
+++ b/src/commands/CustomActionEvent.tsx
@@ -4,41 +4,41 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 import { commandIDs } from "./CommandIDs";
 
 interface CustomActionEventOptions {
-    app: JupyterFrontEnd;
-    getWidgetId: () => string;
+  app: JupyterFrontEnd;
+  getWidgetId: () => string;
 }
 
 export class CustomActionEvent extends Action {
-    constructor(options: CustomActionEventOptions) {
-        super({
-            type: InputType.KEY_DOWN,
-            fire: (event: ActionEvent<React.KeyboardEvent>) => {
-                const app = options.app;
-                // @ts-ignore
-                if (app.shell._tracker._activeWidget && options.getWidgetId() === app.shell._tracker._activeWidget.id) {
-                    const keyCode = event.event.key;
-                    const ctrlKey = event.event.ctrlKey;
+  constructor(options: CustomActionEventOptions) {
+    super({
+      type: InputType.KEY_DOWN,
+      fire: (e: ActionEvent<React.KeyboardEvent>) => {
+        const app = options.app;
+        // @ts-ignore
+        if (app.shell._tracker._activeWidget && options.getWidgetId() === app.shell._tracker._activeWidget.id) {
+          const { key, ctrlKey, metaKey, nativeEvent } = e.event;
+          const cmd = ctrlKey || metaKey;
 
-                    const executeIf = (condition, command) => {
-                        if (condition) {
-                            event.event.preventDefault();
-                            event.event.stopPropagation();
-                            if (event.event.nativeEvent) {
-                                event.event.nativeEvent.stopImmediatePropagation();
-                            }
-                            app.commands.execute(command);
-                        }
-                    };
-
-                    executeIf(ctrlKey && keyCode === 'z', commandIDs.undo);
-                    executeIf(ctrlKey && keyCode === 'y', commandIDs.redo);
-                    executeIf(ctrlKey && keyCode === 's', commandIDs.saveXircuit);
-                    executeIf(ctrlKey && keyCode === 'x', commandIDs.cutNode);
-                    executeIf(ctrlKey && keyCode === 'c', commandIDs.copyNode);
-                    executeIf(ctrlKey && keyCode === 'v', commandIDs.pasteNode);
-                    executeIf(keyCode == 'Delete' || keyCode == 'Backspace', commandIDs.deleteEntity);
-                }
+          const executeIf = (condition, command) => {
+            if (condition) {
+              e.event.preventDefault();
+              e.event.stopPropagation();
+              if (nativeEvent) {
+                nativeEvent.stopImmediatePropagation();
+              }
+              app.commands.execute(command);
             }
-        });
-    }
+          };
+
+          executeIf(cmd && key === 'z', commandIDs.undo);
+          executeIf(cmd && key === 'y', commandIDs.redo);
+          executeIf(cmd && key === 's', commandIDs.saveXircuit);
+          executeIf(cmd && key === 'x', commandIDs.cutNode);
+          executeIf(cmd && key === 'c', commandIDs.copyNode);
+          executeIf(cmd && key === 'v', commandIDs.pasteNode);
+          executeIf(key === 'Delete' || key === 'Backspace', commandIDs.deleteEntity);
+        }
+      }
+    });
+  }
 }


### PR DESCRIPTION
# Description

This PR updates our `CustomActionEvent` handler so that on macOS it responds to the “⌘” key as well as “Ctrl” on Windows/Linux. Internally, we now treat `event.ctrlKey || event.metaKey` as the “command” modifier, and all existing keybindings (`Z`, `Y`, `S`, `X`, `C`, `V`, `Delete`/`Backspace`) continue to work exactly as before. 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)  
- [ ] Xircuits Canvas (Custom RD Related changes)  
- [ ] Xircuits Component Library  
- [ ] Xircuits Project Template  
- [ ] Testing Automation  
- [ ] Documentation  
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] This change requires a documentation update  

# Tests

**1. Test A**  
   1. Press Ctrl+Z, Ctrl+Y, Ctrl+S, Ctrl+X, Ctrl+C, Ctrl+V, Delete, and Backspace to verify undo/redo/save/cut/copy/paste/delete commands still fire.  
   2. On macOS, press ⌘+Z, ⌘+Y, ⌘+S, ⌘+X, ⌘+C, ⌘+V, Delete, and Backspace — verify the same commands execute.  
   3. Ensure no other keybindings or modifiers were impacted.

**Tested on? Specify Version.**

- [x] Windows 10
- [x] Linux
- [] Mac
- [ ] Others  (State here → xxx )  