### PR TITLE
🐛 Fix Memory Bloat from Excessive Model Serialization on Change

### DIFF
--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -427,21 +427,22 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 		zoomOut(xircuitsApp.getDiagramEngine());
 		}, [xircuitsApp]);
 	
-	const onChange = useCallback(
-		(): void => {
-			if (contextRef.current.isReady) {
-				let currentModel = xircuitsApp.getDiagramEngine().getModel().serialize();
-				contextRef.current.model.fromString(
-					JSON.stringify(currentModel, null, 4)
-				);
-				setSaved(false);
-			}
-		}, []);
+	const onChange = useCallback(() => {
+		if (contextRef.current.isReady) {
+	        contextRef.current.model.dirty = true;
+		}
+		setSaved(false);
+	}, []);
 
-	function replacer(key, value) {
-		if (key == "x" || key == "y") return Math.round((value + Number.EPSILON) * 1000) / 1000;
-		return value;
-	}
+	const serializeModel = useCallback(() => {
+		if (contextRef.current.isReady) {
+			let currentModel = xircuitsApp.getDiagramEngine().getModel().serialize();
+			contextRef.current.model.fromString(
+				JSON.stringify(currentModel, null, 4)
+			);
+			setSaved(false);
+		}
+	}, []);
 
 	useEffect(() => {
 		const currentContext = contextRef.current;
@@ -850,7 +851,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			return;
 		}
 		checkAllCompulsoryInPortsConnected();  
-		onChange()
+		serializeModel();
 		setInitialize(true);
 		setSaved(true);
 		await commands.execute(commandIDs.saveDocManager);


### PR DESCRIPTION
# Description

For so long, Xircuits Canvas was serializing the entire model on **every** `onChange` event (e.g., delete node, create node, reconnect ports).  For massive workflows (+100 components), if you press **Reload All** this resulted in repeated calls of:

```ts
let currentModel = xircuitsApp.getDiagramEngine().getModel().serialize();
contextRef.current.model.fromString(JSON.stringify(currentModel, null, 4));
```

which caused **hundreds of MBs** (even GBs) of `(string)` and `(concatenated string)` allocations in memory, leading to significant slowdowns.

<img width="1624" height="304" alt="image" src="https://github.com/user-attachments/assets/5ef08660-84f4-4b0f-b741-31a4d2fd4015" />

This PR separates the concerns: `onChange` now only updates **dirty state** (for JupyterLab) and local model state, and full model serialization occurs when saving, not on every change.

<img width="1653" height="509" alt="image" src="https://github.com/user-attachments/assets/2ca4b771-a04a-418d-b42c-259d19a47189" />

- Reloads are now **~10× faster** on large diagrams.
- Heap snapshots no longer show large `(concatenated string)` dominance.
- **Dirty state behavior is preserved** and remains accurate.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

---

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

# Tests

## Memory and Performance Test

**Steps to Record and Check Memory:**
1. Open Chrome DevTools → **Memory** tab.
2. Select **Record Allocation Timeline**.
3. Perform a **Reload All** on a large diagram.
4. Stop the recording.
5. Verify:
   - No large `(concatenated string)` entries in heap snapshots.
   - Significantly lower retained size for `(string)`.
   - Reload completes faster.

You can use this canvas:
https://gist.github.com/MFA-X-AI/3c5b1174885ee322eea57be625076b14
It contains 64 Print components + 64 Literal Strings. 

## Functional Behaviour Tests

Ensure **core behaviours remain unchanged**:

1. **Node updates**  
   - Add and remove nodes.  
   - Update ports via code (add/edit a port → reload) and confirm changes persist.

2. **Link updates**  
   - Add and remove links between nodes.  
   - Reload and confirm connections are saved.

3. **Link point updates**  
   - Move link points and ensure updated positions persist after reload.

4. **Port updates**  
   - Modify port configurations and verify they persist after reload.

---

**Environment Tested On:**  
- [x] Windows  
- [x] Linux  

