### PR TITLE
🐛 Fix Run Don't Compile Option

### DIFF
--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -937,7 +937,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 	
 			let result;
 	
-			if (runType == 'run') {
+			if (runType == 'run' || runType == 'run-dont-compile') {
 				result = await handleLocalRunDialog();
 				if (result.status === 'ok') {
 				code += "%run " + model_path + result.args;


### PR DESCRIPTION
# Description

This PR fixes the `run w/o compile` run option. 

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Check Run without Compile Functionality**

    1. Open canvas, save compile run. Verify that it works normally.
    2. Make a change (eg change a value of a Literal String). Select the `run w/o compile` option. Verify that the output does not reflect the newest changes (same output as previous)

**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux
- [ ] Mac  
- [ ] Others  (State here -> xxx )  