### PR TITLE
🐛 Enable Argument Input Interface when Submitting via Terminal Run

### DIFF
--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -957,9 +957,12 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 			}
 			
 			else if (runType === 'terminal-run') {
-				commands.execute(commandIDs.executeToTerminal, {
-					command: `xircuits run ${workflow_path}`
-				});
+				const result = await handleLocalRunDialog();
+				if (result.status === 'ok') {
+					commands.execute(commandIDs.executeToTerminal, {
+					command: `xircuits run ${workflow_path} ${result.args}`
+					});
+				}
 			}
 			
 			else {


### PR DESCRIPTION
# Description

This PR enables the argument input interface to spawn when running a workflow using the Terminal Run option.

## Pull Request Type

* [x] Xircuits Core (Jupyterlab Related changes)
* [ ] Xircuits Canvas (Custom RD Related changes)
* [ ] Xircuits Component Library
* [ ] Xircuits Project Template
* [ ] Testing Automation
* [ ] Documentation
* [ ] Others (Please Specify)

## Type of Change

* [ ] New feature (non-breaking change which adds functionality)
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

# Tests

1. Create a workflow with an argument component. 
2. Run workflow in terminal mode (`terminal-run`)
3. Verify that the argument dialog appears; and the workflow output is as expected

**Tested on? Specify Version.**

* [x] Windows
* [x] Linux
* [ ] Mac
* [ ] Others  (State here -> N/A )
