### PR TITLE
✨ Improve missing component handling V2

### DIFF
--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -65,12 +65,12 @@ export function addNodeActionCommands(
             if (args['nodePath'] === undefined && args['nodeName'] === undefined && args['nodeLineNo'] === undefined) {
                 node = getLastSelectedNode();
             }
-
+    
             // Assign values based on whether args were provided or derived from getLastSelectedNode()
             nodePath = args['nodePath'] ?? node?.extras.path;
             nodeName = args['nodeName'] ?? node?.name;
             nodeLineNo = args['nodeLineNo'] ?? node?.extras.lineNo;
-
+    
             if (nodeName.startsWith('Literal ') || nodeName.startsWith('Argument ')) {
                 showDialog({
                     title: `${node.name} don't have its own script`,
@@ -101,7 +101,7 @@ export function addNodeActionCommands(
             if (args['nodePath'] === undefined && args['nodeName'] === undefined && args['nodeLineNo'] === undefined) {
                 node = getLastSelectedNode();
             }
-
+    
             // Assign values based on whether args were provided or derived from getLastSelectedNode()
             nodePath = args['nodePath'] ?? node?.extras.path;
             let xircuitsPath = nodePath.replace(/\.py$/, '.xircuits');
@@ -231,7 +231,7 @@ export function addNodeActionCommands(
         execute: async () => {
 
             await fetchComponents();
-
+            
             const widget = tracker.currentWidget?.content as XircuitsPanel;
             const engine = widget.xircuitsApp.getDiagramEngine();
             const model = engine.getModel();
@@ -247,9 +247,9 @@ export function addNodeActionCommands(
                     console.info(selected_node.name + " cannot be reloaded.");
                     continue;
                 }
-
+            
                 let node;
-
+            
                 if (selected_node.name.startsWith("Literal ")) {
                     const nodeName = selected_node["name"];
                     const label = selected_node.getPorts()["out-0"].getOptions()["label"];
@@ -258,7 +258,7 @@ export function addNodeActionCommands(
                         type: selected_node["extras"]["type"],
                     };
                     const attached = selected_node["extras"]["attached"];
-
+    
                     node = createLiteralNode({
                         nodeName,
                         nodeData,
@@ -266,7 +266,7 @@ export function addNodeActionCommands(
                         type: nodeData.type,
                         attached
                     });
-
+    
                 } else if (selected_node.name.startsWith("Argument ")) {
                     const nodeName = selected_node["name"];
                     const nodeData = {
@@ -274,12 +274,12 @@ export function addNodeActionCommands(
                         type: selected_node["extras"]["type"],
                     };
                     const inputValue = nodeName.split(": ")[1];
-
+    
                     node = createArgumentNode({
                         nodeData,
                         inputValue
                     });
-
+    
                 } else if (selected_node.name == "Finish") {
                     node = BaseComponentLibrary('Finish');
                 } else {
@@ -324,10 +324,10 @@ export function addNodeActionCommands(
                         continue;
                     }
                 }
-
+            
                 let nodePositionX = selected_node.getX();
                 let nodePositionY = selected_node.getY();
-
+                
                 // Add node at given position
                 node.setPosition(nodePositionX, nodePositionY);
                 engine.getModel().addNode(node);
@@ -337,10 +337,10 @@ export function addNodeActionCommands(
                     let ports = selected_node.getPorts();
                     for (let portName in ports) {
                         let port = ports[portName];
-
+                
                         for (let linkID in port.links) {
                             let link = port.links[linkID];
-
+                
                             if (link.getSourcePort() === port) {
                                 let sourcePortName = link.getSourcePort().getName();
                                 let newSourcePort = node.getPorts()[sourcePortName];
@@ -351,9 +351,9 @@ export function addNodeActionCommands(
                                     linksToRemove.push(link);
                                     continue;
                                 }
-
+                
                             } else if (link.getTargetPort() === port) {
-
+                                
                                 let targetPort = link.getTargetPort();
                                 let targetPortName = targetPort.getName();
                                 let newTargetPort = node.getPorts()[targetPortName];
@@ -373,7 +373,7 @@ export function addNodeActionCommands(
                                 link.setTargetPort(newTargetPort);
 
                                 }
-
+                                
                             engine.getModel().addLink(link);
                         }
                     }
@@ -402,7 +402,7 @@ export function addNodeActionCommands(
             // Repaint canvas
             selected_nodes.forEach(node => node.setSelected(false));
             nodesToHighlight.forEach(node => node.setSelected(true));
-
+            
             pruneLooseLinks(model);
             engine.repaintCanvas();
 
@@ -411,7 +411,7 @@ export function addNodeActionCommands(
     });
 
     function pruneLooseLinks(model: SRD.DiagramModel): void {
-
+ 
         const links = model.getLinks()
 
         // Iterate over all links and prune those that do not have either a source or a target port
@@ -507,7 +507,7 @@ export function addNodeActionCommands(
                 // When node got no outputPort, just return
                 return;
             }
-
+    
             // Helper function to parse Union types
             const parseUnionType = (type: string): string[] => {
                 const unionMatch = type.match(/^Union\[(.*)\]$/);
@@ -516,7 +516,7 @@ export function addNodeActionCommands(
                 }
                 return [type];
             };
-
+    
             for (let outPortIndex in outPorts) {
                 const outPort = outPorts[outPortIndex];
                 const outPortName = outPort.getOptions()['name'];
@@ -524,17 +524,17 @@ export function addNodeActionCommands(
                 const outPortType = outPort.getOptions()['dataType'];
                 const outPortLabelArr: string[] = outPortLabel.split('_');
                 const outPortTypes = parseUnionType(outPortType);
-
+    
                 if (outPort.getOptions()['label'] == '▶') {
                     // Skip ▶ outPort
                     continue;
                 }
-
+    
                 // Check if there are existing links from the target port
                 if (Object.keys(outPort.getLinks()).length > 0) {
                     continue;
                 }
-
+    
                 for (let inPortIndex in inPorts) {
                     const inPort = inPorts[inPortIndex];
                     const inPortName = inPort.getOptions()['name'];
@@ -545,20 +545,20 @@ export function addNodeActionCommands(
                     const inPortTypes = parseUnionType(inPortType);
                     // Compare if there is similarity for each word
                     const intersection = outPortLabelArr.filter(element => inPortLabelArr.includes(element));
-
+    
                     // Check if there are existing links from the source port
                     if (Object.keys(inPort.getLinks()).length > 0) {
                         continue;
                     }
-
+    
                     // Check datatype compatibility
-                    const typesCompatible = outPortTypes.some(outType =>
+                    const typesCompatible = outPortTypes.some(outType => 
                         inPortTypes.includes(outType) || inPortTypes.includes('any')
                     );
                     if (!typesCompatible) {
                         continue;
                     }
-
+    
                     // Check label compatibility or intersection
                     if ((outPortLabel === inPortLabel && typesCompatible) || intersection.length >= 1) {
                         const newLink = new DefaultLinkModel();
@@ -580,7 +580,7 @@ export function addNodeActionCommands(
     commands.addCommand(commandIDs.addCommentNode, {
         execute: async (args) => {
             const widget = tracker.currentWidget?.content as XircuitsPanel;
-
+            
             const dialogOptions: Partial<Dialog.IOptions<any>> = {
                 body: formDialogWidget(
                         <CommentDialog commentInput={""}/>
@@ -640,7 +640,7 @@ export function addNodeActionCommands(
 
         localStorage.setItem('clipboard', JSON.stringify(copies));
 
-
+    
     }
 
     function copyNode(): void {
@@ -656,22 +656,22 @@ export function addNodeActionCommands(
     function pasteNode(): void {
         const widget = tracker.currentWidget?.content as XircuitsPanel;
         if (!widget) return;
-
+    
         const engine = widget.xircuitsApp.getDiagramEngine();
         const model = engine.getModel();
         const clipboard = JSON.parse(localStorage.getItem('clipboard'));
-
+    
         if (!clipboard) return;
         model.clearSelection();
-
+    
         const newNodeModels = [];
         let idMap = {};
-
+    
         const clipboardNodes = clipboard.filter(serialized => serialized.type.includes('node'));
         const clipboardLinks = clipboard.filter(serialized => serialized.type.includes('link'));
-
+    
         let totalX = 0, totalY = 0, nodesCount = clipboardNodes.length;
-
+    
         clipboardNodes.forEach(serializedNode => {
 
             if (serializedNode.name === 'Start' || serializedNode.name === 'Finish') {
@@ -681,36 +681,36 @@ export function addNodeActionCommands(
 
             let originalNodeInstance = model.getNodes().find(node => node.getID() === serializedNode.id);
             let clonedNodeModelInstance;
-
+    
             if (originalNodeInstance) {
                 clonedNodeModelInstance = originalNodeInstance.clone();
             } else {
                 clonedNodeModelInstance = createNewNodeInstance(model, engine, serializedNode);
             }
-
+    
             newNodeModels.push(clonedNodeModelInstance);
             idMap = mapNodeAndPortIds(serializedNode, clonedNodeModelInstance, idMap);
-
+    
             totalX += clonedNodeModelInstance.getX();
             totalY += clonedNodeModelInstance.getY();
         });
-
+    
         // Calculate the center of the group of nodes.
         const centerX = totalX / nodesCount;
         const centerY = totalY / nodesCount;
-
+    
         placeNodes(engine, model, newNodeModels, widget.mousePosition, centerX, centerY);
         recreateLinks(engine, model, clipboardLinks, idMap, widget.mousePosition, centerX, centerY);
         app.commands.execute(commandIDs.reloadNode);
         engine.repaintCanvas();
     }
-
+    
     function createNewNodeInstance(model: SRD.DiagramModel, engine: SRD.DiagramEngine, serializedNode): NodeModel {
         const clonedNodeModelInstance = model.getActiveNodeLayer()
                                         .getChildModelFactoryBank(engine)
                                         .getFactory(serializedNode.type)
                                         .generateModel({ initialConfig: serializedNode });
-
+    
         clonedNodeModelInstance.deserialize({
             engine: engine,
             data: serializedNode,
@@ -719,47 +719,47 @@ export function addNodeActionCommands(
                 throw new Error('Function not implemented.');
             }
         });
-
+    
         return clonedNodeModelInstance;
     }
-
+    
     function mapNodeAndPortIds(serializedNode, clonedNodeModelInstance: CustomNodeModel, idMap) {
         // Map the ID of the serialized node to the ID of the cloned node instance.
         idMap[serializedNode.id] = clonedNodeModelInstance.getID();
-
+    
         // For each serialized port in the serialized node...
         serializedNode.ports.forEach(serializedPort => {
             // ...find the corresponding port in the cloned node instance by comparing names.
             const correspondingNewPort: any = Object.values(clonedNodeModelInstance.getPorts()).find((newPort: CustomPortModel) => newPort.getName() === serializedPort.name);
-
+    
             // If the corresponding port exists, map the ID of the serialized port to the ID of the cloned port.
             if(correspondingNewPort) idMap[serializedPort.id] = correspondingNewPort.getID();
         });
-
+    
         // Return the updated ID map.
         return idMap;
     }
-
+    
     function placeNodes(engine: SRD.DiagramEngine, model: SRD.DiagramModel, newNodeModels: CustomNodeModel[], mousePosition: { x: number; y: number }, centerX: number, centerY: number): void {
         let clientMouseEvent = { clientX: mousePosition.x, clientY: mousePosition.y };
         let relativeMousePosition = engine.getRelativeMousePoint(clientMouseEvent);
-
+    
         newNodeModels.forEach((modelInstance) => {
             // Get the offset position of the node relative to the group's center
             let nodeOffsetX = modelInstance.getX() - centerX;
             let nodeOffsetY = modelInstance.getY() - centerY;
-
+    
             modelInstance.setPosition(
                 relativeMousePosition.x + nodeOffsetX,
                 relativeMousePosition.y + nodeOffsetY
             );
-
+    
             model.addNode(modelInstance);
-
+    
             if (modelInstance.getOptions()['type'] === 'default') {
                 model.removeNode(modelInstance);
             }
-
+    
             modelInstance.setSelected(true);
         });
     }
@@ -774,63 +774,63 @@ export function addNodeActionCommands(
                 if(sourcePort && targetPort) recreateLink(engine, model, serializedLink, sourcePort, targetPort, mousePosition, centerX, centerY);
             }
         });
-    }
-
+    }    
+    
     function getSourceAndTargetPorts(model: SRD.DiagramModel, newSourceID: string, newTargetID: string): { sourcePort, targetPort } {
         let sourcePort, targetPort;
-
+    
         model.getSelectedEntities().forEach((entity) => {
             if (entity instanceof NodeModel) {
                 if(entity.getPortFromID(newSourceID)) sourcePort = entity.getPortFromID(newSourceID);
                 if(entity.getPortFromID(newTargetID)) targetPort = entity.getPortFromID(newTargetID);
             }
         });
-
+    
         return { sourcePort, targetPort };
     }
-
+    
     function recreateLink(engine: SRD.DiagramEngine, model: SRD.DiagramModel, serializedLink, sourcePort, targetPort, mousePosition: { x: number; y: number }, centerX: number, centerY: number): void {
         let originalLink = model.getLinks().find(link => link.getID() === serializedLink.id);
         let clonedLink;
         let points = [];
-
+    
         let clientMouseEvent = { clientX: mousePosition.x, clientY: mousePosition.y };
         let relativeMousePosition = engine.getRelativeMousePoint(clientMouseEvent);
-
+    
         if (originalLink) {
             clonedLink = originalLink.clone();
         } else {
             clonedLink = createNewLink(serializedLink);
             points = serializedLink.points.map(point => new PointModel({ id: point.id, link: clonedLink, position: new Point(point.x, point.y) }));
         }
-
+    
         clonedLink.setSourcePort(sourcePort);
         clonedLink.setTargetPort(targetPort);
         clonedLink.setSelected(true);
-
+    
         if (points.length > 0) clonedLink.setPoints(points);
-
+    
         clonedLink.getPoints().forEach((point) => {
             // Adjust each point's position relative to the group's center
             let pointOffsetX = point.getX() - centerX;
             let pointOffsetY = point.getY() - centerY;
-
+    
             point.setPosition(
                 relativeMousePosition.x + pointOffsetX,
                 relativeMousePosition.y + pointOffsetY
             );
-
+    
             point.setSelected(true);
         });
-
+    
         model.addLink(clonedLink);
     }
-
+    
     function createNewLink(serializedLink): CustomLinkModel {
         if(serializedLink.type === 'parameter-link') return new ParameterLinkModel(serializedLink);
         else if(serializedLink.type === 'triangle-link') return new TriangleLinkModel(serializedLink);
     }
-
+    
 
     async function editParameter(): Promise<void> {
         const widget = tracker.currentWidget?.content as XircuitsPanel;
@@ -839,7 +839,7 @@ export function addNodeActionCommands(
             const selected_node = getLastSelectedNode();
             const nodeName = selected_node.getOptions()["name"];
             let updatedNode = null;
-
+    
             if (nodeName.startsWith("Literal ")) {
                 updatedNode = await editLiteral(widget, selected_node);
             } else if (nodeName.startsWith("Argument ")) {
@@ -851,31 +851,31 @@ export function addNodeActionCommands(
                 });
                 return;
             }
-
+            
             if (updatedNode) {
                 // Set new node to old node position
                 let position = selected_node.getPosition();
                 updatedNode.setPosition(position);
                 widget.xircuitsApp.getDiagramEngine().getModel().addNode(updatedNode);
-
+    
                 // Update the links
                 const links = widget.xircuitsApp.getDiagramEngine().getModel()["layers"][0]["models"];
                 for (let linkID in links) {
                     let link = links[linkID];
                     if (link["sourcePort"] && link["targetPort"]) {
                         let newLink = new DefaultLinkModel();
-
+                        
                         // a parameter node will have only 1 outPort
                         let sourcePort = Object.values(updatedNode.getPorts())[0] as CustomPortModel;
                         newLink.setSourcePort(sourcePort);
-
+    
                         // This to make sure the new link came from the same literal node as previous link
                         let sourceLinkNodeId = link["sourcePort"].getParent().getID();
                         let sourceNodeId = selected_node.getOptions()["id"];
                         if (sourceLinkNodeId == sourceNodeId) {
                             newLink.setTargetPort(link["targetPort"]);
                         }
-
+    
                         widget.xircuitsApp.getDiagramEngine().getModel().addLink(newLink);
                     }
                 }
@@ -886,7 +886,7 @@ export function addNodeActionCommands(
             }
         }
     }
-
+    
     async function editLiteral(widget: XircuitsPanel, selected_node: any): Promise<any> {
         if (!selected_node.getOptions()["name"].startsWith("Literal ")) {
             showDialog({
@@ -902,23 +902,23 @@ export function addNodeActionCommands(
 
         const literalType = selected_node["extras"]["type"];
         let oldValue = selected_node.getPorts()["out-0"].getOptions()["label"];
-
+        
         if (literalType == "chat") {
             oldValue = JSON.parse(oldValue);
         }
-
+        
         const updateTitle = `Update ${literalType}`;
         let nodeData: CustomNodeModelOptions = {color: selected_node["color"], type: selected_node["extras"]["type"], extras: {attached: selected_node["extras"]["attached"]}}
         let updatedContent = await handleLiteralInput(selected_node["name"], nodeData, oldValue, literalType, updateTitle, connections);
-
+        
         if (!updatedContent) {
             // handle case where Cancel was clicked or an error occurred
             return null;
         }
-
+        
         return updatedContent;
     }
-
+    
     async function editArgument(widget: XircuitsPanel, selected_node: any): Promise<any> {
         if (!selected_node.getOptions()["name"].startsWith("Argument ")) {
             showDialog({
@@ -933,12 +933,12 @@ export function addNodeActionCommands(
         const updateTitle = `Update Argument`;
         let nodeData: CustomNodeModelOptions = {color: selected_node["color"], type: selected_node["extras"]["type"]}
         let updatedContent = await handleArgumentInput(nodeData, updateTitle, oldValue);
-
+        
         if (!updatedContent) {
             // handle case where Cancel was clicked or an error occurred
             return null;
         }
-
+        
         return updatedContent;
     }
 
@@ -980,7 +980,7 @@ export function addNodeActionCommands(
                                 const hasOtherConnections = sourceNode.getOutPorts().some(outPort => {
                                     return Object.values(outPort.getLinks()).some(link => {
                                         const targetNode = link.getTargetPort()?.getParent();
-                                        return targetNode && targetNode !== entity &&
+                                        return targetNode && targetNode !== entity && 
                                                 !selectedEntities.includes(targetNode);
                                     });
                                 });
@@ -1000,7 +1000,7 @@ export function addNodeActionCommands(
         });
 
         selectedEntities = widget.xircuitsApp.getDiagramEngine().getModel().getSelectedEntities();
-
+        
         // Separate collections for nodes and links
         let nodes = [];
         let links = [];
@@ -1167,5 +1167,5 @@ export function addNodeActionCommands(
         },
         label: trans.__('detach all nodes')
     });
-
+    
 }

--- a/src/commands/NodeActionCommands.tsx
+++ b/src/commands/NodeActionCommands.tsx
@@ -25,7 +25,7 @@ import { CustomDynaPortModel } from '../components/port/CustomDynaPortModel';
 import { fetchComponents } from '../tray_library/Component';
 import { BaseComponentLibrary } from '../tray_library/BaseComponentLib';
 import { commandIDs } from "./CommandIDs";
-import { showNodeCenteringNotification } from '../helpers/notificationEffects';
+import { showNodeCenteringNotification, resolveLibraryForNode, showInstallForRemoteLibrary } from '../helpers/notificationEffects';
 
 /**
  * Add the commands for node actions.
@@ -65,12 +65,12 @@ export function addNodeActionCommands(
             if (args['nodePath'] === undefined && args['nodeName'] === undefined && args['nodeLineNo'] === undefined) {
                 node = getLastSelectedNode();
             }
-    
+
             // Assign values based on whether args were provided or derived from getLastSelectedNode()
             nodePath = args['nodePath'] ?? node?.extras.path;
             nodeName = args['nodeName'] ?? node?.name;
             nodeLineNo = args['nodeLineNo'] ?? node?.extras.lineNo;
-    
+
             if (nodeName.startsWith('Literal ') || nodeName.startsWith('Argument ')) {
                 showDialog({
                     title: `${node.name} don't have its own script`,
@@ -101,7 +101,7 @@ export function addNodeActionCommands(
             if (args['nodePath'] === undefined && args['nodeName'] === undefined && args['nodeLineNo'] === undefined) {
                 node = getLastSelectedNode();
             }
-    
+
             // Assign values based on whether args were provided or derived from getLastSelectedNode()
             nodePath = args['nodePath'] ?? node?.extras.path;
             let xircuitsPath = nodePath.replace(/\.py$/, '.xircuits');
@@ -231,7 +231,7 @@ export function addNodeActionCommands(
         execute: async () => {
 
             await fetchComponents();
-            
+
             const widget = tracker.currentWidget?.content as XircuitsPanel;
             const engine = widget.xircuitsApp.getDiagramEngine();
             const model = engine.getModel();
@@ -247,9 +247,9 @@ export function addNodeActionCommands(
                     console.info(selected_node.name + " cannot be reloaded.");
                     continue;
                 }
-            
+
                 let node;
-            
+
                 if (selected_node.name.startsWith("Literal ")) {
                     const nodeName = selected_node["name"];
                     const label = selected_node.getPorts()["out-0"].getOptions()["label"];
@@ -258,7 +258,7 @@ export function addNodeActionCommands(
                         type: selected_node["extras"]["type"],
                     };
                     const attached = selected_node["extras"]["attached"];
-    
+
                     node = createLiteralNode({
                         nodeName,
                         nodeData,
@@ -266,7 +266,7 @@ export function addNodeActionCommands(
                         type: nodeData.type,
                         attached
                     });
-    
+
                 } else if (selected_node.name.startsWith("Argument ")) {
                     const nodeName = selected_node["name"];
                     const nodeData = {
@@ -274,17 +274,17 @@ export function addNodeActionCommands(
                         type: selected_node["extras"]["type"],
                     };
                     const inputValue = nodeName.split(": ")[1];
-    
+
                     node = createArgumentNode({
                         nodeData,
                         inputValue
                     });
-    
+
                 } else if (selected_node.name == "Finish") {
                     node = BaseComponentLibrary('Finish');
                 } else {
                     const extras = selected_node.getOptions().extras ?? {};
-                    const path = extras.path || '' .trim();
+                    const path = (extras.path ?? '').trim();
                     const isComment = extras.type === 'comment';
 
                     if (!path || isComment) {
@@ -298,17 +298,36 @@ export function addNodeActionCommands(
                     } catch (error) {
                         console.log(`Error reloading component from path: ${path}. Error: ${error.message}`);
                         selected_node.getOptions().extras["borderColor"] = "red";
-                        const message =
-                            `Component could not be loaded from path: \`${path}\`.\nPlease ensure that the component exists!`;
-                        showNodeCenteringNotification(message, selected_node.getID(), engine);
+
+                        const { libId, status } = await resolveLibraryForNode(selected_node);
+                        const componentName = selected_node.getOptions().name;
+
+                        if (status === 'remote' && libId) {
+                            const message = `You need to install the "${libId}" library to use "${componentName}" component.`;
+
+                            // Show "Install" only for remote libraries; otherwise use legacy message.
+                            await showInstallForRemoteLibrary({
+                            app,
+                            engine,
+                            nodeId: selected_node.getID(),
+                            libName: libId,
+                            path,
+                            message
+                            });
+
+                        } else {
+                            const message =
+                            `Component "${componentName}" could not be loaded from path: \`${path}\`.\nPlease ensure that the component exists!`;
+                            showNodeCenteringNotification(message, selected_node.getID(), engine);
+                        }
                         nodesToHighlight.push(selected_node);
                         continue;
                     }
                 }
-            
+
                 let nodePositionX = selected_node.getX();
                 let nodePositionY = selected_node.getY();
-                
+
                 // Add node at given position
                 node.setPosition(nodePositionX, nodePositionY);
                 engine.getModel().addNode(node);
@@ -318,10 +337,10 @@ export function addNodeActionCommands(
                     let ports = selected_node.getPorts();
                     for (let portName in ports) {
                         let port = ports[portName];
-                
+
                         for (let linkID in port.links) {
                             let link = port.links[linkID];
-                
+
                             if (link.getSourcePort() === port) {
                                 let sourcePortName = link.getSourcePort().getName();
                                 let newSourcePort = node.getPorts()[sourcePortName];
@@ -332,9 +351,9 @@ export function addNodeActionCommands(
                                     linksToRemove.push(link);
                                     continue;
                                 }
-                
+
                             } else if (link.getTargetPort() === port) {
-                                
+
                                 let targetPort = link.getTargetPort();
                                 let targetPortName = targetPort.getName();
                                 let newTargetPort = node.getPorts()[targetPortName];
@@ -354,7 +373,7 @@ export function addNodeActionCommands(
                                 link.setTargetPort(newTargetPort);
 
                                 }
-                                
+
                             engine.getModel().addLink(link);
                         }
                     }
@@ -383,7 +402,7 @@ export function addNodeActionCommands(
             // Repaint canvas
             selected_nodes.forEach(node => node.setSelected(false));
             nodesToHighlight.forEach(node => node.setSelected(true));
-            
+
             pruneLooseLinks(model);
             engine.repaintCanvas();
 
@@ -392,7 +411,7 @@ export function addNodeActionCommands(
     });
 
     function pruneLooseLinks(model: SRD.DiagramModel): void {
- 
+
         const links = model.getLinks()
 
         // Iterate over all links and prune those that do not have either a source or a target port
@@ -488,7 +507,7 @@ export function addNodeActionCommands(
                 // When node got no outputPort, just return
                 return;
             }
-    
+
             // Helper function to parse Union types
             const parseUnionType = (type: string): string[] => {
                 const unionMatch = type.match(/^Union\[(.*)\]$/);
@@ -497,7 +516,7 @@ export function addNodeActionCommands(
                 }
                 return [type];
             };
-    
+
             for (let outPortIndex in outPorts) {
                 const outPort = outPorts[outPortIndex];
                 const outPortName = outPort.getOptions()['name'];
@@ -505,17 +524,17 @@ export function addNodeActionCommands(
                 const outPortType = outPort.getOptions()['dataType'];
                 const outPortLabelArr: string[] = outPortLabel.split('_');
                 const outPortTypes = parseUnionType(outPortType);
-    
+
                 if (outPort.getOptions()['label'] == '▶') {
                     // Skip ▶ outPort
                     continue;
                 }
-    
+
                 // Check if there are existing links from the target port
                 if (Object.keys(outPort.getLinks()).length > 0) {
                     continue;
                 }
-    
+
                 for (let inPortIndex in inPorts) {
                     const inPort = inPorts[inPortIndex];
                     const inPortName = inPort.getOptions()['name'];
@@ -526,20 +545,20 @@ export function addNodeActionCommands(
                     const inPortTypes = parseUnionType(inPortType);
                     // Compare if there is similarity for each word
                     const intersection = outPortLabelArr.filter(element => inPortLabelArr.includes(element));
-    
+
                     // Check if there are existing links from the source port
                     if (Object.keys(inPort.getLinks()).length > 0) {
                         continue;
                     }
-    
+
                     // Check datatype compatibility
-                    const typesCompatible = outPortTypes.some(outType => 
+                    const typesCompatible = outPortTypes.some(outType =>
                         inPortTypes.includes(outType) || inPortTypes.includes('any')
                     );
                     if (!typesCompatible) {
                         continue;
                     }
-    
+
                     // Check label compatibility or intersection
                     if ((outPortLabel === inPortLabel && typesCompatible) || intersection.length >= 1) {
                         const newLink = new DefaultLinkModel();
@@ -561,7 +580,7 @@ export function addNodeActionCommands(
     commands.addCommand(commandIDs.addCommentNode, {
         execute: async (args) => {
             const widget = tracker.currentWidget?.content as XircuitsPanel;
-            
+
             const dialogOptions: Partial<Dialog.IOptions<any>> = {
                 body: formDialogWidget(
                         <CommentDialog commentInput={""}/>
@@ -621,7 +640,7 @@ export function addNodeActionCommands(
 
         localStorage.setItem('clipboard', JSON.stringify(copies));
 
-    
+
     }
 
     function copyNode(): void {
@@ -637,22 +656,22 @@ export function addNodeActionCommands(
     function pasteNode(): void {
         const widget = tracker.currentWidget?.content as XircuitsPanel;
         if (!widget) return;
-    
+
         const engine = widget.xircuitsApp.getDiagramEngine();
         const model = engine.getModel();
         const clipboard = JSON.parse(localStorage.getItem('clipboard'));
-    
+
         if (!clipboard) return;
         model.clearSelection();
-    
+
         const newNodeModels = [];
         let idMap = {};
-    
+
         const clipboardNodes = clipboard.filter(serialized => serialized.type.includes('node'));
         const clipboardLinks = clipboard.filter(serialized => serialized.type.includes('link'));
-    
+
         let totalX = 0, totalY = 0, nodesCount = clipboardNodes.length;
-    
+
         clipboardNodes.forEach(serializedNode => {
 
             if (serializedNode.name === 'Start' || serializedNode.name === 'Finish') {
@@ -662,36 +681,36 @@ export function addNodeActionCommands(
 
             let originalNodeInstance = model.getNodes().find(node => node.getID() === serializedNode.id);
             let clonedNodeModelInstance;
-    
+
             if (originalNodeInstance) {
                 clonedNodeModelInstance = originalNodeInstance.clone();
             } else {
                 clonedNodeModelInstance = createNewNodeInstance(model, engine, serializedNode);
             }
-    
+
             newNodeModels.push(clonedNodeModelInstance);
             idMap = mapNodeAndPortIds(serializedNode, clonedNodeModelInstance, idMap);
-    
+
             totalX += clonedNodeModelInstance.getX();
             totalY += clonedNodeModelInstance.getY();
         });
-    
+
         // Calculate the center of the group of nodes.
         const centerX = totalX / nodesCount;
         const centerY = totalY / nodesCount;
-    
+
         placeNodes(engine, model, newNodeModels, widget.mousePosition, centerX, centerY);
         recreateLinks(engine, model, clipboardLinks, idMap, widget.mousePosition, centerX, centerY);
         app.commands.execute(commandIDs.reloadNode);
         engine.repaintCanvas();
     }
-    
+
     function createNewNodeInstance(model: SRD.DiagramModel, engine: SRD.DiagramEngine, serializedNode): NodeModel {
         const clonedNodeModelInstance = model.getActiveNodeLayer()
                                         .getChildModelFactoryBank(engine)
                                         .getFactory(serializedNode.type)
                                         .generateModel({ initialConfig: serializedNode });
-    
+
         clonedNodeModelInstance.deserialize({
             engine: engine,
             data: serializedNode,
@@ -700,47 +719,47 @@ export function addNodeActionCommands(
                 throw new Error('Function not implemented.');
             }
         });
-    
+
         return clonedNodeModelInstance;
     }
-    
+
     function mapNodeAndPortIds(serializedNode, clonedNodeModelInstance: CustomNodeModel, idMap) {
         // Map the ID of the serialized node to the ID of the cloned node instance.
         idMap[serializedNode.id] = clonedNodeModelInstance.getID();
-    
+
         // For each serialized port in the serialized node...
         serializedNode.ports.forEach(serializedPort => {
             // ...find the corresponding port in the cloned node instance by comparing names.
             const correspondingNewPort: any = Object.values(clonedNodeModelInstance.getPorts()).find((newPort: CustomPortModel) => newPort.getName() === serializedPort.name);
-    
+
             // If the corresponding port exists, map the ID of the serialized port to the ID of the cloned port.
             if(correspondingNewPort) idMap[serializedPort.id] = correspondingNewPort.getID();
         });
-    
+
         // Return the updated ID map.
         return idMap;
     }
-    
+
     function placeNodes(engine: SRD.DiagramEngine, model: SRD.DiagramModel, newNodeModels: CustomNodeModel[], mousePosition: { x: number; y: number }, centerX: number, centerY: number): void {
         let clientMouseEvent = { clientX: mousePosition.x, clientY: mousePosition.y };
         let relativeMousePosition = engine.getRelativeMousePoint(clientMouseEvent);
-    
+
         newNodeModels.forEach((modelInstance) => {
             // Get the offset position of the node relative to the group's center
             let nodeOffsetX = modelInstance.getX() - centerX;
             let nodeOffsetY = modelInstance.getY() - centerY;
-    
+
             modelInstance.setPosition(
                 relativeMousePosition.x + nodeOffsetX,
                 relativeMousePosition.y + nodeOffsetY
             );
-    
+
             model.addNode(modelInstance);
-    
+
             if (modelInstance.getOptions()['type'] === 'default') {
                 model.removeNode(modelInstance);
             }
-    
+
             modelInstance.setSelected(true);
         });
     }
@@ -755,63 +774,63 @@ export function addNodeActionCommands(
                 if(sourcePort && targetPort) recreateLink(engine, model, serializedLink, sourcePort, targetPort, mousePosition, centerX, centerY);
             }
         });
-    }    
-    
+    }
+
     function getSourceAndTargetPorts(model: SRD.DiagramModel, newSourceID: string, newTargetID: string): { sourcePort, targetPort } {
         let sourcePort, targetPort;
-    
+
         model.getSelectedEntities().forEach((entity) => {
             if (entity instanceof NodeModel) {
                 if(entity.getPortFromID(newSourceID)) sourcePort = entity.getPortFromID(newSourceID);
                 if(entity.getPortFromID(newTargetID)) targetPort = entity.getPortFromID(newTargetID);
             }
         });
-    
+
         return { sourcePort, targetPort };
     }
-    
+
     function recreateLink(engine: SRD.DiagramEngine, model: SRD.DiagramModel, serializedLink, sourcePort, targetPort, mousePosition: { x: number; y: number }, centerX: number, centerY: number): void {
         let originalLink = model.getLinks().find(link => link.getID() === serializedLink.id);
         let clonedLink;
         let points = [];
-    
+
         let clientMouseEvent = { clientX: mousePosition.x, clientY: mousePosition.y };
         let relativeMousePosition = engine.getRelativeMousePoint(clientMouseEvent);
-    
+
         if (originalLink) {
             clonedLink = originalLink.clone();
         } else {
             clonedLink = createNewLink(serializedLink);
             points = serializedLink.points.map(point => new PointModel({ id: point.id, link: clonedLink, position: new Point(point.x, point.y) }));
         }
-    
+
         clonedLink.setSourcePort(sourcePort);
         clonedLink.setTargetPort(targetPort);
         clonedLink.setSelected(true);
-    
+
         if (points.length > 0) clonedLink.setPoints(points);
-    
+
         clonedLink.getPoints().forEach((point) => {
             // Adjust each point's position relative to the group's center
             let pointOffsetX = point.getX() - centerX;
             let pointOffsetY = point.getY() - centerY;
-    
+
             point.setPosition(
                 relativeMousePosition.x + pointOffsetX,
                 relativeMousePosition.y + pointOffsetY
             );
-    
+
             point.setSelected(true);
         });
-    
+
         model.addLink(clonedLink);
     }
-    
+
     function createNewLink(serializedLink): CustomLinkModel {
         if(serializedLink.type === 'parameter-link') return new ParameterLinkModel(serializedLink);
         else if(serializedLink.type === 'triangle-link') return new TriangleLinkModel(serializedLink);
     }
-    
+
 
     async function editParameter(): Promise<void> {
         const widget = tracker.currentWidget?.content as XircuitsPanel;
@@ -820,7 +839,7 @@ export function addNodeActionCommands(
             const selected_node = getLastSelectedNode();
             const nodeName = selected_node.getOptions()["name"];
             let updatedNode = null;
-    
+
             if (nodeName.startsWith("Literal ")) {
                 updatedNode = await editLiteral(widget, selected_node);
             } else if (nodeName.startsWith("Argument ")) {
@@ -832,31 +851,31 @@ export function addNodeActionCommands(
                 });
                 return;
             }
-            
+
             if (updatedNode) {
                 // Set new node to old node position
                 let position = selected_node.getPosition();
                 updatedNode.setPosition(position);
                 widget.xircuitsApp.getDiagramEngine().getModel().addNode(updatedNode);
-    
+
                 // Update the links
                 const links = widget.xircuitsApp.getDiagramEngine().getModel()["layers"][0]["models"];
                 for (let linkID in links) {
                     let link = links[linkID];
                     if (link["sourcePort"] && link["targetPort"]) {
                         let newLink = new DefaultLinkModel();
-                        
+
                         // a parameter node will have only 1 outPort
                         let sourcePort = Object.values(updatedNode.getPorts())[0] as CustomPortModel;
                         newLink.setSourcePort(sourcePort);
-    
+
                         // This to make sure the new link came from the same literal node as previous link
                         let sourceLinkNodeId = link["sourcePort"].getParent().getID();
                         let sourceNodeId = selected_node.getOptions()["id"];
                         if (sourceLinkNodeId == sourceNodeId) {
                             newLink.setTargetPort(link["targetPort"]);
                         }
-    
+
                         widget.xircuitsApp.getDiagramEngine().getModel().addLink(newLink);
                     }
                 }
@@ -867,7 +886,7 @@ export function addNodeActionCommands(
             }
         }
     }
-    
+
     async function editLiteral(widget: XircuitsPanel, selected_node: any): Promise<any> {
         if (!selected_node.getOptions()["name"].startsWith("Literal ")) {
             showDialog({
@@ -883,23 +902,23 @@ export function addNodeActionCommands(
 
         const literalType = selected_node["extras"]["type"];
         let oldValue = selected_node.getPorts()["out-0"].getOptions()["label"];
-        
+
         if (literalType == "chat") {
             oldValue = JSON.parse(oldValue);
         }
-        
+
         const updateTitle = `Update ${literalType}`;
         let nodeData: CustomNodeModelOptions = {color: selected_node["color"], type: selected_node["extras"]["type"], extras: {attached: selected_node["extras"]["attached"]}}
         let updatedContent = await handleLiteralInput(selected_node["name"], nodeData, oldValue, literalType, updateTitle, connections);
-        
+
         if (!updatedContent) {
             // handle case where Cancel was clicked or an error occurred
             return null;
         }
-        
+
         return updatedContent;
     }
-    
+
     async function editArgument(widget: XircuitsPanel, selected_node: any): Promise<any> {
         if (!selected_node.getOptions()["name"].startsWith("Argument ")) {
             showDialog({
@@ -914,12 +933,12 @@ export function addNodeActionCommands(
         const updateTitle = `Update Argument`;
         let nodeData: CustomNodeModelOptions = {color: selected_node["color"], type: selected_node["extras"]["type"]}
         let updatedContent = await handleArgumentInput(nodeData, updateTitle, oldValue);
-        
+
         if (!updatedContent) {
             // handle case where Cancel was clicked or an error occurred
             return null;
         }
-        
+
         return updatedContent;
     }
 
@@ -961,7 +980,7 @@ export function addNodeActionCommands(
                                 const hasOtherConnections = sourceNode.getOutPorts().some(outPort => {
                                     return Object.values(outPort.getLinks()).some(link => {
                                         const targetNode = link.getTargetPort()?.getParent();
-                                        return targetNode && targetNode !== entity && 
+                                        return targetNode && targetNode !== entity &&
                                                 !selectedEntities.includes(targetNode);
                                     });
                                 });
@@ -981,7 +1000,7 @@ export function addNodeActionCommands(
         });
 
         selectedEntities = widget.xircuitsApp.getDiagramEngine().getModel().getSelectedEntities();
-        
+
         // Separate collections for nodes and links
         let nodes = [];
         let links = [];
@@ -1148,5 +1167,5 @@ export function addNodeActionCommands(
         },
         label: trans.__('detach all nodes')
     });
-    
+
 }

--- a/src/helpers/notificationEffects.ts
+++ b/src/helpers/notificationEffects.ts
@@ -1,5 +1,8 @@
 import { DiagramEngine } from '@projectstorm/react-diagrams';
 import { Notification } from '@jupyterlab/apputils';
+import { requestAPI } from '../server/handler';
+import { handleInstall } from '../context-menu/TrayContextMenu';
+import { commandIDs } from '../commands/CommandIDs';
 
 export function showNodeCenteringNotification(
   message: string,
@@ -49,4 +52,90 @@ export function centerNodeInView(engine: DiagramEngine, nodeId: string) {
 
   model.setOffset(offsetX, offsetY);
   engine.repaintCanvas();
+}
+
+type LibraryStatus = 'installed' | 'incomplete' | 'remote' | 'unknown';
+
+function pathToLibraryId(rawPath?: string | null): string | null {
+  if (!rawPath || typeof rawPath !== 'string') return null;
+  const m = rawPath.match(/xai_components[\/\\]([a-z0-9_-]+)[\/\\]/i);
+  if (!m) return null;
+  return m[1].replace(/^xai[-_]/i, '').toUpperCase();
+}
+
+function computeStatusFromEntry(entry: any | undefined): { libId: string | null; status: LibraryStatus } {
+  if (!entry) return { libId: null, status: 'unknown' };
+
+  const libId = entry?.library_id ? String(entry.library_id).toUpperCase() : null;
+  const status = String(entry?.status ?? '').toLowerCase();
+  const isRemote = status === 'remote';
+
+  return { libId, status: isRemote ? 'remote' : 'installed' };
+}
+
+export async function resolveLibraryForNode(
+  node: any
+): Promise<{ libId: string | null; status: LibraryStatus }> {
+  const extras = node?.getOptions?.().extras ?? {};
+  const candidateId = pathToLibraryId(extras.path);
+  if (!candidateId) return { libId: null, status: 'unknown' };
+
+  const res: any = await requestAPI('library/get_config', { method: 'GET' });
+  const libraries: any[] = Array.isArray(res?.config?.libraries) ? res.config.libraries : [];
+
+  const entry = libraries.find(e => String(e?.library_id ?? '').toUpperCase() === candidateId);
+  return computeStatusFromEntry(entry);
+}
+
+export async function showInstallForRemoteLibrary(args: {
+  app: any;
+  engine?: DiagramEngine;
+  nodeId: string;
+  libName?: string | null;  
+  path?: string | null;
+  message: string;
+}): Promise<boolean> {
+  const { app, engine, nodeId, message } = args;
+
+  const candidateId = String(args.libName ?? '').trim().toUpperCase();
+  if (!candidateId) return false;
+
+  const res: any = await requestAPI('library/get_config', { method: 'GET' });
+  const libraries: any[] = Array.isArray(res?.config?.libraries) ? res.config.libraries : [];
+
+  const entry = libraries.find(e => String(e?.library_id ?? '').toUpperCase() === candidateId);
+  const { libId, status } = computeStatusFromEntry(entry);
+
+  if (status !== 'remote' || !libId) return false;
+
+  const displayName = libId; 
+
+  const actions: any[] = [
+    {
+      label: `Install ${displayName}`,
+      caption: `Install ${displayName} library`,
+      callback: async (event: MouseEvent) => {
+        event.preventDefault();
+        await handleInstall(
+          app,
+          displayName,
+          () => app.commands.execute(commandIDs.refreshComponentList)
+        );
+      }
+    }
+  ];
+
+  if (engine) {
+    actions.push({
+      label: 'Show Node',
+      caption: 'Center this node on canvas',
+      callback: (event: MouseEvent) => {
+        event.preventDefault();
+        centerNodeInView(engine, nodeId);
+      }
+    });
+  }
+
+  Notification.error(message, { autoClose: 3000, actions });
+  return true;
 }


### PR DESCRIPTION
# Description

This PR refines and simplifies the handling of **missing components** on the Xircuits canvas by switching to a more **robust and deterministic detection** mechanism based on `library_id`  provided by the backend 

### 🔧 Key Improvements

* **Reliable library detection:**

  * Introduced `pathToLibraryId()` to extract a candidate `library_id` from the component path.
  * Components are now matched **strictly** against `library_id` from the backend config returned by `library/get_config`.
  * Reused the existing normalizeLibraryName() utility for consistent ID normalization across the codebase

* **Accurate remote detection:**

  * Remote status is determined **solely** based on the backend's `status` field (`status === "remote"`).

* **Improved install prompt logic:**

  * The button label now uses the original backend library_id instead of a derived name
  * Non-remote or unknown components fall back to the legacy error notification.

* **Preserved UX features:**

  * **"Show Node"** button to center the node remains available.
  * Nodes with loading issues are **highlighted with a red border**.
  * Error messages now clearly reference the component name and missing library.

### 🧪 Test Scenarios Verified

**1. Remote library component not installed**

* Open a `.xircuits` file containing a component from a remote library that is not installed.
* Reload the canvas.
* A notification appears with:

  * Message:
    `You need to install the <LibraryName> library to use "<ComponentName>" component.`
  * Actions:

    * **Install <LibraryName>**
    * **Show Node**
* Node is highlighted in red.

**2. Local or non-remote component missing**

* Open a `.xircuits` file with a component from a local or non-remote library that cannot be found.
* Reload the canvas.
* A notification appears with:

  * Message:
    `Component "<ComponentName>" could not be loaded from path: <path>. Please ensure that the component exists!`
  * Action:

    * **Show Node**
* Node is highlighted in red.


## Pull Request Type

* [x] Xircuits Core (Jupyterlab Related changes)


## Type of Change

* [x] New feature (non-breaking change which adds functionality)


