### PR TITLE
🧪 Add Playwright tests: Clipboard + Light/Dark toggle

### DIFF
--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -86,18 +86,51 @@ jobs:
         nohup jupyter lab --ServerApp.token='' --ServerApp.password='' --LabApp.default_url='/lab?reset' > jupyter.log 2>&1 &
         sleep 10
         cd ui-tests/tests
-        xvfb-run -a python3 zoom-buttons-test.py
-        xvfb-run -a python3 connecting-args-test.py
-        xvfb-run -a python3 parameter-names-autoshift.py
-        xvfb-run -a python3 parameter-names-despawn.py
-        xvfb-run -a python3 parameter-names-spawn.py
-        xvfb-run -a python3 protected-nodes-and-lock-test.py
-        xvfb-run -a python3 remote_run_arguments_test.py
-        xvfb-run -a python3 connecting-nodes-test.py
-        xvfb-run -a python3 editing-literal-nodes-test.py
-        
 
-      
+        echo "===== 🚀 Starting test_toggle_light_dark.py ====="
+        xvfb-run -a python3 test_clipboard_copy_paste.py
+        echo "===== ✅ Finished test_toggle_light_dark.py ====="
+
+        echo "===== 🚀 Starting test_clipboard_single_print.py ====="
+        xvfb-run -a python3 test_toggle_light_dark.py
+        echo "===== ✅ Finished test_clipboard_single_print.py ====="
+
+        echo "===== 🚀 Starting zoom-buttons-test.py ====="
+        xvfb-run -a python3 zoom-buttons-test.py
+        echo "===== ✅ Finished zoom-buttons-test.py ====="
+
+        echo "===== 🚀 Starting connecting-args-test.py ====="
+        xvfb-run -a python3 connecting-args-test.py
+        echo "===== ✅ Finished connecting-args-test.py ====="
+
+        echo "===== 🚀 Starting parameter-names-autoshift.py ====="
+        xvfb-run -a python3 parameter-names-autoshift.py
+        echo "===== ✅ Finished parameter-names-autoshift.py ====="
+
+        echo "===== 🚀 Starting parameter-names-despawn.py ====="
+        xvfb-run -a python3 parameter-names-despawn.py
+        echo "===== ✅ Finished parameter-names-despawn.py ====="
+
+        echo "===== 🚀 Starting parameter-names-spawn.py ====="
+        xvfb-run -a python3 parameter-names-spawn.py
+        echo "===== ✅ Finished parameter-names-spawn.py ====="
+
+        echo "===== 🚀 Starting protected-nodes-and-lock-test.py ====="
+        xvfb-run -a python3 protected-nodes-and-lock-test.py
+        echo "===== ✅ Finished protected-nodes-and-lock-test.py ====="
+
+        echo "===== 🚀 Starting remote_run_arguments_test.py ====="
+        xvfb-run -a python3 remote_run_arguments_test.py
+        echo "===== ✅ Finished remote_run_arguments_test.py ====="
+
+        echo "===== 🚀 Starting connecting-nodes-test.py ====="
+        xvfb-run -a python3 connecting-nodes-test.py
+        echo "===== ✅ Finished connecting-nodes-test.py ====="
+
+        echo "===== 🚀 Starting editing-literal-nodes-test.py ====="
+        xvfb-run -a python3 editing-literal-nodes-test.py
+        echo "===== ✅ Finished editing-literal-nodes-test.py ====="
+
     - uses: actions/upload-artifact@v4
       if: failure()
       with:

