### PR TITLE
🐛 Fix template library install checks

### DIFF
--- a/src/context-menu/TrayContextMenu.tsx
+++ b/src/context-menu/TrayContextMenu.tsx
@@ -12,13 +12,18 @@ import { normalizeLibraryName } from '../tray_library/ComponentLibraryConfig';
 export async function handleInstall(
     app,
     libraryName: string,
-    refreshTrigger: () => void
+    refreshTrigger: () => void,
+    opts?: { silent?: boolean }
+
 ): Promise<boolean> {
+    const { silent = false } = opts ?? {};
     const originalName = libraryName;
     const normalizedLibName = normalizeLibraryName(originalName);
 
-    const proceed = confirm(`Do you want to proceed with installing "${originalName}" library?`);
-    if (!proceed) return false;
+    if (!silent) {
+        const proceed = confirm(`Do you want to proceed with installing "${originalName}" library?`);
+        if (!proceed) return false;
+    }
 
     const installPromise = requestAPI<any>('library/install', {
         method: 'POST',


### PR DESCRIPTION
# Description
This PR addresses two issues with template library installation:

1. **Duplicate prompts for already installed libraries**  
   - Added `canon()` function to normalize library names (e.g., `xai_flask` → `flask`) before comparison.  
   - Prevents re-install prompts when libraries are already present.

2. **Multiple confirmation dialogs for missing libraries**  
   - Replaced per-library confirmations with a **single aggregated confirm dialog** listing all missing libraries.  
   - Uses `handleInstall(..., { silent: true })` to skip internal confirms and only show one confirmation to the user.


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

### 1. Already installed libraries

**Goal:** Ensure templates no longer prompt for libraries that are already installed.
**Steps:**

1. Install  `xai_flask` libraries.
2. Open  **Service Template** from the Launcher.
3. Verify: no confirmation dialog appears for this library, and the template open directly.


### 2. Missing library

**Goal:** Confirm dialog appears only once when one library is missing.
**Steps:**

1. Uninstall or remove the `xai_agent` and `xai_openai` libraries.
2. Open **Agent Template**.
3. Verify:

   * A single confirm dialog appears asking to install `AGENT` and `OPENAI`.
   * After accepting, the install runs silently.
   * Template file opens automatically.

### 3. Cancel install

**Goal:** Verify user cancellation aborts correctly.
**Steps:**

1. Uninstall `xai_agent`.
2. Open **Agent Template**.
3. In the confirm dialog, click **Cancel**.
4. Verify:

   * No library install occurs.
   * Template is not opened.

**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
