### PR TITLE
✨ Add automatic sidebar sync with canvas updates

### DIFF
--- a/src/components/XircuitsBodyWidget.tsx
+++ b/src/components/XircuitsBodyWidget.tsx
@@ -206,6 +206,10 @@ const ZoomControls = styled.div<{visible: boolean}>`
 	}
 `;
 
+export type CanvasUpdatedPayload = { reason: 'content'; };
+
+export const canvasUpdatedSignal = new Signal<Window, CanvasUpdatedPayload>(window);
+
 export const BodyWidget: FC<BodyWidgetProps> = ({
 	context,
 	xircuitsApp,
@@ -471,6 +475,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 					return () => clearTimeout(timeout);
 				},
 				linksUpdated: (event) => {
+					canvasUpdatedSignal.emit({ reason: 'content' });
 					const timeout = setTimeout(() => {
 					event.link.registerListener({
 						sourcePortChanged: () => {
@@ -494,6 +499,8 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 				xircuitsApp.getDiagramEngine().setModel(deserializedModel);
 				clearSearchFlags();
 				
+				canvasUpdatedSignal.emit({ reason: 'content' });
+
 				// On the first load, clear undo history and register global engine listeners
 				if (initialRender.current) {
 					currentContext.model.sharedModel.clearUndoHistory();


### PR DESCRIPTION
# Description

This PR introduces automatic synchronization between the Component Preview sidebar and the canvas state.

The sidebar’s Inputs and Outputs sections now update immediately when nodes or links change — such as when connections are added, removed, or modified — without requiring a manual refresh.


## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [ ] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Xircuits Project Template
- [ ] Testing Automation
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

## 1. Node and I/O synchronization

**Steps:**

1. Open a workflow and select a node.
2. Add or remove inputs/outputs or modify parameter values.

**Expected:**

* The **Inputs** and **Outputs** sections in the sidebar update immediately.
* The toolbar buttons remain functional and update correctly.



## 2. Link connection and removal

**Steps:**

1. Start dragging a link from a node output.
2. Drop it on a valid input port, then remove the link again.

**Expected:**

* While dragging, the sidebar does **not flicker** or clear sections.
* After connecting or removing the link, the sidebar updates automatically to reflect the new state.


**Tested on? Specify Version.**

- [ ] Windows  
- [x] Linux Fedora
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