--- a/ui-tests/tests/test_clipboard_copy_paste.py
+++ b/ui-tests/tests/test_clipboard_copy_paste.py
@@ -1,0 +1,51 @@
+from playwright.sync_api import sync_playwright
+from xircuits_test_utils import  simulate_drag_component_to_position, click_toolbar_button, wait_for_count, click_node_center 
+
+PRINT_NAME = "Print"
+PRINT_SEL  = f'div.node[data-default-node-name="{PRINT_NAME}"]'
+
+BTN_COPY_TITLE  = "Copy selected nodes"
+BTN_PASTE_TITLE = "Paste nodes from the clipboard"
+BTN_CUT_TITLE   = "Cut selected nodes"
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True, slow_mo=120)
+    page = browser.new_page()
+    page.goto("http://localhost:8888")
+    page.wait_for_selector("#jupyterlab-splash", state="detached")
+    page.get_by_text("New Xircuits File", exact=True).click()
+    page.wait_for_selector(".xircuits-canvas", timeout=10000)
+
+    print("Dropping Print...")
+    simulate_drag_component_to_position(page, "UTILS", PRINT_NAME, drop_x=520, drop_y=360)
+
+    page.wait_for_function("(sel)=>document.querySelectorAll(sel).length>=1", arg=PRINT_SEL)
+    base = page.locator(PRINT_SEL).count()
+    print(f"found {base} Print node(s).")
+
+    click_node_center(page, PRINT_SEL)
+
+    # Copy → Paste (+1)
+    click_toolbar_button(page, BTN_COPY_TITLE)
+    click_toolbar_button(page, BTN_PASTE_TITLE)
+    wait_for_count(page, PRINT_SEL, base + 1)
+    print(f"After Copy+Paste: count is {base + 1}.")
+
+    # Paste again (+2 total)
+    click_toolbar_button(page, BTN_PASTE_TITLE)
+    wait_for_count(page, PRINT_SEL, base + 2)
+    print(f"After extra Paste: count is {base + 2}.")
+
+    # Cut one (−1)
+    click_node_center(page, PRINT_SEL)
+    click_toolbar_button(page, BTN_CUT_TITLE)
+    wait_for_count(page, PRINT_SEL, base + 1)
+    print(f"After Cut: count is {base + 1}.")
+
+    # Paste after Cut (+1 back)
+    click_toolbar_button(page, BTN_PASTE_TITLE)
+    wait_for_count(page, PRINT_SEL, base + 2)
+    print(f"After Paste post-Cut: count is {base + 2}.")
+
+    print("Clipboard test on a single Print node passed cleanly.")
+    browser.close()

--- a/ui-tests/tests/test_toggle_light_dark.py
+++ b/ui-tests/tests/test_toggle_light_dark.py
@@ -1,0 +1,41 @@
+from playwright.sync_api import sync_playwright
+from xircuits_test_utils import click_toolbar_button, get_official_theme_info, wait_official_theme_change
+
+BTN_TOGGLE_TITLE = "Toggle Light/Dark Mode"
+
+def mode_from_flag(flag):
+    return "light" if flag == "true" else "dark" if flag == "false" else None
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True, slow_mo=120)
+    page = browser.new_page()
+    page.goto("http://localhost:8888")
+    page.wait_for_selector("#jupyterlab-splash", state="detached")
+    page.get_by_text("New Xircuits File", exact=True).click()
+    page.wait_for_selector(".xircuits-canvas", timeout=10000)
+
+    # Press toggle twice to sync JupyterLab and Xircuits canvas themes
+    click_toolbar_button(page, BTN_TOGGLE_TITLE)
+    click_toolbar_button(page, BTN_TOGGLE_TITLE)
+
+    s0 = get_official_theme_info(page) 
+    if s0["themeName"] is None and s0["themeLight"] is None:
+        raise AssertionError("Missing official JupyterLab theme attributes (data-jp-theme-*)")
+    init_mode = mode_from_flag(s0["themeLight"])
+    print(f"[✔] Initial: name={s0['themeName']}, lightFlag={s0['themeLight']}, mode≈{init_mode}")
+
+    # Toggle
+    exp1 = {"light": "dark", "dark": "light"}.get(init_mode)
+    click_toolbar_button(page, BTN_TOGGLE_TITLE)
+    wait_official_theme_change(page, before=s0, expect_mode=exp1, timeout=15000)
+    s1 = get_official_theme_info(page)
+    print(f"After 1st toggle: name={s1['themeName']}, lightFlag={s1['themeLight']}")
+
+    # Toggle back 
+    click_toolbar_button(page, BTN_TOGGLE_TITLE)
+    wait_official_theme_change(page, before=s1, expect_mode=init_mode, timeout=15000)
+    s2 = get_official_theme_info(page)
+    print(f"After 2nd toggle: name={s2['themeName']}, lightFlag={s2['themeLight']}")
+
+    print("Light/Dark toggle test passed.")
+    browser.close()

