### PR TITLE
🐛 Fix: hide uninstall option for core libraries

### DIFF
--- a/src/context-menu/TrayContextMenu.tsx
+++ b/src/context-menu/TrayContextMenu.tsx
@@ -186,7 +186,10 @@ const TrayContextMenu = ({ app, x, y, visible, libraryName, status, refreshTrigg
         return null;
     }
 
-    const isCore = CORE_LIBS.has(libraryName.toLowerCase());
+    const normalizedName = normalizeLibraryName(libraryName).split('/').pop();
+    const isCore = CORE_LIBS.has(normalizedName);
+
+
 
     function addHoverClass(e){
         e.currentTarget.classList.add("lm-mod-active");


### PR DESCRIPTION

# Description


This PR fixes a bug where the "Uninstall" option still appeared in the context menu for core libraries such as CONTROLFLOW, even though they are supposed to be protected.

The issue was due to comparing the raw libraryName with the CORE_LIBS set, while normalizeLibraryName() was returning a path-like string (xai_components/xai_controlflow). The fix extracts the last part of the path using .split('/').pop() before comparing.


## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Test core library context menu**

1. Go to the "Libraries" panel in the sidebar.
2. Right-click on a known core library (e.g. `CONTROLFLOW`).
3. Verify that the **"Uninstall"** option **does NOT appear** in the context menu.


**2. Test non-core library context menu**

1. Right-click on a non-core library (e.g. `actors`, `gradio`, etc.).
2. Verify that the **"Uninstall"** option **does appear** in the context menu.
3. Click "Uninstall" and confirm that the library is successfully removed and notification appears.


**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux Fedora
- [ ] Mac  
- [ ] Others  (State here -> xxx )  


