### PR TITLE
🐛 Fix core libraries context menu

### DIFF
--- a/src/context-menu/TrayContextMenu.tsx
+++ b/src/context-menu/TrayContextMenu.tsx
@@ -90,7 +90,7 @@ const TrayContextMenu = ({ app, x, y, visible, libraryName, status, refreshTrigg
             try {
                 const libraryConfig = await fetchLibraryConfig(libraryName);
                 setValidOptions({
-                    showInFileBrowser: !!libraryConfig.local_path,
+                    showInFileBrowser: !!libraryConfig.path,
                     showReadme: await buildLocalFilePath(libraryName, 'readme') !== null,
                     showExample: await buildLocalFilePath(libraryName, 'default_example_path') !== null,
                     showPageInNewTab: !!libraryConfig.repository
@@ -123,8 +123,8 @@ const TrayContextMenu = ({ app, x, y, visible, libraryName, status, refreshTrigg
         try {
             const libraryConfig = await fetchLibraryConfig(libraryName);
     
-            if (libraryConfig && libraryConfig.local_path) {
-                await app.commands.execute('filebrowser:go-to-path', { path: libraryConfig.local_path });
+            if (libraryConfig && libraryConfig.path) {
+                await app.commands.execute('filebrowser:go-to-path', { path: libraryConfig.path });
             }
         } catch (error) {
             alert(`Failed to Show in File Browser: ${error}`);

--- a/src/tray_library/ComponentLibraryConfig.tsx
+++ b/src/tray_library/ComponentLibraryConfig.tsx
@@ -9,7 +9,7 @@ export interface LibraryConfig {
     name: string;
     library_id: string;
     repository: string;
-    local_path: string;
+    path: string;
     status: string;
     version?: string;
     description?: string;
@@ -101,7 +101,7 @@ export const buildLocalFilePath = async (libName, fileKey) => {
     const libraryConfig = await fetchLibraryConfig(libName);
 
     if (libraryConfig && libraryConfig[fileKey]) {
-        return `${libraryConfig.local_path}/${libraryConfig[fileKey]}`;
+        return `${libraryConfig.path}/${libraryConfig[fileKey]}`;
     } else if (libraryConfig) {
         // console.log(`File not found for: ${libName} (Key: ${fileKey})`);
     }


### PR DESCRIPTION
# Description

This PR fixes the issue where the context menu for core libraries (Controlflow, Events, Template, Utils) appeared empty.  
The root cause was that core libraries were missing from `index.json`.  

- Updated `ComponentLibraryConfig` and `TrayContextMenu` to correctly use the `path` field.  
- Ensured context menus render properly for both core and installed libraries. 
- Additionally, the **Show in File Browser** option did not appear for other libraries due to the recent change in how `index.json` handles `path` vs `local_path`. 


## References

A follow-up PR will be opened on the **xai-components-manifest** repository to update `index.json` accordingly.  


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

- Verified that context menus now show for core libraries.  
- Verified that "Show in File Browser" option appears correctly for other libraries.  


**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