--- a/ui-tests/tests/xircuits_test_utils.py
+++ b/ui-tests/tests/xircuits_test_utils.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from typing import Optional
 
 def fill_literal_string_input_and_submit(page: Page, text: str = "Hello Test!"):
     print(f"Filling Literal String input with: {text}")

--- a/ui-tests/tests/xircuits_test_utils.py
+++ b/ui-tests/tests/xircuits_test_utils.py
@@ -581,3 +581,74 @@ def update_literal_chat(page, messages):
 
     page.get_by_role("button", name="Submit").click()
     page.wait_for_timeout(500)
+
+def click_toolbar_button(page, title: str, timeout: int = 10000) -> None:
+    host = page.locator(f'jp-button[title="{title}"]')
+    host.wait_for(state="attached", timeout=timeout)
+    host.locator('button[part="control"]').click()
+
+def wait_for_count(page, selector: str, expected: int, timeout: int = 12000) -> None:
+    """
+    Waits until the number of elements matching 'selector' equals 'expected'.
+    """
+    page.wait_for_function(
+        "({s, n}) => document.querySelectorAll(s).length === n",
+        arg={"s": selector, "n": expected},
+        timeout=timeout,
+    )
+
+def click_node_center(page, selector: str, ensure_canvas_focus: bool = True) -> None:
+    if ensure_canvas_focus:
+        page.click(".xircuits-canvas")
+    loc = page.locator(selector).first
+    loc.wait_for(state="visible", timeout=10000)
+    box = loc.bounding_box()
+    assert box is not None, "Could not read bounding box for the target node."
+    cx = box["x"] + box["width"] / 2
+    cy = box["y"] + box["height"] / 2
+    page.mouse.click(cx, cy)
+
+
+def get_official_theme_info(page):
+    """
+    Read ThemeManager's official attributes from <body>:
+      - data-jp-theme-name
+      - data-jp-theme-light ("true" | "false")
+    """
+    return page.evaluate("""
+    () => {
+      const body = document.body;
+      return {
+        themeName:  body.getAttribute('data-jp-theme-name'),
+        themeLight: body.getAttribute('data-jp-theme-light')
+      };
+    }
+    """)
+
+def wait_official_theme_change(page, before: dict, expect_mode: str | None = None, timeout: int = 15000):
+    """
+    Wait for an official theme change on <body>.
+
+    """
+    exp_flag = None
+    if expect_mode == "light":
+        exp_flag = "true"
+    elif expect_mode == "dark":
+        exp_flag = "false"
+
+    page.wait_for_function(
+        """
+        (args) => {
+          const name  = document.body.getAttribute('data-jp-theme-name');
+          const light = document.body.getAttribute('data-jp-theme-light'); // "true"|"false"|null
+
+          if (args.expFlag !== null) {
+            return light !== null && light === args.expFlag;
+          }
+
+          return name !== args.before.themeName || light !== args.before.themeLight;
+        }
+        """,
+        arg={"before": before, "expFlag": exp_flag},
+        timeout=timeout
+    )

--- a/ui-tests/tests/xircuits_test_utils.py
+++ b/ui-tests/tests/xircuits_test_utils.py
@@ -681,7 +681,7 @@ def get_official_theme_info(page):
     }
     """)
 
-def wait_official_theme_change(page, before: dict, expect_mode: str | None = None, timeout: int = 15000):
+def wait_official_theme_change(page, before: dict, expect_mode: Optional[str] = None, timeout: int = 15000):
     """
     Wait for an official theme change on <body>.
 


### PR DESCRIPTION
# Description

This PR introduces two Playwright UI tests focused on stability and official signals:

- Clipboard test on a single Print node (Copy, Paste, Cut).
- Light/Dark toggle test using JupyterLab official theme signals.

Includes new helpers in xircuits_test_utils for toolbar clicks, node selection, count waits, and theme checks.



## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [x] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

To run the test locally, please follow the setup and usage instructions in the  [README.md](https://github.com/XpressAI/xircuits/blob/master/ui-tests/README.md) file 


**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux Fedora
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
