### PR TITLE
🐛 Fix Import Error When using xircuits run from Subdirectories

### DIFF
--- a/xircuits/start_xircuits.py
+++ b/xircuits/start_xircuits.py
@@ -178,6 +178,16 @@ def cmd_run(args, extra_args=[]):
         output_filename = args.out_file if args.out_file else args.source_file.replace(
             '.xircuits', '.py')
 
+    # Get the working directory (project root) for PYTHONPATH
+    working_dir = resolve_working_dir() or Path.cwd()
+    
+    # Set PYTHONPATH to include working directory for proper imports
+    current_pythonpath = os.environ.get('PYTHONPATH', '')
+    if current_pythonpath:
+        os.environ['PYTHONPATH'] = f"{working_dir}{os.pathsep}{current_pythonpath}"
+    else:
+        os.environ['PYTHONPATH'] = str(working_dir)
+
     run_command = f"python {output_filename} {' '.join(extra_args)}"
     os.system(run_command)
 


### PR DESCRIPTION
# Description

This PR fixes the `ModuleNotFoundError` that occurs when running Xircuits workflows from subdirectories using the `xircuits run` command. 

When users execute `xircuits run xai_components/xai_library/examples/workflow.xircuits`, the generated Python script fails to import component modules with:
```
ModuleNotFoundError: No module named 'xai_components.xai_library'
```

This happens because in compiled workflow script runs from a subdirectory, but in terminal run, the Python's import path doesn't resolve it from the current working dir (moving to working dir logic was introduced in https://github.com/XpressAI/xircuits/pull/387). The solution is to simply set the `PYTHONPATH` environment variable to include the Xircuits working directory (project root) before running the xircuits run cmd. 

## References

https://github.com/XpressAI/xircuits/pull/387

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [x] Others (Xircuits CLI)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Test Workflow Execution from Subdirectory**

1. From project root: `cd xai_components/xai_fastmcp/examples/`
2. Run: `xircuits run FastMCP_Example.xircuits`
3. Verify workflow executes successfully with proper path resolution

**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux (Ubuntu 22.04)
- [ ] Mac  
- [ ] Others  (State here -> xxx )

# Notes

We need a CLI test for this to ensure it doesn't break again. The reason why it was elusive to check was because the xai_components is packaged inside the site-packages, and therefore the test we try are usually core libraries, which will work. The import error can be reproduced by using remote libraries.