### PR TITLE
🐞 Fix search input text color in dark theme

### DIFF
--- a/src/tray_library/Sidebar.tsx
+++ b/src/tray_library/Sidebar.tsx
@@ -349,7 +349,7 @@ export default function Sidebar(props: SidebarProps) {
                               <a onClick={handleSearchOnClick} className="search-input__button"><i
                                 className="fa fa-search "></i></a>
                               <input type="text" name="" placeholder="SEARCH"
-                                     className="search-input__text-input" style={{ width: "75%" }}
+                                     className="search-input__text-input" style={{ width: "75%", color: "var(--jp-ui-font-color1)"}}
                                      onChange={handleOnChange} />
                           </div>
                           <a onClick={showMenu} className="button" title="More actions...">


### PR DESCRIPTION

# Description

Ensure the component library search input uses JupyterLab theme variables
instead of  black, so the text is visible in both light and dark themes.

## Pull Request Type

- [x] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux Fedora
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
