### PR TITLE
✨ Preserve parameter links on "Drop On link" remove only unsafe loops

### DIFF
--- a/src/components/link/LinkSplitManager.ts
+++ b/src/components/link/LinkSplitManager.ts
@@ -22,9 +22,10 @@ export class LinkSplitManager {
 
     
     static canSplit(link: DefaultLinkModel): boolean {
-        const src = link.getSourcePort() as CustomPortModel;
-        const dst = link.getTargetPort() as CustomPortModel;
-        return src.getName() === 'out-0' && dst.getName() === 'in-0';
+        if (link.getOptions().type === 'triangle-link') {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/components/link/SplitLinkCommand.ts
+++ b/src/components/link/SplitLinkCommand.ts
@@ -42,9 +42,9 @@ export class SplitLinkCommand {
   /** Remove all links on *any* port of the dragged node, except those connected to Literal nodes */
   private clearAllNodeLinks() {
       const isLiteralNode = (node: CustomNodeModel) => {
-          const opts = node?.getOptions?.() ?? {};
-          const n = (opts as any).name ?? '';
-          return /literal/i.test(n);
+          const options = node?.getOptions?.() ?? {};
+          const nodeName = (options as any).name ?? '';
+          return nodeName.toLowerCase().includes("literal");
       };
 
     Object.values(this.draggedNode.getPorts()).forEach(port => {

--- a/src/components/link/SplitLinkCommand.ts
+++ b/src/components/link/SplitLinkCommand.ts
@@ -38,54 +38,27 @@ export class SplitLinkCommand {
   private clonePoint(orig: PointModel, link: DefaultLinkModel): PointModel {
       return link.generatePoint(orig.getX(), orig.getY());
   }
-  // Clean up unsafe parameter links (loops/back-edges) after insertion
-  private sanitizeParamLinksAfterInsertion() {
-    const paramPorts = Object.values(this.draggedNode.getPorts())
-      .filter(p => {
-        const name = (p as CustomPortModel).getName?.();
-        return name !== 'in-0' && name !== 'out-0';
-      }) as CustomPortModel[];
 
-    let removed = 0;
+  /** Remove all links on *any* port of the dragged node, except those connected to Literal nodes */
+  private clearAllNodeLinks() {
+      const isLiteralNode = (node: CustomNodeModel) => {
+          const opts = node?.getOptions?.() ?? {};
+          const n = (opts as any).name ?? '';
+          return /literal/i.test(n);
+      };
 
-    for (const p of paramPorts) {
-      const links = [...Object.values(p.getLinks())];
+    Object.values(this.draggedNode.getPorts()).forEach(port => {
+        Object.values((port as CustomPortModel).getLinks()).forEach(l => {
+            const srcNode = (l.getSourcePort() as CustomPortModel)?.getParent() as CustomNodeModel;
+            const dstNode = (l.getTargetPort() as CustomPortModel)?.getParent() as CustomNodeModel;
 
-      for (const l of links) {
-        const a = l.getSourcePort() as CustomPortModel;
-        const b = l.getTargetPort() as CustomPortModel;
-
-        let provider: CustomPortModel;
-        let consumer: CustomPortModel;
-        if (!a.getOptions().in && b.getOptions().in) {
-          provider = a;
-          consumer = b;
-        } else if (!b.getOptions().in && a.getOptions().in) {
-          provider = b;
-          consumer = a;
-        } else if (p === a) {
-          provider = b;
-          consumer = a;
-        } else {
-          provider = a;
-          consumer = b;
-        }
-
-        if (!provider.checkExecutionLoop(provider, consumer)) {
-          this.diagramModel.removeLink(l);
-          removed++;
-        }
-      }
-    }
-
-    if (removed) {
-      Notification.info(
-        `Removed ${removed} unsafe parameter link(s) that would create an execution loop.`,
-        { autoClose: 4000 }
-      );
-    }
+            if (isLiteralNode(srcNode) || isLiteralNode(dstNode)) {
+                return;
+            }
+            this.diagramModel.removeLink(l);
+        });
+    });
   }
-
   execute(): void {
       const inPort = this.draggedNode.getPort('in-0') as CustomPortModel;
       const outPort = this.draggedNode.getPort('out-0') as CustomPortModel;
@@ -95,14 +68,8 @@ export class SplitLinkCommand {
         return;
     }
     
-
-    const existingInLinks = Object.values(inPort.getLinks());
-    const existingOutLinks = Object.values(outPort.getLinks());
-    if (existingInLinks.length > 0 || existingOutLinks.length > 0) {
-        Notification.info("Flow ports are already connected. Existing flow connections will be removed.", { autoClose: 3000 });
-        existingInLinks.forEach(l => this.diagramModel.removeLink(l));
-        existingOutLinks.forEach(l => this.diagramModel.removeLink(l));
-    }
+    this.clearAllNodeLinks();
+    Notification.info("Flow ports are already connected. Existing flow connections will be removed.", { autoClose: 3000 });
 
     const oldLink = this.diagramModel.getLink(this.linkId) as DefaultLinkModel;
     if (!oldLink) return;
@@ -122,7 +89,7 @@ export class SplitLinkCommand {
 
     const points = [...oldLink.getPoints()];
     this.diagramModel.removeLink(oldLink);
-    
+
     // Straight link (no bends)
     if (points.length <= 2) {
         const leftLink = new DefaultLinkModel();
@@ -133,7 +100,6 @@ export class SplitLinkCommand {
         rightLink.setTargetPort(dstPort);
         this.diagramModel.addLink(leftLink);
         this.diagramModel.addLink(rightLink);
-        this.sanitizeParamLinksAfterInsertion();
         return;
     }
 
@@ -179,8 +145,6 @@ export class SplitLinkCommand {
     // Highlight new links
     leftLink.setSelected(true);
     rightLink.setSelected(true);
-    this.sanitizeParamLinksAfterInsertion();
-
     leftBends.forEach(pt => pt.setSelected(true));
     rightBends.forEach(pt => pt.setSelected(true));
   }

--- a/src/components/link/SplitLinkCommand.ts
+++ b/src/components/link/SplitLinkCommand.ts
@@ -77,9 +77,9 @@ export class SplitLinkCommand {
     const srcPort = oldLink.getSourcePort() as CustomPortModel;
     const dstPort = oldLink.getTargetPort() as CustomPortModel;
     if (!srcPort || !dstPort) return;
-    if (srcPort.getName() !== 'out-0' || dstPort.getName() !== 'in-0') {
+    if (oldLink.getOptions().type !== 'triangle-link') {
         return;
-        }
+    }
 
     if (!this.diagramModel.getNode(this.draggedNode.getID())) {
         this.diagramModel.addNode(this.draggedNode);

--- a/src/components/link/SplitLinkCommand.ts
+++ b/src/components/link/SplitLinkCommand.ts
@@ -58,12 +58,17 @@ export class SplitLinkCommand {
         let provider: CustomPortModel;
         let consumer: CustomPortModel;
         if (!a.getOptions().in && b.getOptions().in) {
-          provider = a; consumer = b;
+          provider = a;
+          consumer = b;
         } else if (!b.getOptions().in && a.getOptions().in) {
-          provider = b; consumer = a;
+          provider = b;
+          consumer = a;
+        } else if (p === a) {
+          provider = b;
+          consumer = a;
         } else {
-          provider = (p === a) ? b : a;
-          consumer = p;
+          provider = a;
+          consumer = b;
         }
 
         if (!provider.checkExecutionLoop(provider, consumer)) {


### PR DESCRIPTION

# Description

This PR addresses the issue where dropping a node on a flow link caused **all its parameter connections (e.g., to literals)** to be lost. If a node had parameter links already attached, they were completely removed during the split.

### Fix

* Keep parameter links intact when inserting a node on a link.
* Added a **sanitization step** that checks parameter links *after insertion* and removes **only unsafe ones** (those that create execution loops/back-edges).
* Ensures flow ports (`in-0/out-0`) are reconnected correctly, while parameter links remain unless invalid.

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Tests

**1. Preserve parameter links on drop**

1. Create a workflow with a node connected to a literal through a parameter port.
2. Drag another node and drop it on an existing flow link.
3. Verify that the parameter link to the literal is preserved.

**2. Remove unsafe parameter links (loop detection)**

1. Create a workflow where a node’s parameter is connected to another node that appears **after** it in the flow.
2. Drop a new node on a flow link in between.
3. Verify that the unsafe back-edge parameter link is automatically removed and a notification is shown.

**3. Straight vs. bent links**

* Test with a straight link (`points.length <= 2`) and verify split + sanitization works.
* Test with a bent link (`points.length > 2`) and verify split + sanitization also works.

**4. Existing flow connections**

* Drop a node onto a link where its `in-0` or `out-0` are already connected elsewhere.
* Verify old flow links are removed, replaced with new split links, and the node is inserted correctly.


**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
